### PR TITLE
EDU-2156-next-13

### DIFF
--- a/src/content/docs/en/pages/guides/nextjs/index.mdx
+++ b/src/content/docs/en/pages/guides/nextjs/index.mdx
@@ -34,8 +34,6 @@ Before getting started, make sure you have:
 
 To install Azion CLI, visit the [Installing Azion CLI manually](/en/documentation/products/guides/cli-installing-manually/) page.
 
-> **Note**: currently, the supported Next.js version is `12`.
-
 ### Setting up the Project
 
 1. Create a new folder for your project:
@@ -53,7 +51,7 @@ To install Azion CLI, visit the [Installing Azion CLI manually](/en/documentatio
 3. Inside the project folder, use the following command to create a Next.js project:
 
 ```bash
-  npx create-next-app@12 azion-next-ssr && cd azion-next-ssr && npm i next@12
+  npx create-next-app azion-next-ssr && cd azion-next-ssr && npm i next@
 ```
 
 4. Open the project directory in your preferred code editor, such as VSCode:
@@ -64,18 +62,17 @@ To install Azion CLI, visit the [Installing Azion CLI manually](/en/documentatio
 
 ### Configuring Next.js for Azion
 
-1. Open the `next.config.js` file in your project's root directory.
-2. Add the `experimental` object inside the `nextConfig` constant:
+1. Open the `src/pages/api/hello.js` file in your project's root directory.
+2. Paste the following content to the file:
 
 ```js
-  const nextConfig = {
-    experimental: {
-      runtime: 'experimental-edge',
-    },
-    reactStrictMode: true,
-    swcMinify: true,
+  // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
+  
+  export const runtime = 'edge' // 'nodejs' (default) | 'edge'
+  
+  export default function handler(req, res) {
+    res.status(200).json({ name: 'John Doe' })
   }
-  module.exports = nextConfig
 ```
 
 ### Building and Publishing the application on the Azion Platform
@@ -83,7 +80,7 @@ To install Azion CLI, visit the [Installing Azion CLI manually](/en/documentatio
 1. In the terminal, in your project's root directory, initialize the Azion Edge Application:
 
 ```bash
-  azioncli edge_applications init
+  azioncli edge_applications init --type nextjs
 ```
 
 2. Run the `build` command:

--- a/src/content/docs/en/pages/guides/nextjs/index.mdx
+++ b/src/content/docs/en/pages/guides/nextjs/index.mdx
@@ -28,7 +28,7 @@ permalink: /documentation/products/guides/nextjs-ssr-on-azion-platform/
 Before getting started, make sure you have:
 
 - An Azion platform account with Edge Functions enabled.
-- Node.js runtime environment 18.x installed in your build environment.
+- Node.js runtime environment v18.x installed in your build environment.
 - The latest version of Azion CLI installed.
 - Next.js installed.
 

--- a/src/content/docs/en/pages/guides/nextjs/index.mdx
+++ b/src/content/docs/en/pages/guides/nextjs/index.mdx
@@ -28,7 +28,7 @@ permalink: /documentation/products/guides/nextjs-ssr-on-azion-platform/
 Before getting started, make sure you have:
 
 - An Azion platform account with Edge Functions enabled.
-- Node.js runtime environment (version 16.x or 18.x) installed in your build environment.
+- Node.js runtime environment 18.x installed in your build environment.
 - The latest version of Azion CLI installed.
 - Next.js installed.
 
@@ -51,7 +51,7 @@ To install Azion CLI, visit the [Installing Azion CLI manually](/en/documentatio
 3. Inside the project folder, use the following command to create a Next.js project:
 
 ```bash
-  npx create-next-app azion-next-ssr && cd azion-next-ssr && npm i next@
+  npx create-next-app azion-next-ssr && cd azion-next-ssr && npm i next
 ```
 
 4. Open the project directory in your preferred code editor, such as VSCode:

--- a/src/content/docs/pt-br/pages/guias/nextjs/index.mdx
+++ b/src/content/docs/pt-br/pages/guias/nextjs/index.mdx
@@ -33,8 +33,6 @@ Antes de iniciar a implementação, certifique-se de ter:
 
 Para instalar a Azion CLI, visite a página [Instalando o Azion CLI manualmente](/pt-br/documentacao/produtos/guias/cli-instalando-manualmente/).
 
-> **Nota**: atualmente, a versão Next.js suportada é a `12`.
-
 ### Configurando o Projeto
 
 1. Crie uma nova pasta para o seu projeto:
@@ -43,23 +41,17 @@ Para instalar a Azion CLI, visite a página [Instalando o Azion CLI manualmente]
   mkdir next-js-azion
 ```
 
-
-
 2. Acesse a pasta do projeto:
 
 ```bash
   cd next-js-azion
 ```
 
-
-
 3. Dentro da pasta do projeto, use o seguinte comando para criar um projeto Next.js:
 
 ```bash
-  npx create-next-app@12 azion-next-ssr && cd azion-next-ssr && npm i next@12
+  npx create-next-app azion-next-ssr && cd azion-next-ssr && npm i next
 ```
-
-
 
 4. Abra o diretório do projeto em seu editor de código preferido, como VSCode:
 
@@ -69,18 +61,17 @@ Para instalar a Azion CLI, visite a página [Instalando o Azion CLI manualmente]
 
 ### Configurando Next.js para Azion
 
-1. Abra o arquivo `next.config.js` no diretório raiz do seu projeto.
-2. Adicione o objeto `experimental` dentro da constante `nextConfig`:
+1. Abra o arquivo `src/pages/api/hello.js` no diretório raiz do seu projeto.
+2. Copie e cole a seguinte configuração:
 
 ```js
-  const nextConfig = {
-    experimental: {
-      runtime: 'experimental-edge',
-    },
-    reactStrictMode: true,
-    swcMinify: true,
+  // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
+  
+  export const runtime = 'edge' // 'nodejs' (default) | 'edge'
+  
+  export default function handler(req, res) {
+    res.status(200).json({ name: 'John Doe' })
   }
-  module.exports = nextConfig
 ```
 
 ### Publicando a aplicação na Plataforma da Azion
@@ -88,18 +79,14 @@ Para instalar a Azion CLI, visite a página [Instalando o Azion CLI manualmente]
 1. No terminal, no diretório raiz do seu projeto, inicialize a edge application:
 
 ```bash
-  azioncli edge_applications init
+  azioncli edge_applications init --type nextjs
 ```
-
-
 
 2. Execute o comando `build`:
 
 ```bash
   azioncli edge_applications build
 ```
-
-
 
 3. Publique a aplicação:
 

--- a/src/content/docs/pt-br/pages/guias/nextjs/index.mdx
+++ b/src/content/docs/pt-br/pages/guias/nextjs/index.mdx
@@ -27,7 +27,7 @@ O **SSR** gera o HTML para cada requisição, oferecendo vários benefícios, co
 Antes de iniciar a implementação, certifique-se de ter:
 
 - Uma conta da plataforma Azion com o módulo de Edge Functions ativado.
-- O **Node.js** (versão 16.x ou 18.x) instalado em seu ambiente de desenvolvimento.
+- O **Node.js** na versão 18.x instalado em seu ambiente de desenvolvimento.
 - A versão mais recente da Azion CLI instalada.
 - Next.js instalado.
 

--- a/src/content/docs/pt-br/pages/guias/nextjs/index.mdx
+++ b/src/content/docs/pt-br/pages/guias/nextjs/index.mdx
@@ -27,7 +27,7 @@ O **SSR** gera o HTML para cada requisição, oferecendo vários benefícios, co
 Antes de iniciar a implementação, certifique-se de ter:
 
 - Uma conta da plataforma Azion com o módulo de Edge Functions ativado.
-- O **Node.js** na versão 18.x instalado em seu ambiente de desenvolvimento.
+- O Node.js na versão 18.x instalado em seu ambiente de desenvolvimento.
 - A versão mais recente da Azion CLI instalada.
 - Next.js instalado.
 


### PR DESCRIPTION
Update next guide, now supporting next 13. It was necessary explicit the version 12 before. Now, it's not. 