### PR TITLE
EDU-1222-graphql-top-x-queries

### DIFF
--- a/src/content/docs/en/pages/api-graphql/features/features.mdx
+++ b/src/content/docs/en/pages/api-graphql/features/features.mdx
@@ -41,8 +41,6 @@ To see which fields are available for each Metrics dataset, read the [Fields Rea
 You can also run an **Introspection Query** to consult metadata on the Metrics and Events datasets. Metadata provide what each dataset of the GraphQL APIs supports and specific information: name, description, and format. Find out more on the [How to query metadata with GraphQL API](/en/documentation/products/guides/graphql-metadata/) guide.
 :::
 
-> Find out more on [How to select Top X queries with GraphQL API](/en/documentation/products/guides/graphql-top-x-query/).
-
 While using datasets, it's important to note you can request both *raw* and *aggregated* data models. By running a request for *raw* information, using the Events datasets, you receive as a response the *raw numbers* related to that specific dataset. By running a request for *aggregated* information, using the Metrics datasets, you receive your information in the form of *graphs* related to that specific dataset.
 
 To specify you want to aggregate data with a time interval, you must add the *aggregate* operator in your query along with the `group_by` field. For example, the following query aggregates data:

--- a/src/content/docs/en/pages/api-graphql/queries/queries.mdx
+++ b/src/content/docs/en/pages/api-graphql/queries/queries.mdx
@@ -94,6 +94,12 @@ It's recommended to inform:
 
 - A time range interval for queries, using either **tsRange** or **tsGt** + **tsLt**.
 
+:::tip
+You can also use the **Top X query** feature with the Real-Time Events GraphQL API. They help to visualize how resources and tools are being used and provide a more detailed analysis of certain conditions that are either more or less commonly used. For example, you can query for “Top 10 Hosts” or “Top 10 Status Codes”.
+
+Find out more on [How to select Top X queries with GraphQL API](/en/documentation/products/guides/graphql-top-x-query/).
+:::
+
 ### Aggregated data
 
 Aggregated data are a type of structured data that have been clustered. They go through modifications to allow a better analytic processing seeking a segmented analysis, making it easier to visualize even great amount of data over a larger period of time.

--- a/src/content/docs/en/pages/api-graphql/queries/queries.mdx
+++ b/src/content/docs/en/pages/api-graphql/queries/queries.mdx
@@ -95,7 +95,7 @@ It's recommended to inform:
 - A time range interval for queries, using either **tsRange** or **tsGt** + **tsLt**.
 
 :::tip
-You can also use the **Top X query** feature with the Real-Time Events GraphQL API. They help to visualize how resources and tools are being used and provide a more detailed analysis of certain conditions that are either more or less commonly used. For example, you can query for “Top 10 Hosts” or “Top 10 Status Codes”.
+You can also use the **Top X query** feature with the Real-Time Events GraphQL API. It helps to visualize how resources and tools are being used and provide a more detailed analysis of certain conditions that are either more or less commonly used. For example, you can query for “Top 10 Hosts” or “Top 10 Status Codes”.
 
 Find out more on [How to select Top X queries with GraphQL API](/en/documentation/products/guides/graphql-top-x-query/).
 :::

--- a/src/content/docs/pt-br/pages/api-graphql/queries/index.mdx
+++ b/src/content/docs/pt-br/pages/api-graphql/queries/index.mdx
@@ -93,6 +93,12 @@ Para consultar dados brutos, é *obrigatório* informar:
 
 - Um intervalo de tempo para consultas, usando **tsRange** ou **tsGt** + **tsLt**.
 
+:::tip[dica]
+Você também pode utilizar o recurso **Top X query** com a API GraphQL do Real-Time Events. Ela tem a finalidade de visualizar o uso de recursos e ferramentas e ter uma visão detalhada sobre determinadas condições que são mais ou menos usadas. Por exemplo, você pode consultar os “Top 10 Hosts” ou os “Top 10 Status Codes”.
+
+Veja mais sobre [Como selecionar Top X queries com a GraphQL API](/pt-br/documentacao/produtos/guias/graphql-query-top-x/).
+:::
+
 ### Dados agregados
 
 Dados agregados são um tipo de dados estruturados que foram agrupados. Eles passam por modificações para permitir um melhor processamento analítico que busca uma análise segmentada, facilitando a visualização até de grandes quantidades de dados ao longo de períodos de tempo maiores.

--- a/src/content/docs/pt-br/pages/api-graphql/recursos/index.mdx
+++ b/src/content/docs/pt-br/pages/api-graphql/recursos/index.mdx
@@ -42,8 +42,6 @@ Para ver quais campos estão disponíveis em cada conjunto de dados de Metrics, 
 Você também pode rodar uma **Introspection Query** para consultar os metadados dos datasets de Metrics e Events. Os metadados fornecem o que cada dataset das APIs GraphQL permite e informações específicas: nome, descrição e formato. Veja mais no guia [Como consultar metadados com a API GraphQL](/pt-br/documentacao/produtos/guias/graphql-metadados/).
 :::
 
-> Veja mais sobre [Como realizar consultas de Queries Top X com a API GraphQL](/pt-br/documentacao/produtos/guias/graphql-query-top-x/).
-
 Ao usar conjuntos de dados, é importante lembrar que você pode solicitar dados *raw* (*brutos*) ou *aggregated* (*agregados*). Ao solicitar informações de dados *raw*, usando os conjuntos Events, você recebe *dados brutos* relacionados ao conjunto específico sendo consultado. Ao solicitar informações de dados *aggregated*, usando os conjuntos Metrics, você recebe os dados relacionados ao conjunto específico sendo consultado em formato de *gráficos*.
 
 Para especificar que você quer agregar dados dentro de um intervalo de tempo, você deve adicionar o operador *aggregate* na sua query junto ao campo `group_by`. A seguinte query, por exemplo, agrega dados:


### PR DESCRIPTION
Changed where the top X query info was located at and improved the explanation a bit ✌️  EN and PT