### PR TITLE
[EDU-2471] Add RE missing variables

### DIFF
--- a/src/content/docs/en/pages/products/edge-application/rules-engine.mdx
+++ b/src/content/docs/en/pages/products/edge-application/rules-engine.mdx
@@ -106,10 +106,10 @@ import TableContainer from "~/components/Table/TableContainer.astro"
 | `${request_uri}` | The complete URI of the request, with arguments (query string). | Request Phase<br />Response Phase |
 | `${scheme}` | The scheme of the request. For example: `http` or `https`. | Request Phase<br />Response Phase |
 | `${sent_http_name}` | The value of the response header field name. The name argument must be converted to lowercase and the hyphens must be converted to underscore. For example: `${sent_http_content_length}` will take the value of the `Content-Length` header. | Response Phase |
-| `${server_addr}` | The IP address of the server that is receiving the HTTP request. | Request Phase |
-| `${server_port}` | The HTTP port of the server that receives the request. | Request Phase |
+| `${server_addr}` | The IP address of the server that will be receiving the HTTP request. | Request Phase |
+| `${server_port}` | The HTTP port of the server that will be receiving the request. | Request Phase |
 | `${status}` | Status code of the response. | Response Phase |
-| `${tcpinfo_rtt}` | Round Trip Time (RTT) of the client's TCP connection, in microseconds. | Response Phase |
+| `${tcpinfo_rtt}` | Round-Trip Time (RTT) of the client's TCP connection, in microseconds. | Response Phase |
 | `${upstream_addr}` | The IP address and port of the queried origin for obtaining the response. If many origins are consulted during the processing of the request, the addresses will be separated by a comma (`,`). For example: `192.168.1.1:80, 192.168.1.2:80`. If an internal redirect from one group of servers to another occurs, initiated by an `X-Accel-Redirect` or an error page, the addresses of the different groups will be separated by a colon (`:`). For example: `192.168.1.1:80, 192.168.1.2:80 : 192.168.10.1:80, 192.168.10.2:80`. | Response Phase |
 | `${upstream_cookie_name}` | Value of cookie name sent by the origin using the Set-Cookie header field. If many origins are consulted while the request is processed, only cookies from the last origin are stored. | Response Phase |
 | `${upstream_http_name}` | Value of the name header field sent by the origin. The name argument must be converted to lowercase and the hyphens must be converted to underscore. If many origins are consulted while the request is processed, only headers from the last origin are stored. For example: `${upstream_http_server}` will assume the value of the Server header field sent by the last queried origin. | Response Phase |

--- a/src/content/docs/en/pages/products/edge-application/rules-engine.mdx
+++ b/src/content/docs/en/pages/products/edge-application/rules-engine.mdx
@@ -94,18 +94,22 @@ import TableContainer from "~/components/Table/TableContainer.astro"
 | `${geoip_continent_code}` | 2-letter continent code. For example: `EU` for Europe, `NA` for North America. | Request Phase<br />Response Phase |
 | `${geoip_country_code}` | 2-letter country code, using the geolocation base `geoip_country`. For example: `RU` for Russia, `BR` for Brazil. | Request Phase<br />Response Phase |
 | `${geoip_country_name}` | Name of the country, using the geolocation base `geoip_country`. For example: `United States`, `Brazil`. | Request Phase<br />Response Phase |
-| `${geoip_region_name}` | Name of the country, using the geolocation base `geoip_region`. For example: `Ontario`, `Sao Paulo`. | Request Phase<br />Response Phase |
 | `${geoip_region}` | 2-letter region code. For example: `RS` for Rio Grande do Sul, `ON` for Toronto. | Request Phase<br />Response Phase |
+| `${geoip_region_name}` | Name of the country, using the geolocation base `geoip_region`. For example: `Ontario`, `Sao Paulo`. | Request Phase<br />Response Phase |
 | `${host}` | In order of precedence: the host name of the request line, or the value of the Host header field of the request, or the name of the server serving the request. For example: `blog.domain.com`. | Request Phase<br />Response Phase |
 | `${http_name}` | The value of a request header. `name` must be a valid [HTTP request header](https://developer.mozilla.org/en-US/docs/Glossary/Request_header) converted to lowercase; hyphens must be converted to underscore. For example: `${http_accept}` will take the value of the `Accept` header of the HTTP request field. | Request Phase<br />Response Phase |
 | `${remote_addr}` | The IP address of the client performing the HTTP request. | Request Phase<br />Response Phase |
+| `${remote_port}` | The HTTP port being used in the request URL of the client. | Request Phase<br />Response Phase |
 | `${remote_user}` | The username provided by basic authentication, if any. | Request Phase<br />Response Phase |
 | `${request}` | Complete request query. | Request Phase<br />Response Phase |
 | `${request_method}` | The HTTP method of the request. For example: `GET`. | Request Phase<br />Response Phase |
 | `${request_uri}` | The complete URI of the request, with arguments (query string). | Request Phase<br />Response Phase |
 | `${scheme}` | The scheme of the request. For example: `http` or `https`. | Request Phase<br />Response Phase |
-| `${sent_http_name}` | The value of the response header field name. The name argument must be converted to lowercase and the hyphens must be converted to underscore. For example: `${sent_http_content_length}` will take the value of the Content-Length header. | Response Phase |
+| `${sent_http_name}` | The value of the response header field name. The name argument must be converted to lowercase and the hyphens must be converted to underscore. For example: `${sent_http_content_length}` will take the value of the `Content-Length` header. | Response Phase |
+| `${server_addr}` | The IP address of the server that is receiving the HTTP request. | Request Phase |
+| `${server_port}` | The HTTP port of the server that receives the request. | Request Phase |
 | `${status}` | Status code of the response. | Response Phase |
+| `${tcpinfo_rtt}` | Round Trip Time (RTT) of the client's TCP connection, in microseconds. | Response Phase |
 | `${upstream_addr}` | The IP address and port of the queried origin for obtaining the response. If many origins are consulted during the processing of the request, the addresses will be separated by a comma (`,`). For example: `192.168.1.1:80, 192.168.1.2:80`. If an internal redirect from one group of servers to another occurs, initiated by an `X-Accel-Redirect` or an error page, the addresses of the different groups will be separated by a colon (`:`). For example: `192.168.1.1:80, 192.168.1.2:80 : 192.168.10.1:80, 192.168.10.2:80`. | Response Phase |
 | `${upstream_cookie_name}` | Value of cookie name sent by the origin using the Set-Cookie header field. If many origins are consulted while the request is processed, only cookies from the last origin are stored. | Response Phase |
 | `${upstream_http_name}` | Value of the name header field sent by the origin. The name argument must be converted to lowercase and the hyphens must be converted to underscore. If many origins are consulted while the request is processed, only headers from the last origin are stored. For example: `${upstream_http_server}` will assume the value of the Server header field sent by the last queried origin. | Response Phase |

--- a/src/content/docs/pt-br/pages/produtos/edge-application/rules-engine/index.mdx
+++ b/src/content/docs/pt-br/pages/produtos/edge-application/rules-engine/index.mdx
@@ -106,10 +106,10 @@ import TableContainer from "~/components/Table/TableContainer.astro"
 | `${request_uri}` | A URI completa da requisição, com argumentos (query string). | Request Phase <br />Response Phase |
 | `${scheme}` | O scheme da requisição: `http` ou `https`. | Request Phase <br />Response Phase |
 | `${sent_http_name}` | O valor do campo de cabeçalho de resposta name. O argumento name deve ser convertido para letras minúsculas e os hífens devem ser convertidos para underscore. Por exemplo: `${sent_http_content_length}` assumirá o valor do cabeçalho `Content-Length`. | Response Phase |
-| `${server_addr}` | O endereço IP do servidor que está recebendo a requisição HTTP. | Request Phase |
-| `${server_port}` | A porta HTTP do servidor que recebe a requisição. | Request Phase |
+| `${server_addr}` | O endereço IP do servidor que irá receber a requisição HTTP. | Request Phase |
+| `${server_port}` | A porta HTTP do servidor que irá receber a requisição. | Request Phase |
 | `${status}` | O status code da resposta. | Response Phase |
-| `${tcpinfo_rtt}` | Round Trip Time (RTT) da conexão TCP do cliente, em microsegundos. | Response Phase |
+| `${tcpinfo_rtt}` | Round-Trip Time (RTT) da conexão TCP do cliente, em microsegundos. | Response Phase |
 | `${upstream_addr}` | O endereço IP e porta da origem consultada para obtenção da resposta. Caso múltiplas origens sejam consultadas durante o processamento da requisição, os endereços serão separados por vírgula (`,`). Por exemplo: `192.168.1.1:80, 192.168.1.2:80`. Se um redirect interno de um grupo de servidores para outro ocorrer, iniciado por um `X-Accel-Redirect` ou por uma página de erro, os endereços dos diferentes grupos serão separados por dois pontos (`:`). Por exemplo: `192.168.1.1:80, 192.168.1.2:80 : 192.168.10.1:80, 192.168.10.2:80`. | Response Phase |
 | `${upstream_cookie_name}` | Valor do cookie name enviado pela origem através do campo de cabeçalho Set-Cookie. Caso múltiplas origens sejam consultadas durante o processamento da requisição, apenas os cookies da última origem são armazenados. | Response Phase |
 | `${upstream_http_name}` | Valor do campo de cabeçalho name enviado pela origem. O argumento name deve ser convertido para letras minúsculas e os hífens devem ser convertidos para underscore. Caso múltiplas origens sejam consultadas durante o processamento da requisição, apenas os cabeçalhos da última origem são armazenados. Por exemplo: `${upstream_http_server}` assumirá o valor do campo de cabeçalho Server enviado pela última origem consultada. | Response Phase |

--- a/src/content/docs/pt-br/pages/produtos/edge-application/rules-engine/index.mdx
+++ b/src/content/docs/pt-br/pages/produtos/edge-application/rules-engine/index.mdx
@@ -77,7 +77,9 @@ Por exemplo, o seguinte critério identifica se um usuário está usando um nave
 ---
 
 ## Variáveis
+import TableContainer from "~/components/Table/TableContainer.astro"
 
+<TableContainer>
 | Variável | Descrição | Disponível para |
 | --- | --- | --- |
 | `${arg_name}` | Argumento *name* enviado pelo usuário na linha de requisição (query string). Por exemplo, para a requisição GET `/path?Search=test`, a variável `${arg_search}` assumirá o valor `test`. | Request Phase <br />Response Phase |
@@ -92,23 +94,28 @@ Por exemplo, o seguinte critério identifica se um usuário está usando um nave
 | `${geoip_continent_code}` | Código de continente com 2 letras. Por exemplo: `EU` para Europa, `NA` para América do Norte. | Request Phase <br />Response Phase |
 | `${geoip_country_code}` | Código de país com 2 letras, utilizando a base de geolocalização `geoip_country`. Por exemplo: `RU` para Rússia, `BR` para Brasil. | Request Phase <br />Response Phase |
 | `${geoip_country_name}` | Nome do país por extenso, utilizando a base de geolocalização `geoip_country`. Por exemplo: `United States`, `Brazil`. | Request Phase <br />Response Phase |
-| `${geoip_region_name}` | Nome do país por extenso, utilizando a base de geolocalização `geoip_region`. Por exemplo: `Ontario`, `Sao Paulo` etc. | Request Phase <br />Response Phase |
 | `${geoip_region}` | Código da região com 2 letras. Por exemplo: `RS` para Rio Grande do Sul, `ON` para Toronto etc. | Request Phase <br />Response Phase |
+| `${geoip_region_name}` | Nome do país por extenso, utilizando a base de geolocalização `geoip_region`. Por exemplo: `Ontario`, `Sao Paulo` etc. | Request Phase <br />Response Phase |
 | `${host}` | Em ordem de precedência: o host name da linha de requisição, ou o valor do campo de cabeçalho Host da requisição, ou o nome do servidor atendendo a requisição. Por exemplo: `blog.domain.com`. | Request Phase <br />Response Phase |
 | `${http_name}` | O valor do campo de cabeçalho da requisição. `name` deve ser um [cabeçalho HTTP](https://developer.mozilla.org/en-US/docs/Glossary/Request_header) válido convertido em letras minúsculas; hífens devem ser convertidos para underscore. Por exemplo: `${http_accept}` assumirá o valor da campo de cabeçalho `Accept` da requisição HTTP. | Request Phase <br />Response Phase |
 | `${remote_addr}` | O endereço IP do cliente que está realizando a requisição HTTP. | Request Phase <br />Response Phase |
+| `${remote_port}` | A porta HTTP sendo usada na URL da requisição do cliente. | Request Phase <br />Response Phase |
 | `${remote_user}` | O username fornecido pela autenticação básica, quando houver. | Request Phase <br />Response Phase |
 | `${request}` | A linha completa da requisição. | Request Phase <br />Response Phase |
 | `${request_method}` | O método HTTP da requisição. Por exemplo: `GET`. | Request Phase <br />Response Phase |
 | `${request_uri}` | A URI completa da requisição, com argumentos (query string). | Request Phase <br />Response Phase |
 | `${scheme}` | O scheme da requisição: `http` ou `https`. | Request Phase <br />Response Phase |
-| `${sent_http_name}` | O valor do campo de cabeçalho de resposta name. O argumento name deve ser convertido para letras minúsculas e os hífens devem ser convertidos para underscore. Por exemplo: `${sent_http_content_length}` assumirá o valor do cabeçalho Content-Length. | Response Phase |
+| `${sent_http_name}` | O valor do campo de cabeçalho de resposta name. O argumento name deve ser convertido para letras minúsculas e os hífens devem ser convertidos para underscore. Por exemplo: `${sent_http_content_length}` assumirá o valor do cabeçalho `Content-Length`. | Response Phase |
+| `${server_addr}` | O endereço IP do servidor que está recebendo a requisição HTTP. | Request Phase |
+| `${server_port}` | A porta HTTP do servidor que recebe a requisição. | Request Phase |
 | `${status}` | O status code da resposta. | Response Phase |
+| `${tcpinfo_rtt}` | Round Trip Time (RTT) da conexão TCP do cliente, em microsegundos. | Response Phase |
 | `${upstream_addr}` | O endereço IP e porta da origem consultada para obtenção da resposta. Caso múltiplas origens sejam consultadas durante o processamento da requisição, os endereços serão separados por vírgula (`,`). Por exemplo: `192.168.1.1:80, 192.168.1.2:80`. Se um redirect interno de um grupo de servidores para outro ocorrer, iniciado por um `X-Accel-Redirect` ou por uma página de erro, os endereços dos diferentes grupos serão separados por dois pontos (`:`). Por exemplo: `192.168.1.1:80, 192.168.1.2:80 : 192.168.10.1:80, 192.168.10.2:80`. | Response Phase |
 | `${upstream_cookie_name}` | Valor do cookie name enviado pela origem através do campo de cabeçalho Set-Cookie. Caso múltiplas origens sejam consultadas durante o processamento da requisição, apenas os cookies da última origem são armazenados. | Response Phase |
 | `${upstream_http_name}` | Valor do campo de cabeçalho name enviado pela origem. O argumento name deve ser convertido para letras minúsculas e os hífens devem ser convertidos para underscore. Caso múltiplas origens sejam consultadas durante o processamento da requisição, apenas os cabeçalhos da última origem são armazenados. Por exemplo: `${upstream_http_server}` assumirá o valor do campo de cabeçalho Server enviado pela última origem consultada. | Response Phase |
 | `${upstream_status}` | Status Code da resposta da origem enviada para o RTM. Caso múltiplas origens sejam consultadas durante o processamento da requisição, os status codes serão separados por vírgula (`,`). Se um redirect interno de um grupo de servidores para outro ocorrer, iniciado por um `X-Accel-Redirect` ou por uma página de erro, os status codes dos diferentes grupos serão separados por dois pontos (`:`). | Response Phase |
 | `${uri}` | A URI normalizada (urldecoded) da requisição. O valor da `${uri}` pode mudar durante o processamento de uma requisição, por exemplo, quando ocorre um redirect interno ou quando são utilizados arquivos index. NÃO carrega os parâmetros do Query String como `${request_uri}` faz. | Request Phase<br />Response Phase |
+</TableContainer>
 
 ### Variáveis para Mutual Transport Layer Security (mTLS) 
 


### PR DESCRIPTION
<!--
Thank you for contributing to Azion Docs! Please fill out the information below.
Don't forget to add the Jira issue code to the title of this PR or the GitHub issue hash.
For example: 
- [EDU-3000] Modify origins page to include load balancer
- [#34] Add new edge application CLI commands
- [HOTFIX] Fix broken link in Orch doc
-->

### Related issue: [EDU-2471]

### Changes

Added the following variables (unlisted in UI but accepted by the code):
- remote_port
- server_addr
- server_port
- tcpinfo_rtt

[EDU-2471]: https://aziontech.atlassian.net/browse/EDU-2471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ