### PR TITLE
EDU-2367-EN-Create-API-overview

### DIFF
--- a/src/content/docs/en/pages/azion-api/overview/azion-api-overview.mdx
+++ b/src/content/docs/en/pages/azion-api/overview/azion-api-overview.mdx
@@ -12,7 +12,9 @@ This documentation will guide you on the first steps of using the **Azion API**.
 
 The **Azion API** is a *RESTful API* based on *HTTPS* requests, that allows users to fully interact with Azion products through API requests. Most API endpoints have the main HTTP methods (`GET`, `POST`, `PUT`, `PATCH`, and `DELETE`), so you can create, read, update, and delete Azion configuration instances. All changes made through the API are reflected on the [Real-Time Manager (RTM)](https://manager.azion.com).
 
+:::tip
 > Access the [introduction](https://api.azion.com/#intro) documentation to find reference information about the API.
+:::
 
 ## Prerequisites
 

--- a/src/content/docs/en/pages/azion-api/overview/azion-api-overview.mdx
+++ b/src/content/docs/en/pages/azion-api/overview/azion-api-overview.mdx
@@ -6,8 +6,6 @@ namespace: documentation_products_azion_api_overview
 permalink: /documentation/products/azion-api-overview/
 ---
 
-# Getting Started 
-
 This documentation will guide you on the first steps of using the **Azion API**.
 
 ## API overview

--- a/src/content/docs/en/pages/azion-api/overview/azion-api-overview.mdx
+++ b/src/content/docs/en/pages/azion-api/overview/azion-api-overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get started with Azion API
-description: Azion RESTful API. Learn more about oficial endpoints, methods and API use cases.
+description: Learn more about oficial endpoints, methods, and API use cases of the Azion RESTful API.
 meta_tags: azion, rest api, restful api, azion restful api
 namespace: documentation_products_azion_api_overview
 permalink: /documentation/products/azion-api-overview/

--- a/src/content/docs/en/pages/azion-api/overview/azion-api-overview.mdx
+++ b/src/content/docs/en/pages/azion-api/overview/azion-api-overview.mdx
@@ -23,7 +23,9 @@ To run **Azion API** requests you need:
 - **Real-Time Manager (RTM)** account.
 - **API token (personal token)**.
 
+:::tip
 > Learn [how to create an RTM account](https://www.azion.com/en/documentation/products/accounts/creating-account/) and how to create a [personal token](https://www.azion.com/en/documentation/products/accounts/personal-tokens/) to use with the API.
+:::
 
 ## Make API requests with curl (and other programming languages) snippets
  

--- a/src/content/docs/en/pages/azion-api/overview/azion-api-overview.mdx
+++ b/src/content/docs/en/pages/azion-api/overview/azion-api-overview.mdx
@@ -1,0 +1,80 @@
+---
+title: Azion API
+description: Azion RESTful API. Learn more about oficial endpoints, methods and API use cases.
+meta_tags: azion, rest api, restful api, azion restful api
+namespace: documentation_products_azion_api_overview
+permalink: /documentation/products/azion-api-overview/
+---
+
+# Getting Started 
+
+This documentation will guide you on the first steps of using the **Azion API**.
+
+## API overview
+
+The **Azion API** is a *RESTful API* based on *HTTPS* requests, that allows users to fully interact with Azion products through API requests. Most API endpoints have the main HTTP methods (`GET`, `POST`, `PUT`, `PATCH`, and `DELETE`), so you can create, read, update, and delete Azion configuration instances. All changes made through the API are reflected on the [Real-Time Manager (RTM)](https://manager.azion.com) web platform.
+
+> Access the [introduction](https://api.azion.com/#intro) documentation to find reference information about the API.
+
+## Prerequisites
+
+To run **Azion API** requests you need:
+
+- **Real-Time Manager (RTM)** account.
+- **API token (personal token)**.
+
+> Learn [how to create an RTM account](https://www.azion.com/en/documentation/products/accounts/creating-account/) and how to create a [personal token](https://www.azion.com/en/documentation/products/accounts/personal-tokens/) to use with the API.
+
+## Make API requests with curl (and other programming languages) snippets
+ 
+Azion API documentation offers code examples to make requests with the terminal, using the curl tool, or to automate them with programming languages. 
+
+Postman offers HTTPS request snippets for many programming languages.
+
+To make Azion API requests with curl:
+
+1. Access the [Azion API documentation](https://api.azion.com).
+2. On the first column, select the endpoint and method you would like to perform. For example `Tools` > `Personal Tokens` > `POST Create Personal Token`.
+3. Navigate to `Example Request`.
+4. Change the authorization token header with your personal token.
+5. Change the request body properties with your data.
+
+curl request stdin example:
+
+```bash
+curl --location 'https://api.azionapi.net/iam/personal_tokens' \
+--header 'Accept: application/json; version=3' \
+--header 'Authorization: Token aziona4FbA7K7EfT4OdK3E1N641289b6346b02b4' \
+--header 'Content-Type: application/json' \
+--data '{   
+    "name": "My personal Token created with the Azion API",
+    "expires_at": "2024-01-01T00:00",
+    "description": "This token was created with Azion API"
+}'
+```
+
+6. Press `enter` to send.
+7. The success response should look like the `Example Response`, in the method documentation.
+
+Stdout example:
+
+```bash
+{
+  "uuid": "ef1a5k4e-t7o2-k9e4-n1d8-d07567bb0a13",
+  "name": "My personal Token created with the Azion API",
+  "key": "aziona4FbA7K7EfT4OdK3E1N641289b6346b02b4",
+  "user_id": 999,
+  "created": "2023-07-06T09:41:22.777299-03:00",
+  "expires_at": "2024-01-01T00:00:00-03:00",
+  "description": "This token was created with Azion API"
+}
+```
+
+### Implement requests with programming languages
+
+To change from curl to another desired programming language:
+
+1. Navigate to **LANGUAGE** on the Postman UI top bar.
+2. From the dropdown menu, select the desired programming language.
+
+The code snippet from `Example Request` will change to the desired programming language request snippet.

--- a/src/content/docs/en/pages/azion-api/overview/azion-api-overview.mdx
+++ b/src/content/docs/en/pages/azion-api/overview/azion-api-overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: Azion API
+title: Get started with Azion API
 description: Azion RESTful API. Learn more about oficial endpoints, methods and API use cases.
 meta_tags: azion, rest api, restful api, azion restful api
 namespace: documentation_products_azion_api_overview

--- a/src/content/docs/en/pages/azion-api/overview/azion-api-overview.mdx
+++ b/src/content/docs/en/pages/azion-api/overview/azion-api-overview.mdx
@@ -10,7 +10,7 @@ This documentation will guide you on the first steps of using the **Azion API**.
 
 ## API overview
 
-The **Azion API** is a *RESTful API* based on *HTTPS* requests, that allows users to fully interact with Azion products through API requests. Most API endpoints have the main HTTP methods (`GET`, `POST`, `PUT`, `PATCH`, and `DELETE`), so you can create, read, update, and delete Azion configuration instances. All changes made through the API are reflected on the [Real-Time Manager (RTM)](https://manager.azion.com) web platform.
+The **Azion API** is a *RESTful API* based on *HTTPS* requests, that allows users to fully interact with Azion products through API requests. Most API endpoints have the main HTTP methods (`GET`, `POST`, `PUT`, `PATCH`, and `DELETE`), so you can create, read, update, and delete Azion configuration instances. All changes made through the API are reflected on the [Real-Time Manager (RTM)](https://manager.azion.com).
 
 > Access the [introduction](https://api.azion.com/#intro) documentation to find reference information about the API.
 


### PR DESCRIPTION
Related issue: [EDU-2367](https://aziontech.atlassian.net/browse/EDU-2367)

Changes:

* Introducing new file: `Azion API overview` for the documentation portal.

> This overview brings all necessary knowledge to make Azion RESTful API requests. For more information on Postman UI, and how to make Azion API request through Postman UI, reach out to the API oficial documentation. There you will find this same page, but with more content about Postman UI. Postman UI is out of here because is only relevant for Postman users, and the API overview is relevant for all API users.

[EDU-2367]: https://aziontech.atlassian.net/browse/EDU-2367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ