### PR TITLE
[EDU-2677] add-activity-history-gql-ttl-date

### DIFF
--- a/src/content/docs/en/pages/api-graphql/features/features.mdx
+++ b/src/content/docs/en/pages/api-graphql/features/features.mdx
@@ -38,7 +38,7 @@ Find each available dataset and what they request next.
 
 | Dataset | Description |
 | ------- | ----------- |
-| activityHistoryEvents | Events logs from an account on Real-Time Manager (RTM) regarding activities registered on [Activity History](/en/documentation/products/accounts/activity-history/). |
+| activityHistoryEvents | Events logs from an account on Real-Time Manager (RTM) regarding activities registered on [Activity History](/en/documentation/products/accounts/activity-history/). It stores data for *2 years* and exhibits data starting from *September 22nd, 2023*. |
 | cellsConsoleEvents |  Events logs from applications using [Edge Runtime](/en/documentation/products/edge-application/edge-functions/runtime/overview/) returned by the Cells Console. |
 | dataStreamedEvents | Sent events of data by [Data Streaming](/en/documentation/products/data-streaming/) to the clients' endpoint. |
 | edgeFunctionsEvents | Events executed by [Edge Functions](/en/documentation/products/edge-application/edge-functions/). |

--- a/src/content/docs/pt-br/pages/api-graphql/recursos/index.mdx
+++ b/src/content/docs/pt-br/pages/api-graphql/recursos/index.mdx
@@ -39,6 +39,7 @@ Veja cada um dos conjuntos de dados disponíveis e o que eles buscam.
 
 | Conjunto de dados | Descrição |
 | ----------------- | --------- |
+| activityHistoryEvents | Logs de eventos de uma conta no Real-Time Manager (RTM) relacionados às atividades registradas no [Activity History](/pt-br/documentacao/produtos/gestao-de-contas/activity-history/). Armazena dados por *2 anos* e exibe dados a partir de *22 de setembro de 2023*. |
 | cellsConsoleEvents | Logs de eventos das aplicações usando o [Edge Runtime](/pt-br/documentacao/produtos/edge-application/edge-functions/runtime/visao-geral/) retornados pelo Cells Console. |
 | dataStreamedEvents | Registros de envio de dados do [Data Streaming](/pt-br/documentacao/produtos/data-streaming/) para o endpoint do cliente. |
 | edgeFunctionsEvents | Eventos de execução do [Edge Functions](/pt-br/documentacao/produtos/edge-application/edge-functions/). |


### PR DESCRIPTION
### Related issue:

[EDU-2677]

### Changes

* Added info on data storage + data beginning for the activityHistoryEvents dataset on Real-Time Events GQL.

[EDU-2677]: https://aziontech.atlassian.net/browse/EDU-2677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ