### PR TITLE
EDU-2676-EN-Add-learning-video-to-WAF-Custom-Allowed-Rules

### DIFF
--- a/src/content/docs/en/pages/products/edge-firewall/web-application-firewall/custom-allowed-rule.mdx
+++ b/src/content/docs/en/pages/products/edge-firewall/web-application-firewall/custom-allowed-rule.mdx
@@ -22,68 +22,70 @@ When creating custom allowed rules for a WAF configuration, it's necessary to ch
 
 See the list of all available internal rules below:
 
-| Rule ID | Description                                                                                                                               |
-|:-------:|:------------------------------------------------------------------------------------------------------------------------------------------|
-| 1       | Weird request, unable to parse                                                                                                            |
-| 2       | Request larger than 128 kilobytes, stored on disk, and not parsed                                                                                            |
-| 10      | Invalid HEX encoding (null bytes)                                                                                                         |
-| 11      | Missing or unknown Content-Type header in a POST (this rule applies only to Request Body match zone)                                      |
-| 12      | Invalid formatted URL                                                                                                                     |
-| 13      | Invalid POST format                                                                                                                       |
-| 14      | Invalid POST boundary                                                                                                                     |
-| 15      | Invalid JSON format                                                                                                                       |
-| 16      | POST with no body                                                                                                                         |
-| 17      | Possible SQL Injection attack: validation with `libinjection_sql`                                                                         |
-| 18      | Possible XSS attack: validation with `libinjection_xss`                                                                                   |
-| 1000    | Possible SQL Injection attack: SQL keywords found in Body, Path, Query String, or Cookies                                                  |
-| 1001    | Possible SQL Injection or XSS attack: double quote `"` found in Body, Path, Query String or Cookies                                       |
-| 1002    | Possible SQL Injection attack: possible hex encoding `0x` found in Body, Path, Query String or Cookies                                    |
-| 1003    | Possible SQL Injection attack: MySQL comment `/*` found in Body, Path, Query String or Cookies                                            |
-| 1004    | Possible SQL Injection attack: MySQL comment `*/` found in Body, Path, Query String or Cookies                                            |
-| 1005    | Possible SQL Injection attack: MySQL keyword `\|` found in Body, Path, Query String or Cookies                                            |
-| 1006    | Possible SQL Injection attack: MySQL keyword `&&` found in Body, Path, Query String or Cookies                                            |
-| 1007    | Possible SQL Injection attack: MySQL comment `--` found in Body, Path, Query String or Cookies                                            |
-| 1008    | Possible SQL Injection or XSS attack: semicolon `;` found in Body, Path or Query String                                                   |
-| 1009    | Possible SQL Injection attack: equal sign `=` found in Body or Query String                                                               |
-| 1010    | Possible SQL Injection or XSS attack: open parenthesis `(` found in Body, Path, Query String or Cookies                                   |
-| 1011    | Possible SQL Injection or XSS attack: close parenthesis `)` found in Body, Path, Query String or Cookies                                  |
-| 1013    | Possible SQL Injection or XSS attack: apostrophe `'` found in Body, Path, Query String or Cookies                                         |
-| 1015    | Possible SQL Injection attack: comma `,` found in Body, Path, Query String or Cookies                                                     |
-| 1016    | Possible SQL Injection attack: MySQL comment `#` found in Body, Path, Query String or Cookies                                             |
-| 1017    | Possible SQL Injection attack: double at sign `@@` found in Body, Path, Query String or Cookies                                           |
-| 1100    | Possible RFI attack: scheme `http://` found in Body, Query String or Cookies                                                              |
-| 1101    | Possible RFI attack: scheme `https://` found in Body, Query String or Cookies                                                             |
-| 1102    | Possible RFI attack: scheme `ftp://` found in Body, Query String or Cookies                                                               |
-| 1103    | Possible RFI attack: scheme `php://` found in Body, Query String or Cookies                                                               |
-| 1104    | Possible RFI attack: scheme `sftp://` found in Body, Query String or Cookies                                                              |
-| 1105    | Possible RFI attack: scheme `zlib://` found in Body, Query String or Cookies                                                              |
-| 1106    | Possible RFI attack: scheme `data://` found in Body, Query String or Cookies                                                              |
-| 1107    | Possible RFI attack: scheme `glob://` found in Body, Query String or Cookies                                                              |
-| 1108    | Possible RFI attack: scheme `phar://` found in Body, Query String or Cookies                                                              |
-| 1109    | Possible RFI attack: scheme `file://` found in Body, Query String or Cookies                                                              |
-| 1110    | Possible RFI attack: scheme `gopher://` found in Body, Query String or Cookies                                                            |
-| 1198    | Possible RCE attack: validation with `log4j` (Log4Shell) in `HEADERS_VAR`                                                                 |
-| 1199    | Possible RCE attack: validation with `log4j` (Log4Shell) in Body, Path, Query String, Headers, or Cookies                                  |
-| 1200    | Possible Directory Traversal attack: double dot `..` found in Body, Path, Query String or Cookies                                         |
-| 1202    | Possible Directory Traversal attack: obvious probe `/etc/passwd` found in Body, Path, Query String or Cookies                             |
-| 1203    | Possible Directory Traversal attack: obvious Windows path `c:\\` found in Body, Path, Query String or Cookies                             |
-| 1204    | Possible Directory Traversal attack: obvious probe `cmd.exe` found in Body, Path, Query String or Cookies                                 |
-| 1205    | Possible Directory Traversal attack: backslash `\` found in Body, Path, Query String or Cookies                                           |
-| 1206    | Possible Directory Traversal attack: slash `/` found in Body, Query String, or Cookies                                                     |
-| 1207    | Possible Directory Traversal attack: obvious probe `/..;/)` found in Body, Path, Query String or Cookies                                  |
-| 1208    | Possible Directory Traversal attack: obvious probe `/.;/)` found in Body, Path, Query String or Cookies                                   |
-| 1209    | Possible Directory Traversal attack: obvious probe `/.%2e/)` found in Body, Path, Query String or Cookies                                 |
-| 1209    | Possible Directory Traversal attack: obvious probe `/%2e./)` found in Body, Path, Query String or Cookies                                 |
-| 1302    | Possible XSS attack: HTML open tag `<` found in Body, Path, Query String or Cookies                                                       |
-| 1303    | Possible XSS attack: HTML close tag `>` found in Body, Path, Query String or Cookies                                                      |
-| 1310    | Possible XSS attack: open square bracket `[` found in Body, Path, Query String or Cookies                                                 |
-| 1311    | Possible XSS attack: close square bracket `]` found in Body, Path, Query String or Cookies                                                |
-| 1312    | Possible XSS attack: tilde character `~` found in Body, Path, Query String, or Cookies                                                     |
-| 1314    | Possible XSS attack: <code>`</code> (*backtick*) found in Body, Path, Query String, or Cookies                                                     |
-| 1315    | Possible XSS attack: double encoding `%[2\|3]` found in Body, Path, Query String or Cookies                                                |
-| 1400    | Possible trick to evade protection: UTF7/8 encoding `&#` found in Body, Path, Query String or Cookies                                     |
-| 1401    | Possible trick to evade protection: MS encoding `%U` found in Body, Path, Query String or Cookies                                         |
-| 1402    | Possible trick to evade protection: encoded chars `%20-%3F` found in Body, Path, Query String or Cookies                                  |
-| 1500    | Possible File Upload attempt: `asp/php` or `.ph`, `.asp`, `.ht` found in filename in a multipart POST containing a file                   |
+| Rule ID | Description                                                                                                                                |
+|---------|--------------------------------------------------------------------------------------------------------------------------------------------|
+| 1       | Weird request, unable to parse.                                                                                                            |
+| 2       | Request larger than 128 kilobytes, stored on disk, and not parsed.                                                                         |
+| 10      | Invalid HEX encoding (null bytes).                                                                                                         |
+| 11      | Missing or unknown Content-Type header in a POST (this rule applies only to Request Body match zone).                                      |
+| 12      | Invalid formatted URL.                                                                                                                     |
+| 13      | Invalid POST format.                                                                                                                       |
+| 14      | Invalid POST boundary.                                                                                                                     |
+| 15      | Invalid JSON format.                                                                                                                       |
+| 16      | POST with no body.                                                                                                                         |
+| 17      | Possible SQL Injection attack: validation with `libinjection_sql`.                                                                         |
+| 18      | Possible XSS attack: validation with `libinjection_xss`.                                                                                   |
+| 1000    | Possible SQL Injection attack: SQL keywords found in Body, Path, Query String, or Cookies.                                                 |
+| 1001    | Possible SQL Injection or XSS attack: double quote `"` found in Body, Path, Query String or Cookies.                                       |
+| 1002    | Possible SQL Injection attack: possible hex encoding `0x` found in Body, Path, Query String or Cookies.                                    |
+| 1003    | Possible SQL Injection attack: MySQL comment `/*` found in Body, Path, Query String or Cookies.                                            |
+| 1004    | Possible SQL Injection attack: MySQL comment `*/` found in Body, Path, Query String or Cookies.                                            |
+| 1005    | Possible SQL Injection attack: MySQL keyword `\|` found in Body, Path, Query String or Cookies.                                            |
+| 1006    | Possible SQL Injection attack: MySQL keyword `&&` found in Body, Path, Query String or Cookies.                                            |
+| 1007    | Possible SQL Injection attack: MySQL comment `--` found in Body, Path, Query String or Cookies.                                            |
+| 1008    | Possible SQL Injection or XSS attack: semicolon `;` found in Body, Path or Query String.                                                   |
+| 1009    | Possible SQL Injection attack: equal sign `=` found in Body or Query String.                                                               |
+| 1010    | Possible SQL Injection or XSS attack: open parenthesis `(` found in Body, Path, Query String or Cookies.                                   |
+| 1011    | Possible SQL Injection or XSS attack: close parenthesis `)` found in Body, Path, Query String or Cookies.                                  |
+| 1013    | Possible SQL Injection or XSS attack: apostrophe `'` found in Body, Path, Query String or Cookies.                                         |
+| 1015    | Possible SQL Injection attack: comma `,` found in Body, Path, Query String or Cookies.                                                     |
+| 1016    | Possible SQL Injection attack: MySQL comment `#` found in Body, Path, Query String or Cookies.                                             |
+| 1017    | Possible SQL Injection attack: double at sign `@@` found in Body, Path, Query String or Cookies.                                           |
+| 1100    | Possible RFI attack: scheme `http://` found in Body, Query String or Cookies.                                                              |
+| 1101    | Possible RFI attack: scheme `https://` found in Body, Query String or Cookies.                                                             |
+| 1102    | Possible RFI attack: scheme `ftp://` found in Body, Query String or Cookies.                                                               |
+| 1103    | Possible RFI attack: scheme `php://` found in Body, Query String or Cookies.                                                               |
+| 1104    | Possible RFI attack: scheme `sftp://` found in Body, Query String or Cookies.                                                              |
+| 1105    | Possible RFI attack: scheme `zlib://` found in Body, Query String or Cookies.                                                              |
+| 1106    | Possible RFI attack: scheme `data://` found in Body, Query String or Cookies.                                                              |
+| 1107    | Possible RFI attack: scheme `glob://` found in Body, Query String or Cookies.                                                              |
+| 1108    | Possible RFI attack: scheme `phar://` found in Body, Query String or Cookies.                                                              |
+| 1109    | Possible RFI attack: scheme `file://` found in Body, Query String or Cookies.                                                              |
+| 1110    | Possible RFI attack: scheme `gopher://` found in Body, Query String or Cookies.                                                            |
+| 1198    | Possible RCE attack: validation with `log4j` (Log4Shell) in `HEADERS_VAR`.                                                                 |
+| 1199    | Possible RCE attack: validation with `log4j` (Log4Shell) in Body, Path, Query String, Headers, or Cookies.                                 |
+| 1200    | Possible Directory Traversal attack: double dot `..` found in Body, Path, Query String or Cookies.                                         |
+| 1202    | Possible Directory Traversal attack: obvious probe `/etc/passwd` found in Body, Path, Query String or Cookies.                             |
+| 1203    | Possible Directory Traversal attack: obvious Windows path `c:\\` found in Body, Path, Query String or Cookies.                             |
+| 1204    | Possible Directory Traversal attack: obvious probe `cmd.exe` found in Body, Path, Query String or Cookies.                                 |
+| 1205    | Possible Directory Traversal attack: backslash `\` found in Body, Path, Query String or Cookies.                                           |
+| 1206    | Possible Directory Traversal attack: slash `/` found in Body, Query String, or Cookies.                                                    |
+| 1207    | Possible Directory Traversal attack: obvious probe `/..;/)` found in Body, Path, Query String or Cookies.                                  |
+| 1208    | Possible Directory Traversal attack: obvious probe `/.;/)` found in Body, Path, Query String or Cookies.                                   |
+| 1209    | Possible Directory Traversal attack: obvious probe `/.%2e/)` found in Body, Path, Query String or Cookies.                                 |
+| 1209    | Possible Directory Traversal attack: obvious probe `/%2e./)` found in Body, Path, Query String or Cookies.                                 |
+| 1302    | Possible XSS attack: HTML open tag `<` found in Body, Path, Query String or Cookies.                                                       |
+| 1303    | Possible XSS attack: HTML close tag `>` found in Body, Path, Query String or Cookies.                                                      |
+| 1310    | Possible XSS attack: open square bracket `[` found in Body, Path, Query String or Cookies.                                                 |
+| 1311    | Possible XSS attack: close square bracket `]` found in Body, Path, Query String or Cookies.                                                |
+| 1312    | Possible XSS attack: tilde character `~` found in Body, Path, Query String, or Cookies.                                                    |
+| 1314    | Possible XSS attack: <code>`</code> (*backtick*) found in Body, Path, Query String, or Cookies.                                            |
+| 1315    | Possible XSS attack: double encoding `%[2\|3]` found in Body, Path, Query String or Cookies.                                               |
+| 1400    | Possible trick to evade protection: UTF7/8 encoding `&#` found in Body, Path, Query String or Cookies.                                     |
+| 1401    | Possible trick to evade protection: MS encoding `%U` found in Body, Path, Query String or Cookies.                                         |
+| 1402    | Possible trick to evade protection: encoded chars `%20-%3F` found in Body, Path, Query String or Cookies.                                  |
+| 1500    | Possible File Upload attempt: `asp/php` or `.ph`, `.asp`, `.ht` found in filename in a multipart POST containing a file.                   |
 
 > **Warning**: requests that fall under rules 1 to 18 will be blocked, even if the WAF is operating in *learning* mode. Read the [Rules Engine for Edge Firewall](/en/documentation/products/edge-firewall/rules-engine/) documentation for the definition of learning/blocking modes. Read this guide [how to check your WAF mode](/en/documentation/products/guides/how-to-check-your-waf-mode/).
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/uhpoeBXLvxk?si=eb8Jx_LRaUq1FBlh" loading="lazy" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>


### PR DESCRIPTION
Related issue: [EDU-2676](https://aziontech.atlassian.net/browse/EDU-2676)

Changes:

* Introducing the WAF Custom Allowed Rules video made by Learning Experience team.

[EDU-2676]: https://aziontech.atlassian.net/browse/EDU-2676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ