### PR TITLE
EDU-2676-PT-Add-learning-video-to-WAF-Custom-Allowed-Rules

### DIFF
--- a/src/content/docs/pt-br/pages/produtos/edge-firewall/web-application-firewall/custom-allowed-rule/index.mdx
+++ b/src/content/docs/pt-br/pages/produtos/edge-firewall/web-application-firewall/custom-allowed-rule/index.mdx
@@ -24,7 +24,7 @@ Veja, abaixo, a lista de todas as regras internas disponíveis:
 | ID da Regra | Descrição                                                                                                                             |
 |:-------:|:------------------------------------------------------------------------------------------------------------------------------------------|
 | 1       | Weird request, unable to parse                                                                                                            |
-| 2       | Request larger than 128 kilobytes, stored on disk and not parsed                                                                                            |
+| 2       | Request larger than 128 kilobytes, stored on disk and not parsed                                                                          |
 | 10      | Invalid HEX encoding (null bytes)                                                                                                         |
 | 11      | Missing or unknown Content-Type header in a POST (this rule applies only to Request Body match zone)                                      |
 | 12      | Invalid formatted URL                                                                                                                     |
@@ -78,11 +78,13 @@ Veja, abaixo, a lista de todas as regras internas disponíveis:
 | 1310    | Possible XSS attack: open square bracket `[` found in Body, Path, Query String or Cookies                                                 |
 | 1311    | Possible XSS attack: close square bracket `]` found in Body, Path, Query String or Cookies                                                |
 | 1312    | Possible XSS attack: tilde character `~` found in Body, Path, Query String or Cookies                                                     |
-| 1314    | Possible XSS attack: <code>`</code> (*backtick*) found in Body, Path, Query String or Cookies                                                     |
-| 1315    | Possible XSS attack: double encoding `%[2\|3]` found in Body, Path, Query String or Cookies                                                |
+| 1314    | Possible XSS attack: <code>`</code> (*backtick*) found in Body, Path, Query String or Cookies                                             |
+| 1315    | Possible XSS attack: double encoding `%[2\|3]` found in Body, Path, Query String or Cookies                                               |
 | 1400    | Possible trick to evade protection: UTF7/8 encoding `&#` found in Body, Path, Query String or Cookies                                     |
 | 1401    | Possible trick to evade protection: MS encoding `%U` found in Body, Path, Query String or Cookies                                         |
 | 1402    | Possible trick to evade protection: encoded chars `%20-%3F` found in Body, Path, Query String or Cookies                                  |
 | 1500    | Possible File Upload attempt: `asp/php` or `.ph`, `.asp`, `.ht` found in filename in a multipart POST containing a file                   |
 
 > **Aviso**: Requisições que caírem nas regras do 1 até 18 serão bloqueadas, mesmo que o WAF esteja operando em modo *learning*. Veja na documentação do [Rules Engine para Edge Firewall](/pt-br/documentacao/produtos/edge-firewall/rules-engine/) a definição dos modos learning/blocking. Veja no guia [como verificar o modo do seu WAF](/pt-br/documentacao/produtos/guias/como-verificar-modo-do-seu-waf/).
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/uhpoeBXLvxk?si=eb8Jx_LRaUq1FBlh" loading="lazy" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>


### PR DESCRIPTION
Tarefa relacionada: [EDU-2676](https://aziontech.atlassian.net/browse/EDU-2676)

Alterações:

* Introdução do vídeo sobre WAF Custom Allowed Rules feito pelo time de Learning.

[EDU-2676]: https://aziontech.atlassian.net/browse/EDU-2676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ