### PR TITLE
EDU-2191-Component-EN-Edge-Firewall-Rules-Engine

### DIFF
--- a/src/content/docs/en/pages/products/edge-firewall/rules-engine.mdx
+++ b/src/content/docs/en/pages/products/edge-firewall/rules-engine.mdx
@@ -21,7 +21,9 @@ You can use the Rules Engine for Edge Firewall to configure all operational aspe
 
 An Edge Firewall Rule Set can have as many rules as needed. These rules are also interchangeable, as you can share the same rule for all other Edge Firewall configurations.
 
-> Learn more about [Edge Firewall](/en/documentation/products/edge-firewall/) and its modules.
+:::note
+Learn more about [Edge Firewall](/en/documentation/products/edge-firewall/) and its modules.
+:::
 
 ## How Rules Engine for Edge Firewall works
 
@@ -45,7 +47,9 @@ An Edge Firewall Rule Set is composable by:
 
 *Criteria* determines the set of conditions that need to be met for the execution of *Behaviors*. The availability of criteria depends on the enabled modules of your Edge Firewall. 
 
-> Learn more about [Edge Firewall modules](/en/documentation/products/edge-firewall/#how-azion-edge-firewall-works).
+:::note
+Learn more about [Edge Firewall modules](/en/documentation/products/edge-firewall/#how-azion-edge-firewall-works).
+:::
 
 #### Criteria variables
 
@@ -84,13 +88,17 @@ The condition for the execution of a rule must be the comparison of a variable w
 | exists              | The variable has a defined value. For example, Request Args exists if an argument is sent in the request's query string. | - |
 | does not exist      | The variable doesn't have a defined value. For example, Request Args doesn't exist if an argument is sent in the request's query string. | - |
 
-> These operators may vary according to the selected Criteria.
+:::tip
+These operators may vary according to the selected Criteria.
+:::
 
 #### Logic Operators
 
 Multiple conditions can be defined using the logical operators `and` and `or`. 
 
-> The operator `and` has implicit precedence over the operator `or`.
+:::tip
+The operator `and` has implicit precedence over the operator `or`.
+:::
 
 If explicit precedence is required, you can add multiple criteria groups under the `and` logic.
 
@@ -109,6 +117,10 @@ These are all the available behaviors:
 | Run a Function                | It runs a function specified as a parameter. The function must have been previously instantiated and parameterized in the Functions tab in order to be used. | Edge Functions           |
 | Set Custom Response           | It allows a customized response when the request matches the criteria. You can customize the `Status Code` by changing it from 200 to 499, `Content Type` header, and `Content Body` of your request with a maximum of `500` characters. | - | 
 
-> The `Maximum Burst size` is only available for the `Req/s` (request per second).
+:::tip
+The `Maximum Burst size` is only available for the `Req/s` (request per second).
+:::
 
-> Azion platform maintains only one `Set WAF Rule Set` behavior configuration for each criteria logic. If you have two different Edge Firewall Rule Sets configured with the same criteria logic but different `Set WAF Rule Set` behaviors, only the most recent one will be processed. This can be useful in case your application needs constant switching between two or more behaviors for the same criteria.
+:::caution[Warning]
+Azion platform maintains only one `Set WAF Rule Set` behavior configuration for each criteria logic. If you have two different Edge Firewall Rule Sets configured with the same criteria logic but different `Set WAF Rule Set` behaviors, only the most recent one will be processed. This can be useful in case your application needs constant switching between two or more behaviors for the same criteria.
+:::


### PR DESCRIPTION
Related issue: [EDU-2164](https://aziontech.atlassian.net/browse/EDU-2191)

Changes:

* Introducing Astro components for substitution of `>`.

[EDU-2164]: https://aziontech.atlassian.net/browse/EDU-2164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ