### PR TITLE
[DEV-838] Open <A> inside content in another tab

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -18,6 +18,8 @@ import { autolinkConfig } from './plugins/rehype-autolink-config';
 import { rehypei18nAutolinkHeadings } from './plugins/rehype-i18n-autolink-headings';
 import { rehypeOptimizeStatic } from './plugins/rehype-optimize-static';
 import { rehypeTasklistEnhancer } from './plugins/rehype-tasklist-enhancer';
+import { rehypeLinks } from './plugins/rehypeLinks.mjs';
+
 
 // https://astro.build/config
 export default defineConfig({
@@ -47,6 +49,7 @@ export default defineConfig({
 		rehypePlugins: [
 			rehypeSlug,
 			// This adds links to headings
+			rehypeLinks,
 			[rehypeAutolinkHeadings, autolinkConfig],
 			// Tweak GFM task list syntax
 			rehypeTasklistEnhancer(),

--- a/plugins/rehypeLinks.mjs
+++ b/plugins/rehypeLinks.mjs
@@ -1,0 +1,25 @@
+export function rehypeLinks() {
+  return function (tree) {
+    tree.children.forEach((node) => {
+      setLinkAttributes(node)
+    })
+  }
+}
+
+const setLinkAttributes = (node) => {
+  if (node.tagName === "p" || node.tagName === "ul" || node.tagName === "li" || node.tagName === "h2" || node.tagName === "h3" ||  node.tagName === "aside" ||  node.tagName === "section") {
+    node.children.forEach((n) => setLinkAttributes(n))
+  } else if (node.tagName === "a") {
+		if (node.properties.href.startsWith('#')) return
+    node.properties.target = "_blank"
+    node.properties.rel = "noopener"
+  }
+}
+
+			// [
+			// 	rehypeExternalLinks,
+			// 	{
+			// 			target: '_blank',
+			// 			rel: ['noopener', 'noreferrer'],
+			// 	},
+			// ],	

--- a/src/components/Button.astro
+++ b/src/components/Button.astro
@@ -5,7 +5,7 @@ const { href, text } = Astro.props;
 const { variant = 'primary' } = Astro.props;
 ---
 
-<a class:list={[`btn-component btn-component-icon btn-component-${variant}`]} {href}>
+<a class:list={[`btn-component btn-component-icon btn-component-${variant}`]} {href} target="_blank" rel="noopener">
 	{text}
 	<i class="icon icon-right-arrow icon-animation-primary">
 		<svg width="7" height="11" viewBox="0 0 7 11" fill="none" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
### Related issue: [DEV-838](https://aziontech.atlassian.net/browse/DEV-838)

### Changes
- Added a custom plugin to open <a> (internal and external) in another browser tab

[DEV-838]: https://aziontech.atlassian.net/browse/DEV-838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ