### PR TITLE
[EDU-2448] refactor: cache keys into edge caching

### DIFF
--- a/src/content/docs/en/pages/main-menu/reference/build/edge-application/edge-caching.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/build/edge-application/edge-caching.mdx
@@ -27,6 +27,78 @@ With Azion, you can customize the time the cache remains in the edge through *ti
 
 ---
 
+## Cache keys
+
+A cache key is an index entry for an object in Azion's edge nodes. When a first request is made to an edge application, the edge requests the objects within the request to the origin server. This generates a cache for each object at the edge. When the next request for the same resource is made to the edge application, if the resource requested matches one already found through the cache key, the request won't be forwarded to the origin.
+
+You can obtain the cache key of an application's resource through a `HEAD` request for the content URI and add the Azion debug header `Pragma: azion-debug-cache`:
+
+```bash
+curl --location --head 'https://yourdomain.com/resource-path/image.jpeg' \
+--header 'Pragma: azion-debug-cache'
+```
+
+The response will return an `X-Cache-Key` header with the cache key value, which based on the example above, would be:
+
+```
+X-Cache-Key: httpsyourdomain.com/resource-path/image.jpeg@@
+```
+
+:::note
+Find out more about how to obtain other cache data in the guide [How to verify application cache indicators using Modheader for Google Chrome](/en/documentation/products/guides/check-page-cache-time/).
+:::
+
+### Cache key format
+
+The default cache key format adopted by Azion concatenates the following URI syntax elements:
+
+- Method (for complex requests)
+- Scheme of the request
+- Host
+- Path to the resource
+- Query string
+
+An object with the URI `https://static.yourdomain.com/page/site.js` should generate the cache key `httpsstatic.yourdomain.com/page/site.js`.
+
+If the resource is obtained using a complex request (any method different than `GET` or `HEAD`), the method is added to the cache key. For example, for an `OPTIONS` request to `https://static.yourdomain.com/page`, the cache key generated for the object will be `optionshttpsstatic.yourdomain.com/page`.
+
+Some cache keys may also append the separator `@@` when variations are generated at the edge. See the 
+
+#### Image Processor
+
+When [Image Processor](/en/documentation/products/edge-application/image-processor/) is activated and an image is resized and converted into `webp` format, the cache key generated will be `httpsstatic.yourdomain.com/static/images/image_1.jpg?ims=880x@@webp`.
+
+#### Device Groups
+
+If there's an object variation per [device group](/en/documentation/products/edge-application/device-groups/), the cache key will be appended with the separator `@@` and the device group name; for example: `httpwww.yourdomain.com/@@Mobile`.
+
+#### Advanced Cache Key
+
+When the [Advanced Cache Key](/en/documentation/products/edge-application/application-acceleration/#advanced-cache-key) feature is configured, the formation of cache keys is also affected. 
+
+**Cache by Cookie** generates a cache key variation with the determined cookie names and values followed by `;`. For example, content variation based on the `user` cookie would generate the following cache keys:
+
+- `httpwww.yourdomain.com/@@;`
+- `httpwww.yourdomain.com/@@user=user;`
+
+**Cache by Query String** generates a cache key variation with the query separator and the determined arguments based on the order of the query string submitted in the request; for example, `httpstatic.yourdomain.com/page?id=1000&name=name`. If **Query string sort** is enabled, the URIs with the query strings `?name=name&city=city` and `?city=city&name=name` will be grouped under the same cache key, ordered alphabetically.
+
+#### File slicing
+
+For sliced objects, the cache key appends the `@@bytes=` separator for each slice of content. Cache keys using optimization for delivering large files have the following format:
+
+- `httpstatic.yourdomain.com/media/file.mp4@@bytes=0-1048575`
+- `httpstatic.yourdomain.com/media/file.mp4@@bytes=1048576-2097151`
+
+#### Cached HTTP methods
+
+For cached `POST` or `OPTIONS` requests, the cache key appends the `@@` separator followed by the MD5 hash of the request body. For example:
+
+- `httpsdynamic.yourdomain.com/path@@md5_of_post_arguments`
+- `httpsdynamic.yourdomain.com/path@@md5_of_options_arguments`
+
+---
+
 ## Expiration settings
 
 With Edge Caching, you can customize both browser cache TTL (Time-to-Live) and edge cache TTL according to your specific requirements.
@@ -59,8 +131,6 @@ However, the server may encounter problems and be unable to get the most up-to-d
 **Adaptive Delivery** detects device groups you've created using [Device Groups](/en/documentation/products/edge-application/device-groups/), allowing you to configure how Azion delivers your content. You may choose to deliver the same version of the content, regardless of device detection or keep device-based variations of objects in cache.
 
 <Button href="/en/documentation/products/edge-application/cache-settings/#adaptive-delivery" text="Learn more about Adaptive Delivery"></Button>
-
-
 
 ---
 

--- a/src/content/docs/en/pages/main-menu/reference/build/edge-application/edge-caching.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/build/edge-application/edge-caching.mdx
@@ -69,24 +69,30 @@ For example, for an `OPTIONS` request, the cache key generated for an object wou
 
 #### Image Processor
 
-When [Image Processor](/en/documentation/products/edge-application/image-processor/) is activated, each `ims` query element is separated by the separator.
+When [Image Processor](/en/documentation/products/edge-application/image-processor/) is activated, in addition to the `ims` query string, variations with converted format contain the file format after the separator.
 
 For example, for an image that is resized and converted into `webp` format, the cache key generated will be `httpsstatic.yourdomain.com/static/images/image_1.jpg?ims=880x@@webp`.
 
 #### Device Groups
 
-If there's an object variation per [device group](/en/documentation/products/edge-application/device-groups/), the cache key will be appended with the separator `@@` and the device group name; for example: `httpwww.yourdomain.com/@@Mobile`.
+If there's an object variation per [device group](/en/documentation/products/edge-application/device-groups/), the cache key will be appended with the separator `@@` and the device group name
+
+For example, for an application that implements variation for the `Mobile` group, the generated cache key will be `httpwww.yourdomain.com/@@Mobile`.
 
 #### Advanced Cache Key
 
 When the [Advanced Cache Key](/en/documentation/products/edge-application/application-acceleration/#advanced-cache-key) feature is configured, the formation of cache keys is also affected. 
 
-**Cache by Cookie** generates a cache key variation with the determined cookie names and values followed by `;`. For example, content variation based on the `user` cookie could generate the following cache keys:
+**Cache by Cookie** generates a cache key variation with the determined cookie names and values followed by `;`. 
+
+For example, content variation based on the `user` cookie could generate the following cache keys:
 
 - `httpwww.yourdomain.com/@@;`
 - `httpwww.yourdomain.com/@@user=user;`
 
-**Cache by Query String** generates cache keys with the query separator and the determined arguments based on the order of the query strings submitted in the request. For example, content variation based on `name` and `city` could generate the following cache keys:
+**Cache by Query String** generates cache keys with the query separator and the determined arguments based on the order of the query strings submitted in the request. 
+
+For example, content variation based on `name` and `city` could generate the following cache keys:
 
 - `httpstatic.yourdomain.com/page?name=name`
 - `httpstatic.yourdomain.com/page?city=city&name=name`
@@ -96,14 +102,18 @@ For multiple query strings, if **Query string sort** is enabled, the query strin
 
 #### File slicing
 
-For sliced objects, the cache key appends the `@@bytes=` separator for each slice of content. Cache keys using optimization for delivering large files have the following format:
+For sliced objects, the cache key appends the `@@bytes=` separator for each slice of content.
+
+For example, for a file that is `2097151` bytes in size, if file slicing is enabled, the cache keys generated will be:
 
 - `httpstatic.yourdomain.com/media/file.mp4@@bytes=0-1048575`
 - `httpstatic.yourdomain.com/media/file.mp4@@bytes=1048576-2097151`
 
 #### Cached HTTP methods
 
-For cached `POST` or `OPTIONS` requests, the cache key appends the `@@` separator followed by the MD5 hash of the request body. For example:
+For cached `POST` or `OPTIONS` requests, the cache key appends the `@@` separator followed by the MD5 hash of the request body. 
+
+For example:
 
 - `httpsdynamic.yourdomain.com/path@@md5_of_post_arguments`
 - `httpsdynamic.yourdomain.com/path@@md5_of_options_arguments`

--- a/src/content/docs/en/pages/main-menu/reference/build/edge-application/edge-caching.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/build/edge-application/edge-caching.mdx
@@ -51,10 +51,11 @@ Find out more about how to obtain other cache data in the [How to verify applica
 
 The default cache key format adopted by Azion concatenates the following URI syntax elements:
 
-- Scheme of the request
+- Scheme of the request (for complex requests)
 - Host
 - Path to the resource
 - Query string
+- A variation separator and appended variations
 
 An object with the URI `https://static.yourdomain.com/page/site.js` should generate the cache key `httpsstatic.yourdomain.com/page/site.js`.
 

--- a/src/content/docs/en/pages/main-menu/reference/build/edge-application/edge-caching.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/build/edge-application/edge-caching.mdx
@@ -55,7 +55,7 @@ The default cache key format adopted by Azion concatenates the following URI syn
 - Host
 - Path to the resource
 - Query strings
-- A variation separator and appended variations
+- A variation separator and, when implemented, appended variations
 
 An object with the URI `https://static.yourdomain.com/page/site.js` should generate the cache key `httpsstatic.yourdomain.com/page/site.js`.
 

--- a/src/content/docs/en/pages/main-menu/reference/build/edge-application/edge-caching.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/build/edge-application/edge-caching.mdx
@@ -54,7 +54,7 @@ The default cache key format adopted by Azion concatenates the following URI syn
 - Scheme of the request
 - Host
 - Path to the resource
-- Query string
+- Query strings
 - A variation separator and appended variations
 
 An object with the URI `https://static.yourdomain.com/page/site.js` should generate the cache key `httpsstatic.yourdomain.com/page/site.js`.

--- a/src/content/docs/en/pages/main-menu/reference/build/edge-application/edge-caching.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/build/edge-application/edge-caching.mdx
@@ -34,8 +34,7 @@ A cache key is an index entry for an object in Azion's edge nodes. When a reques
 You can obtain the cache key of an application's resource through a request for the content URI and add the Azion debug header `Pragma: azion-debug-cache`:
 
 ```bash
-curl --location --head 'https://yourdomain.com/resource-path/image.jpeg' \
---header 'Pragma: azion-debug-cache'
+curl -I https://yourdomain.com/resource-path/image.jpeg -H "Pragma: azion-debug-cache"
 ```
 
 A successful response will return an `X-Cache-Key` header with the cache key value, which based on the example above, would be:

--- a/src/content/docs/en/pages/main-menu/reference/build/edge-application/edge-caching.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/build/edge-application/edge-caching.mdx
@@ -51,7 +51,7 @@ Find out more about how to obtain other cache data in the [How to verify applica
 
 The default cache key format adopted by Azion concatenates the following URI syntax elements:
 
-- Scheme of the request (for complex requests)
+- Scheme of the request
 - Host
 - Path to the resource
 - Query string

--- a/src/content/docs/en/pages/main-menu/reference/build/edge-application/edge-caching.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/build/edge-application/edge-caching.mdx
@@ -29,7 +29,7 @@ With Azion, you can customize the time the cache remains in the edge through *ti
 
 ## Cache keys
 
-A cache key is an index entry for an object in Azion's edge nodes. When a first request is made to an edge application, the edge requests the objects within the request to the origin server. This generates a cache for each object at the edge. When the next request for the same resource is made to the edge application, if the resource requested matches one already found through the cache key, the request won't be forwarded to the origin.
+A cache key is an index entry for an object in Azion's edge nodes. When a request is made to an edge application for the first time, the edge forwards the request to the origin server and generates a cache for each object received at the edge. When the next request for the same resource is made to the edge application, if the resource requested matches one already found through the cache key, the request won't be forwarded to the origin.
 
 You can obtain the cache key of an application's resource through a `HEAD` request for the content URI and add the Azion debug header `Pragma: azion-debug-cache`:
 
@@ -52,7 +52,6 @@ Find out more about how to obtain other cache data in the guide [How to verify a
 
 The default cache key format adopted by Azion concatenates the following URI syntax elements:
 
-- Method (for complex requests)
 - Scheme of the request
 - Host
 - Path to the resource
@@ -60,9 +59,11 @@ The default cache key format adopted by Azion concatenates the following URI syn
 
 An object with the URI `https://static.yourdomain.com/page/site.js` should generate the cache key `httpsstatic.yourdomain.com/page/site.js`.
 
-If the resource is obtained using a complex request (any method different than `GET` or `HEAD`), the method is added to the cache key. For example, for an `OPTIONS` request to `https://static.yourdomain.com/page`, the cache key generated for the object will be `optionshttpsstatic.yourdomain.com/page`.
+Some cache keys may also change depending on the following variations generated at the edge.
 
-Some cache keys may also append the separator `@@` when variations are generated at the edge. See the 
+#### Complex requests
+
+If the resource is obtained using a complex request (any method different than `GET` or `HEAD`), the method is added to the cache key. For example, for an `OPTIONS` request to `https://static.yourdomain.com/page`, the cache key generated for the object will be `optionshttpsstatic.yourdomain.com/page`.
 
 #### Image Processor
 

--- a/src/content/docs/en/pages/main-menu/reference/build/edge-application/edge-caching.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/build/edge-application/edge-caching.mdx
@@ -63,11 +63,15 @@ Some cache keys may also change depending on variations generated at the edge. I
 
 #### Complex requests
 
-If the resource is obtained using a complex request (any method different than `GET` or `HEAD`), the method is added to the cache key. For example, for an `OPTIONS` request, the cache key generated for an object would be `optionshttpsstatic.yourdomain.com/page`.
+If the resource is obtained using a complex request (any method different than `GET` or `HEAD`), the method is added to the start of the cache key.
+
+For example, for an `OPTIONS` request, the cache key generated for an object would be `optionshttpsstatic.yourdomain.com/page`.
 
 #### Image Processor
 
-When [Image Processor](/en/documentation/products/edge-application/image-processor/) is activated and an image is resized and converted into `webp` format, the cache key generated will be `httpsstatic.yourdomain.com/static/images/image_1.jpg?ims=880x@@webp`.
+When [Image Processor](/en/documentation/products/edge-application/image-processor/) is activated, each `ims` query element is separated by the separator.
+
+For example, for an image that is resized and converted into `webp` format, the cache key generated will be `httpsstatic.yourdomain.com/static/images/image_1.jpg?ims=880x@@webp`.
 
 #### Device Groups
 

--- a/src/content/docs/en/pages/main-menu/reference/build/edge-application/edge-caching.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/build/edge-application/edge-caching.mdx
@@ -38,14 +38,14 @@ curl --location --head 'https://yourdomain.com/resource-path/image.jpeg' \
 --header 'Pragma: azion-debug-cache'
 ```
 
-The response will return an `X-Cache-Key` header with the cache key value, which based on the example above, would be:
+A successful response will return an `X-Cache-Key` header with the cache key value, which based on the example above, would be:
 
 ```
 X-Cache-Key: httpsyourdomain.com/resource-path/image.jpeg@@
 ```
 
 :::note
-Find out more about how to obtain other cache data in the guide [How to verify application cache indicators using Modheader for Google Chrome](/en/documentation/products/guides/check-page-cache-time/).
+Find out more about how to obtain other cache data in the [How to verify application cache indicators using Modheader for Google Chrome](/en/documentation/products/guides/check-page-cache-time/) guide.
 :::
 
 ### Cache key format

--- a/src/content/docs/en/pages/main-menu/reference/build/edge-application/edge-caching.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/build/edge-application/edge-caching.mdx
@@ -31,7 +31,7 @@ With Azion, you can customize the time the cache remains in the edge through *ti
 
 A cache key is an index entry for an object in Azion's edge nodes. When a request is made to an edge application for the first time, the edge forwards the request to the origin server and generates a cache for each object received at the edge. When the next request for the same resource is made to the edge application, if the resource requested matches one already found through the cache key, the request won't be forwarded to the origin.
 
-You can obtain the cache key of an application's resource through a `HEAD` request for the content URI and add the Azion debug header `Pragma: azion-debug-cache`:
+You can obtain the cache key of an application's resource through a request for the content URI and add the Azion debug header `Pragma: azion-debug-cache`:
 
 ```bash
 curl --location --head 'https://yourdomain.com/resource-path/image.jpeg' \

--- a/src/content/docs/en/pages/main-menu/reference/build/edge-application/edge-caching.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/build/edge-application/edge-caching.mdx
@@ -63,7 +63,7 @@ Some cache keys may also change depending on the following variations generated 
 
 #### Complex requests
 
-If the resource is obtained using a complex request (any method different than `GET` or `HEAD`), the method is added to the cache key. For example, for an `OPTIONS` request to `https://static.yourdomain.com/page`, the cache key generated for the object will be `optionshttpsstatic.yourdomain.com/page`.
+If the resource is obtained using a complex request (any method different than `GET` or `HEAD`), the method is added to the cache key. For example, for an `OPTIONS` request, the cache key generated for an object would be `optionshttpsstatic.yourdomain.com/page`.
 
 #### Image Processor
 
@@ -77,12 +77,18 @@ If there's an object variation per [device group](/en/documentation/products/edg
 
 When the [Advanced Cache Key](/en/documentation/products/edge-application/application-acceleration/#advanced-cache-key) feature is configured, the formation of cache keys is also affected. 
 
-**Cache by Cookie** generates a cache key variation with the determined cookie names and values followed by `;`. For example, content variation based on the `user` cookie would generate the following cache keys:
+**Cache by Cookie** generates a cache key variation with the determined cookie names and values followed by `;`. For example, content variation based on the `user` cookie could generate the following cache keys:
 
 - `httpwww.yourdomain.com/@@;`
 - `httpwww.yourdomain.com/@@user=user;`
 
-**Cache by Query String** generates a cache key variation with the query separator and the determined arguments based on the order of the query string submitted in the request; for example, `httpstatic.yourdomain.com/page?id=1000&name=name`. If **Query string sort** is enabled, the URIs with the query strings `?name=name&city=city` and `?city=city&name=name` will be grouped under the same cache key, ordered alphabetically.
+**Cache by Query String** generates cache keys with the query separator and the determined arguments based on the order of the query strings submitted in the request. For example, content variation based on `name` and `city` could generate the following cache keys:
+
+- `httpstatic.yourdomain.com/page?name=name`
+- `httpstatic.yourdomain.com/page?city=city&name=name`
+- `httpstatic.yourdomain.com/page?name=name&city=city`
+
+For multiple query strings, if **Query string sort** is enabled, the query strings will be grouped under the same cache key, ordered alphabetically.
 
 #### File slicing
 

--- a/src/content/docs/en/pages/main-menu/reference/build/edge-application/edge-caching.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/build/edge-application/edge-caching.mdx
@@ -59,7 +59,7 @@ The default cache key format adopted by Azion concatenates the following URI syn
 
 An object with the URI `https://static.yourdomain.com/page/site.js` should generate the cache key `httpsstatic.yourdomain.com/page/site.js`.
 
-Some cache keys may also change depending on the following variations generated at the edge.
+Some cache keys may also change depending on variations generated at the edge. If variations are enabled, the cache key may contain the `@@` separator at the end, resulting in `httpsstatic.seudominio.com/pagina/site.js@@`.
 
 #### Complex requests
 

--- a/src/content/docs/en/pages/main-menu/reference/build/edge-application/real-time-purge.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/build/edge-application/real-time-purge.mdx
@@ -127,9 +127,9 @@ You can't purge from the **L2 Caching** layer using a wildcard expression.
 You can purge objects with content variation based on cookies or query strings using the **Advanced Cache Key** feature from the [Application Acceleration](/en/documentation/products/edge-application/application-acceleration/) module. 
 
 
-To remove objects with cookie-based variation, you can use a purge by cache key, entering all variations individually, or a purge by wildcard, using `@@*` at the end.
+To remove objects with [cookie-based variation](/en/documentation/products/edge-application/edge-caching/#advanced-cache-key), you can use a purge by cache key, entering all variations individually, or a purge by wildcard, using `@@*` at the end.
 
-To purge objects with variation based on query string, you can use: 
+To purge objects with [variation based on query string](/en/documentation/products/edge-application/edge-caching/#advanced-cache-key), you can use: 
 
 1. A cache key purge, entering all the variations individually.
 2. A wildcard purge, using `?*` at the end.

--- a/src/content/docs/en/pages/main-menu/reference/build/edge-application/real-time-purge.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/build/edge-application/real-time-purge.mdx
@@ -83,9 +83,7 @@ For example:
 
 ## Cache key purge
 
-Purges cached objects by passing a list of cache keys as an argument. 
-
-A cache key is an index entry for an object in Azion's cache. The default cache key format adopted by Azion concatenates the URI syntax elements `scheme`, `host`, and `path` to identify objects. This means that an object with the URI `https://static.yourdomain.com/include/site.js` will generate the cache key `httpsstatic.yourdomain.com/include/site.js`.
+Purges cached objects by passing a list of [cache keys](/en/documentation/products/edge-application/edge-caching/#cache-keys) as an argument. 
 
 You can specify an advanced cache key to identify different variations of an object, based on:
 
@@ -93,49 +91,7 @@ You can specify an advanced cache key to identify different variations of an obj
 - Cookies when using [Advanced Cache Key](/en/documentation/products/edge-application/cache-settings/#advanced-cache-key).
 - Image format according to browser support when using [Image Processor](/en/documentation/products/edge-application/image-processor/).
 
-To obtain the cache key of an application's resource, you must make a `HEAD` request for the content URI and add the Azion debug header `Pragma: azion-debug-cache`, for example:
-
-```bash
-curl --location --head 'https://yourdomain.com/resource-path/image.jpeg' \
---header 'Pragma: azion-debug-cache'
-```
-
-The response will return an `X-Cache-Key` header with the cache key value, which based on the example above, would be:
-
-```
-X-Cache-Key: httpsyourdomain.com/resource-path/image.jpeg@@
-```
-
-:::tip
-You can also use the [Modheader extension](/en/documentation/products/guides/check-page-cache-time/) for Google Chrome to debug Azion cache indicators from your browser.
-:::
-
-Each object variation is represented by a distinct cache key and is expired individually. 
-
-### Cache key purge arguments
-
-Aside from `schema`, `host`, and `path`, the cache key may include the separator `@@`. For example:
-
-For example:
-
-- `httpwww.yourdomain.com/@@`
-- `httpwww.yourdomain.com/@@Mobile`
-- `httpstatic.yourdomain.com/include/site.css`
-- `httpsstatic.yourdomain.com/include/site.js`
-- `httpsstatic.yourdomain.com/static/images/image_1.jpg?ims=880x@@`
-- `httpsstatic.yourdomain.com/static/images/image_1.jpg?ims=880x@@webp`
-
-:::note
-If there's an object variation per [device group](/en/documentation/products/edge-application/device-groups/), for instance, each URL in each group will have a distinct cache key with the separator `@@` and the device group name. To purge all variations, you must search for the cache key individually for each group.
-:::
-
-### Custom cache key configurations
-
-If you have defined a custom cache key without using **Advanced Cache Key**, you must use the cache key purge to delete the cache of your objects. In addition to `schema`, `host`, and `path`, the cache key may include the `@@` separator followed by custom arguments. For example:
-
-- `httpsdynamic.yourdomain.com/path@@custom_arguments`
-
-You need to refer to the custom format of your cache key to run the cache key purge.
+To purge all variations, you must search for the cache keys individually.
 
 ---
 
@@ -170,20 +126,8 @@ You can't purge from the **L2 Caching** layer using a wildcard expression.
 
 You can purge objects with content variation based on cookies or query strings using the **Advanced Cache Key** feature from the [Application Acceleration](/en/documentation/products/edge-application/application-acceleration/) module. 
 
-In addition to `host` and `path`, the cache key must include the separator `@@` followed by the name of the cookies used and their values. This type of cache key ends in `;`.
 
 To remove objects with cookie-based variation, you can use a purge by cache key, entering all variations individually, or a purge by wildcard, using `@@*` at the end.
-
-For example, for the same URL `http://www.yourdomain.com/`, using content variation based on the `user` cookie, the cache keys could be:
-
-- `httpwww.yourdomain.com/@@;`
-- `httpwww.yourdomain.com/@@user=user1;`
-- `httpwww.yourdomain.com/@@user=user2;`
-
-When using query string based content variation, in addition to the `host` and `path`, the cache key must include the `?` separator and the query string arguments used. For example:
-
-- `httpsdynamic.yourdomain.com/product.py?id=1000`
-- `httpsdynamic.yourdomain.com/product.py?id=1001`
 
 To purge objects with variation based on query string, you can use: 
 
@@ -191,7 +135,7 @@ To purge objects with variation based on query string, you can use:
 2. A wildcard purge, using `?*` at the end.
 3. A URL purge, entering only the arguments used in the cache key in the URL.
 
-If you use **Query String Sort**, the arguments must be sent in the correct order.
+If you use **Query String Sort**, the arguments must be sent in alphabetical order.
 
 ---
 
@@ -214,11 +158,6 @@ You can use a cache key purge, entering all variations individually, or a wildca
 
 If you use the [Slice](/en/documentation/products/edge-application/cache-settings/#slice-settings) feature in your application, large files might still remain in cache.
 
-For sliced objects, in addition to `host` and `path`, the cache key must include the `@@bytes=` separator for each slice of content. Cache keys using optimization for delivering large files have the following format:
-
-- `httpstatic.yourdomain.com/media/file.mp4@@bytes=0-1048575`
-- `httpstatic.yourdomain.com/media/file.mp4@@bytes=1048576-2097151`
-
 :::caution
 When purging individual slices, your content might be liable to issues in case there is a change of content at the origin and outdated slices remain in cache.
 :::
@@ -231,10 +170,7 @@ To purge all file slices using this optimization, you can use a [wildcard](#wild
 
 ## HTTP method purge
 
-By default, Azion allows caching of `GET` and `HEAD` methods only. You can enable `POST` or `OPTIONS` caching with the [Application Acceleration](/en/documentation/products/edge-application/application-acceleration/#support-for-http-methods) module. In addition to `host` and `path`, the cache key must include the `@@` separator followed by the MD5 hash of the request body (`POST` arguments). For example:
-
-- `httpsdynamic.yourdomain.com/path@@md5_of_post_arguments`
-- `httpsdynamic.yourdomain.com/path@@md5_of_options_arguments`
+By default, Azion allows caching of `GET` and `HEAD` methods only. You can enable `POST` or `OPTIONS` caching with the [Application Acceleration](/en/documentation/products/edge-application/application-acceleration/#support-for-http-methods) module.
 
 To purge these objects, you can either use a [cache key purge](#cache-key-purge), entering all variations individually or a [wildcard purge](#wildcard-purge), using `@@*` at the end.
 

--- a/src/content/docs/en/pages/main-menu/reference/build/edge-application/real-time-purge.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/build/edge-application/real-time-purge.mdx
@@ -156,7 +156,7 @@ You can use a cache key purge, entering all variations individually, or a wildca
 
 ## Sliced files purge
 
-If you use the [Slice](/en/documentation/products/edge-application/cache-settings/#slice-settings) feature in your application, large files might still remain in cache.
+If you use the [Slice](/en/documentation/products/edge-application/cache-settings/#slice-settings) feature in your application, large files might still remain in cache. To perform a purge in this case, you must list the cache keys for each slice individually.
 
 :::caution
 When purging individual slices, your content might be liable to issues in case there is a change of content at the origin and outdated slices remain in cache.

--- a/src/content/docs/pt-br/pages/menu-principal/referencia/secure/edge-firewall/edge-firewall.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/referencia/secure/edge-firewall/edge-firewall.mdx
@@ -41,9 +41,6 @@ Você pode compartilhar o mesmo conjunto de regras entre todas suas aplicações
 
 Um Rule Set de Edge Firewall consiste em um nome de identificação, uma lista de domínios que essas configurações de segurança devem ser aplicadas, quais são os módulos aplicados e quais são as regras de segurança configuradas na aba **Rules Engine**.
 
-<Button href="/pt-br/documentacao/produtos/edge-firewall/rules-engine/" text="saiba mais sobre Rules Engine" variant="secondary"> 
-</Button>
-
 Veja todos os módulos de Edge Firewall disponíveis:
 
 - DDoS Protection.
@@ -55,11 +52,15 @@ Veja todos os módulos de Edge Firewall disponíveis:
 Você precisa ativar pelo menos um módulo para que seu Rule Set funcione.
 :::
 
+### Rules Engine para Edge Firewall
+
 Depois de ativar os módulos desejados, você deve configurar suas regras de segurança na aba Rules Engine. As regras que você configurar serão executadas sequencialmente até que a requisição seja bloqueada, ou até que todas as suas regras sejam processadas, autorizando a requisição.
 
 Um requisição só chega a sua aplicação caso nenhuma regra configurada a bloqueie ou a rejeite. Isso garante que requisições mal intencionadas não cheguem à origem/servidor da sua aplicação.
 
 Cada Rule Set é composta de *Criteria* (condicionais) e *Behaviors* (comandos). Se as *Criteria* (condições) forem atendidas, os *Behaviors* (comandos) serão executados. Por exemplo, você pode configurar regras para bloquear requisições provenientes de IPs que estão em uma *lista de bloqueio* ou até mesmo criar regras para excluir IPs que estejam na lista de regras permitidas. Neste exemplo, “block” é o Behavior, enquanto o IP da requisição, que está na *lista de bloqueio* e não está presente nas *regras permitidas*, é a condição (Criteria).
+
+<Button href="/pt-br/documentacao/produtos/edge-firewall/rules-engine/" text="saiba mais sobre rules engine" variant="secondary"></Button>
 
 A disponibilidade de Criteria e Behaviors no Edge Firewall depende dos módulos ativados durante a configuração principal de um Rule Set. Veja a lista de Criteria e Behaviors disponíveis para cada módulo do Edge Firewall:
 


### PR DESCRIPTION
<!--
Thank you for contributing to Azion Docs! Please fill out the information below.
Don't forget to add the Jira issue code to the title of this PR or the GitHub issue hash.
For example: 
- [EDU-3000] Modify origins page to include load balancer
- [#34] Add new edge application CLI commands
- [HOTFIX] Fix broken link in Orch doc
-->

### Related issue: [EDU-2448] 

### Changes

- Removed cache key format information from RTP
- Added cache key section to edge caching page

<!-- List and describe the major changes that this PR will implement.

For example:
- Added note about GraphQL debugging methods
- Removed section on account permissions
- Reworded Network Lists section
- Fixed broken links -->

### Additional links

<!-- You may add any links you believe relevant here, like message threads, external documentation, other issues, etc. -->


[EDU-3000]: https://aziontech.atlassian.net/browse/EDU-3000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EDU-2448]: https://aziontech.atlassian.net/browse/EDU-2448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ