### PR TITLE
[EDU-3227] fix: update link youtube pt

### DIFF
--- a/src/content/docs/pt-br/pages/devtools/api-graphql/primeiros-passos/primeiros-passo-gql.mdx
+++ b/src/content/docs/pt-br/pages/devtools/api-graphql/primeiros-passos/primeiros-passo-gql.mdx
@@ -46,7 +46,7 @@ Após fazer login no **RTM**, acesse `https://manager.azion.com/metrics/graphql`
 Assista um tutorial sobre os primeiros passos da GraphQL no canal do YouTube da Azion, com opção de ativar legendas em português:
 
 <iframe
-   src="https://www.youtube.com/embed/tVyRGO-n_rI"
+   src="https://www.youtube.com/embed/MMBYchMS5MM"
    loading="lazy"
    width="600"
    height="400"


### PR DESCRIPTION
Related issue:
[EDU-3227] Fix broken youtube link PT doc GraphQL


Changes:

- Update link to youtube video on PT doc GraphQL


[EDU-3227]: https://aziontech.atlassian.net/browse/EDU-3227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ