### PR TITLE
[EDU-3281] refactor: remove preview tag metrics

### DIFF
--- a/src/content/docs/en/pages/main-menu/reference/observe/real-time-metrics/real-time-metrics.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/observe/real-time-metrics/real-time-metrics.mdx
@@ -9,10 +9,6 @@ permalink: /documentation/products/real-time-metrics/
 import Badge from '~/components/Badge.astro';
 import Button from '~/components/Button.astro'
 
-<Badge variant="accent">
-Preview
-</Badge>
-
 **Real-Time Metrics** is an [Observe](/en/documentation/products/observe/) product that provides you with real-time access to metrics, through charts, so you can analyze the events of your applications and products configured on Azion. It also helps you optimize the use of Azion products and how your content is delivered.
 
 By analyzing data through Real-Time Metrics, you can check and track the behavior of your applications in near real time. Real-Time Metrics gives you the opportunity to:

--- a/src/content/docs/pt-br/pages/menu-principal/referencia/observe/real-time-metrics/real-time-metrics.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/referencia/observe/real-time-metrics/real-time-metrics.mdx
@@ -9,10 +9,6 @@ permalink: /documentacao/produtos/real-time-metrics/
 import Badge from '~/components/Badge.astro';
 import Button from '~/components/Button.astro'
 
-<Badge variant="accent">
-Preview
-</Badge>
-
 **Real-Time Metrics** é um produto de [Observe](/pt-br/documentacao/produtos/observe/) que fornece acesso a métricas em tempo real, através de gráficos, para que você analise os eventos de suas aplicações e produtos configurados na Azion. Ele também ajuda a otimizar seu uso dos produtos da Azion e como o seu conteúdo é entregue.
 
 Ao analisar dados com o Real-Time Metrics, você consegue verificar e acompanhar o comportamento de suas aplicações o mais próximo possível do tempo real. O Real-Time Metrics permite que você:


### PR DESCRIPTION

### Related issue: [EDU-3281]

### Changes

* Removed `Preview` tag from Real-Time Metrics reference as it's now in GA.


[EDU-3281]: https://aziontech.atlassian.net/browse/EDU-3281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ