### PR TITLE
refactor: replace link from github to azion docs

### DIFF
--- a/src/content/docs/en/pages/devtools/azion-edge-runtime/compatibility/frameworks.mdx
+++ b/src/content/docs/en/pages/devtools/azion-edge-runtime/compatibility/frameworks.mdx
@@ -58,7 +58,7 @@ For Next.js compute mode, Azion supports:
 - [Dynamic route](https://nextjs.org/docs/pages/building-your-application/routing/dynamic-routes)
 - [Web APIs](/en/documentation/products/edge-application/edge-functions/runtime-apis/javascript/) 
 - [Node's async_hooks](https://nodejs.org/api/async_hooks.html): [AsyncLocalStorage](https://nodejs.org/api/async_context.html#class-asynclocalstorage) and [AsyncResource](https://nodejs.org/api/async_hooks.html#class-asyncresource) are implemented.
-- MemoryFS through Vulcan's [Vulcan.config.js](https://github.com/aziontech/vulcan#vulcanconfigjs) file
+- MemoryFS through Vulcan's [Vulcan.config.js](/en/documentation/devtools/vulcan/config/) file
 - Nested route
 - Static page
 - SSR page

--- a/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/compatibilidade/frameworks.mdx
+++ b/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/compatibilidade/frameworks.mdx
@@ -56,7 +56,7 @@ Para o modo `compute` do Next.js, a Azion oferece suporte para:
 - [Dynamic route](https://nextjs.org/docs/pages/building-your-application/routing/dynamic-routes)
 - [Web APIs](/pt-br/documentacao/produtos/edge-application/edge-functions/runtime-apis/javascript/) 
 - [Node async_hooks](https://nodejs.org/api/async_hooks.html): [AsyncLocalStorage](https://nodejs.org/api/async_context.html#class-asynclocalstorage) e [AsyncResource](https://nodejs.org/api/async_hooks.html#class-asyncresource) são suportadas.
-- MemoryFS através do arquivo [Vulcan.config.js](https://github.com/aziontech/vulcan#vulcanconfigjs) do Vulcan
+- MemoryFS através do arquivo [Vulcan.config.js](/pt-br/documentacao/devtools/vulcan/config/) do Vulcan
 - Nested route
 - Static page
 - SSR page


### PR DESCRIPTION
Related issue:
[EDU-3549 ](https://aziontech.atlassian.net/browse/EDU-3549)

Changes

- Replace link to Vulcan.config.js file from GitHub to azion docs
