### PR TITLE
[EDU-3650]refactor: remove initiator type from guides

### DIFF
--- a/src/content/docs/en/pages/guides/edge-functions-firewall/index.mdx
+++ b/src/content/docs/en/pages/guides/edge-functions-firewall/index.mdx
@@ -40,7 +40,7 @@ Now, your edge function can be used on an edge firewall configuration.
 
 After creating an edge function, you need to configure the edge firewall to use it.
 
-### 2.1 Creating a Rules Set
+### 2.1 Creating a rule set
 
 1. On [Real-Time Manager RTM](https://manager.azion.com/), on the upper-left corner, select **Edge Firewall** in the **Secure** section.
 2. Click on **Add a Rule Set**.

--- a/src/content/docs/en/pages/guides/edge-functions-firewall/index.mdx
+++ b/src/content/docs/en/pages/guides/edge-functions-firewall/index.mdx
@@ -11,7 +11,7 @@ permalink: /documentation/products/guides/edge-functions/firewall/
 
 To use functions in your Edge Firewall, you have to go through two steps:
 
-- Create an edge function with the *Initiator Type* set as Edge Firewall.
+- Create an edge function.
 - Configure the behaviors on the Edge Firewall page.
 
 ---
@@ -30,8 +30,7 @@ To use functions in your Edge Firewall, you have to go through two steps:
     });
     ```
 
-5. Once you've placed the source code inside the code block, set the `Initiator Type` to `Edge Firewall`.
-6. Save it.
+5. Save it.
 
 Now, your edge function can be used on an edge firewall configuration.
 
@@ -39,7 +38,7 @@ Now, your edge function can be used on an edge firewall configuration.
 
 ## Configuring your edge function on the Edge Firewall 
 
-After creating an edge function with the `Initiator type` set as Edge Firewall, you need to configure the edge firewall to use it.
+After creating an edge function, you need to configure the edge firewall to use it.
 
 ### 2.1 Creating a Rules Set
 

--- a/src/content/docs/pt-br/pages/guias/edge-functions-firewall/index.mdx
+++ b/src/content/docs/pt-br/pages/guias/edge-functions-firewall/index.mdx
@@ -11,7 +11,7 @@ permalink: /documentacao/produtos/guias/edge-functions/firewall/
 
 Para usar functions no seu Edge Firewall, você deve seguir dois passos: 
 
-- Criar uma edge function com o *Initiator type* definido como Edge Firewall.
+- Criar uma edge function.
 - Configurar os *behaviors* na página do Edge Firewall.
 
 ---
@@ -30,8 +30,7 @@ Para usar functions no seu Edge Firewall, você deve seguir dois passos:
     ```
 
 
-5. Após definir o código da função e o colocar dentro do *codeblock*, defina o `Initiator Type` para `Edge Firewall`.
-6. Salve a função.
+5. Salve a função.
 
 Agora, sua edge function pode ser usada em configurações do edge firewall.
 
@@ -39,7 +38,7 @@ Agora, sua edge function pode ser usada em configurações do edge firewall.
 
 ## Configurando uma edge function no Edge Firewall
 
-Depois de criar uma edge function com o `Initiator type` definido como Edge Firewall, você precisa configurar o firewall para implementá-la.
+Depois de criar uma edge function, você precisa configurar o firewall para implementá-la.
 
 ### Criando um Rules Set
 

--- a/src/content/docs/pt-br/pages/guias/edge-functions-firewall/index.mdx
+++ b/src/content/docs/pt-br/pages/guias/edge-functions-firewall/index.mdx
@@ -40,7 +40,7 @@ Agora, sua edge function pode ser usada em configurações do edge firewall.
 
 Depois de criar uma edge function, você precisa configurar o firewall para implementá-la.
 
-### Criando um Rules Set
+### Criando um rule set
 
 1. No [Real-Time Manager RTM](https://manager.azion.com/), no canto superior esquerdo, selecione **Edge Firewall** na seção **Secure**.
 2. Clique em **Add a Rule Set**.


### PR DESCRIPTION
Related issue: 
[EDU-3650](https://aziontech.atlassian.net/browse/EDU-3650)

Changes

- Remove mentions to initiator type (edge functions)

[EDU-3650]: https://aziontech.atlassian.net/browse/EDU-3650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ