### PR TITLE
fix-update-badge

### DIFF
--- a/src/content/docs/en/pages/main-menu/reference/build/edge-application/main-settings.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/build/edge-application/main-settings.mdx
@@ -23,10 +23,6 @@ If you choose to deliver your application through HTTP & HTTPS, you must associa
 
 ### HTTP/3 support
 
-<Badge variant="accent">
-Experimental
-</Badge>
-
 If you choose to deliver your application through **HTTP & HTTPS**, you can enable **HTTP/3 support**. Based on the QUIC protocol standard, HTTP/3 provides faster load times and lower latency when compared to previous versions.
 
 When you enable HTTP/3 support, your edge applications can utilize this protocol version in compatible browsers only through *HTTP port 80* and *HTTPS port 443*.

--- a/src/content/docs/pt-br/pages/menu-principal/referencia/build/edge-application/main-settings.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/referencia/build/edge-application/main-settings.mdx
@@ -24,10 +24,6 @@ Se você escolher entregar sua aplicação usando HTTP & HTTPS, você deve assoc
 
 ### Suporte a HTTP/3
 
-<Badge variant="accent">
-Experimental
-</Badge>
-
 Se você escolher entregar sua aplicação através de **HTTP & HTTPS**, você pode habilitar o **HTTP/3 support**. Baseado no protocolo QUIC, HTTP/3 proporciona menores tempos de carregamento e latência quando comparados a versões anteriores.
 
 Ao habilitar suporte a HTTP/3, suas edge applications podem utilizar essa versão do protocolo em navegadores compatíveis somente através da porta *80 em HTTP* e porta *443 em HTTPS*.


### PR DESCRIPTION
Changes
- fix: Removed the "Experimental" badge from the HTTP/3 support section in the "main-settings.mdx" file. This change reflects the fact that HTTP/3 support is no longer experimental and is now a GA feature.