### PR TITLE
[EDU-3692] feat: add let's encrypt txt record

### DIFF
--- a/src/content/docs/en/pages/secure-journey/edit-zone/add-records.mdx
+++ b/src/content/docs/en/pages/secure-journey/edit-zone/add-records.mdx
@@ -22,7 +22,7 @@ After defining your [intelligent DNS main settings](/en/documentation/products/g
 5. In **Name**, provide the new record's name. Depending on the [type of record](/en/documentation/products/intelligent-dns/#type) you want to use, there may exist specific formats and recommendations. For example: for a CNAME record, you can use the name `www`.
 6. In **Type**, select the type of record you want to add. Accepts the types `A`, `AAAA`, `ANAME`, `CAA`, `CNAME`, `DS`, `MX`, `NS`, `PTR`, `SRV`, and `TXT`.
 7. In **Value**, add the items for the DNS response to the registered record. The accepted values vary according to the [chosen type of record](/en/documentation/products/intelligent-dns/#type).
-8. In **TTL (seconds)**, choose the time, in seconds, a response can be cached for on a resolver server. Maximum value: `2147483647`.
+8. In **TTL (seconds)**, choose the time, in seconds, that a response can be cached on a resolver server. Maximum value: `2147483647`.
 9. In **Policy**, select between **Simple** or **Weighted**.
 10. If you select **Weighted** in **Policy**:
     - In **Weight**, specify the weight for each record. Accepts values from `0` to `255`.

--- a/src/content/docs/en/pages/secure-journey/edit-zone/add-records.mdx
+++ b/src/content/docs/en/pages/secure-journey/edit-zone/add-records.mdx
@@ -22,7 +22,7 @@ After defining your [intelligent DNS main settings](/en/documentation/products/g
 5. In **Name**, provide the new record's name. Depending on the [type of record](/en/documentation/products/intelligent-dns/#type) you want to use, there may exist specific formats and recommendations. For example: for a CNAME record, you can use the name `www`.
 6. In **Type**, select the type of record you want to add. Accepts the types `A`, `AAAA`, `ANAME`, `CAA`, `CNAME`, `DS`, `MX`, `NS`, `PTR`, `SRV`, and `TXT`.
 7. In **Value**, add the items for the DNS response to the registered record. The accepted values vary according to the [chosen type of record](/en/documentation/products/intelligent-dns/#type).
-8. In **TTl (seconds)**, choose the time, in seconds, a response can be cached for on a resolver server. Maximum value: `2147483647`.
+8. In **TTL (seconds)**, choose the time, in seconds, a response can be cached for on a resolver server. Maximum value: `2147483647`.
 9. In **Policy**, select between **Simple** or **Weighted**.
 10. If you select **Weighted** in **Policy**:
     - In **Weight**, specify the weight for each record. Accepts values from `0` to `255`.

--- a/src/content/docs/en/pages/secure-journey/intelligent-dns-advanced-configurations/add-lets-encrypt-txt-record.mdx
+++ b/src/content/docs/en/pages/secure-journey/intelligent-dns-advanced-configurations/add-lets-encrypt-txt-record.mdx
@@ -9,8 +9,10 @@ menu_namespace: secureMenu
 
 import Button from '~/components/Button.astro'
 
-:::caution[warning]
-This guide covers a scenario in which you have a Let's Encrypt™ certificate created in a platform *outside* Azion and want to associate it with an Intelligent DNS zone. If you've created a Let's Encrypt certificate directly on Azion, the process is automatic and you don't need to create a TXT record. Find out more in the [Let's Encrypt guide](/en/documentation/products/guides/how-to-generate-a-lets-encrypt-certificate/).
+:::note
+This guide covers a scenario in which you want to configure the DNS TXT record required for a Let's Encrypt™ certificate through DNS-01 Challenge validation.
+
+If you've chosen Azion's **Domain** feature to create a Let's Encrypt certificate directly from Real-Time Manager for a zone that is fully configured in Intelligent DNS, the entire process is automated, including the handling of the TXT record. Find out more in the [Let's Encrypt guide](/en/documentation/products/guides/how-to-generate-a-lets-encrypt-certificate/).
 :::
 
 While creating the Let’s Encrypt certificate over [DNS challenge](https://letsencrypt.org/docs/challenge-types/#dns-01-challenge) method, you have to add a specific TXT record to your DNS zone to ensure the certificate validation. If your [zone](/en/documentation/products/guides/secure/intelligent-dns-configure-main-settings/) is hosted in Intelligent DNS, follow the steps described next.

--- a/src/content/docs/en/pages/secure-journey/intelligent-dns-advanced-configurations/add-lets-encrypt-txt-record.mdx
+++ b/src/content/docs/en/pages/secure-journey/intelligent-dns-advanced-configurations/add-lets-encrypt-txt-record.mdx
@@ -1,0 +1,83 @@
+---
+title: How to add a TXT record to configure Let's Encrypt certificate
+description: After you create a Let’s Encrypt certificate in a platform other than Azion, but want to use it with a zone created in Intelligent DNS, you must also create TXT record to add the information.
+meta_tags: secure, intelligent dns, record, certificate, domain, let's encrypt
+namespace: docs_guides_secure_intelligent_dns_lets_encrypt_record
+permalink: /documentation/products/guides/secure/lets-encrypt-record/
+menu_namespace: secureMenu
+---
+
+import Button from '~/components/Button.astro'
+
+:::caution[warning]
+This guide covers a scenario in which you have a Let's Encrypt™ certificate created in a platform *outside* Azion and want to associate it to an Intelligent DNS zone. If you've created a Let's Encrypt certificate directly on Azion, the process is automatic and you don't need to create a TXT record. Find out more in the [Let's Encrypt guide](/en/documentation/products/guides/how-to-generate-a-lets-encrypt-certificate/).
+:::
+
+After you create a Let’s Encrypt certificate in a platform other than Azion, but want to use it with a [zone created in Intelligent DNS](/en/documentation/products/guides/secure/intelligent-dns-configure-main-settings/), you must also create **TXT record** in Intelligent DNS to add the information given by the Let’s Encrypt provider.
+
+---
+
+## Via RTM
+
+1. Follow the general steps described in the [How to add records](/en/documentation/products/guides/secure/add-records/) guide.
+2. In **Name**, provide the new record’s name in a string (text) format. Limited to 100 characters. Example: `lets-encrypt-challenge`.
+3. In the **Type** dropdown menu, select **TXT**.
+4. In **Value**, add a text with the ACME challenge provided by the Let's Encrypt provider and the value. For example: `Deploy a DNS TXT record under the name _acme-challenge.<YOUR_DOMAIN> with the following value: ekgH9kW242Vbt99P27agtr07I09iLsiZZx`.
+5. In **TTL (seconds)**, choose the time, in seconds, a response can be cached for on a resolver server. Maximum value: `2147483647`.
+6. Click the **Save** button.
+
+---
+
+## Via API
+
+1. Run the following `GET` request in your terminal, replacing `[TOKEN VALUE]` with your [personal token](/en/documentation/products/guides/personal-tokens/) to retrieve your `<hosted_zone_id>`:
+
+```bash
+curl --location 'https://api.azionapi.net/intelligent_dns' \
+--header 'Authorization: Token [TOKEN VALUE]' \
+--header 'Accept: application/json; version=3'
+```
+
+2. You'll receive a response with all your existing zones. Copy the value of the `<id>` that you want to use.
+3. Run the following `POST` request, replacing `[TOKEN VALUE]` with your [personal token](/en/documentation/products/guides/personal-tokens/) and the `<hosted_zone_id>` value you copied:
+
+```bash
+curl --location 'https://api.azionapi.net/intelligent_dns/<hosted_zone_id>/records' \
+--header 'Content-Type: application/json' \
+--header 'Authorization: Token [TOKEN VALUE]' \
+--header 'Accept: application/json; version=3' \
+--data-raw '{
+    "record_type": "TXT",
+    "entry": "lets-encrypt-challenge",
+    "answers_list": [
+        "Deploy a DNS TXT record under the name _acme-challenge.<YOUR_DOMAIN> with the following value: ekgH9kW242Vbt99P27agtr07I09iLsiZZx"
+    ],
+    "ttl": 20
+}'
+```
+
+4. You'll receive a response similar to this:
+
+```json
+{
+  "results": {
+    "answers_list": [
+      "Deploy a DNS TXT record under the name _acme-challenge.<YOUR_DOMAIN> with the following value: ekgH9kW242Vbt99P27agtr07I09iLsiZZx"
+    ],
+    "zone_id": 1234,
+    "record_type": "TXT",
+    "ttl": 20,
+    "policy": "simple",
+    "entry": "lets-encrypt-challenge",
+    "id": 56506,
+    "description": ""
+  },
+  "schema_version": 3
+}
+```
+
+Wait a few minutes for the changes to propagate and your records will be created in the hosted zone you chose.
+
+:::tip
+Check the [Azion API documentation](https://api.azion.com/) and the [OpenAPI specification](https://github.com/aziontech/azionapi-openapi/) to know more about what the Azion API can offer.
+:::

--- a/src/content/docs/en/pages/secure-journey/intelligent-dns-advanced-configurations/add-lets-encrypt-txt-record.mdx
+++ b/src/content/docs/en/pages/secure-journey/intelligent-dns-advanced-configurations/add-lets-encrypt-txt-record.mdx
@@ -13,7 +13,7 @@ import Button from '~/components/Button.astro'
 This guide covers a scenario in which you have a Let's Encrypt™ certificate created in a platform *outside* Azion and want to associate it with an Intelligent DNS zone. If you've created a Let's Encrypt certificate directly on Azion, the process is automatic and you don't need to create a TXT record. Find out more in the [Let's Encrypt guide](/en/documentation/products/guides/how-to-generate-a-lets-encrypt-certificate/).
 :::
 
-After you create a Let’s Encrypt certificate in a platform other than Azion, but want to use it with a [zone created in Intelligent DNS](/en/documentation/products/guides/secure/intelligent-dns-configure-main-settings/), you must also create **TXT record** in Intelligent DNS to add the information given by the Let’s Encrypt provider. This helps verify the domain's DNS is owned by those who requested the certificate.
+While creating the Let’s Encrypt certificate over [DNS challenge](https://letsencrypt.org/docs/challenge-types/#dns-01-challenge) method, you have to add a specific TXT record to your DNS zone to ensure the certificate validation. If your [zone](/en/documentation/products/guides/secure/intelligent-dns-configure-main-settings/) is hosted in Intelligent DNS, follow the steps described next.
 
 ---
 

--- a/src/content/docs/en/pages/secure-journey/intelligent-dns-advanced-configurations/add-lets-encrypt-txt-record.mdx
+++ b/src/content/docs/en/pages/secure-journey/intelligent-dns-advanced-configurations/add-lets-encrypt-txt-record.mdx
@@ -10,10 +10,10 @@ menu_namespace: secureMenu
 import Button from '~/components/Button.astro'
 
 :::caution[warning]
-This guide covers a scenario in which you have a Let's Encrypt™ certificate created in a platform *outside* Azion and want to associate it to an Intelligent DNS zone. If you've created a Let's Encrypt certificate directly on Azion, the process is automatic and you don't need to create a TXT record. Find out more in the [Let's Encrypt guide](/en/documentation/products/guides/how-to-generate-a-lets-encrypt-certificate/).
+This guide covers a scenario in which you have a Let's Encrypt™ certificate created in a platform *outside* Azion and want to associate it with an Intelligent DNS zone. If you've created a Let's Encrypt certificate directly on Azion, the process is automatic and you don't need to create a TXT record. Find out more in the [Let's Encrypt guide](/en/documentation/products/guides/how-to-generate-a-lets-encrypt-certificate/).
 :::
 
-After you create a Let’s Encrypt certificate in a platform other than Azion, but want to use it with a [zone created in Intelligent DNS](/en/documentation/products/guides/secure/intelligent-dns-configure-main-settings/), you must also create **TXT record** in Intelligent DNS to add the information given by the Let’s Encrypt provider.
+After you create a Let’s Encrypt certificate in a platform other than Azion, but want to use it with a [zone created in Intelligent DNS](/en/documentation/products/guides/secure/intelligent-dns-configure-main-settings/), you must also create **TXT record** in Intelligent DNS to add the information given by the Let’s Encrypt provider. This helps verify the domain's DNS is owned by those who requested the certificate.
 
 ---
 

--- a/src/content/docs/en/pages/secure-journey/intelligent-dns-advanced-configurations/add-lets-encrypt-txt-record.mdx
+++ b/src/content/docs/en/pages/secure-journey/intelligent-dns-advanced-configurations/add-lets-encrypt-txt-record.mdx
@@ -20,7 +20,7 @@ While creating the Let’s Encrypt certificate over [DNS challenge](https://lets
 ## Via RTM
 
 1. Follow the general steps described in the [How to add records](/en/documentation/products/guides/secure/add-records/) guide.
-2. In **Name**, provide the new record’s name in a string (text) format. Limited to 100 characters. Example: `lets-encrypt-challenge`.
+2. In **Name**, provide the new record’s name in a string (text) format. Limited to *100 characters*. Example: `lets-encrypt-challenge`.
 3. In the **Type** dropdown menu, select **TXT**.
 4. In **Value**, add a text with the ACME challenge provided by the Let's Encrypt provider and the value. For example: `Deploy a DNS TXT record under the name _acme-challenge.<YOUR_DOMAIN> with the following value: ekgH9kW242Vbt99P27agtr07I09iLsiZZx`.
 5. In **TTL (seconds)**, choose the time, in seconds, a response can be cached for on a resolver server. Maximum value: `2147483647`.

--- a/src/content/docs/en/pages/secure-journey/intelligent-dns-advanced-configurations/add-lets-encrypt-txt-record.mdx
+++ b/src/content/docs/en/pages/secure-journey/intelligent-dns-advanced-configurations/add-lets-encrypt-txt-record.mdx
@@ -1,6 +1,6 @@
 ---
 title: How to add a TXT record to configure Let's Encrypt certificate
-description: After you create a Let’s Encrypt certificate in a platform other than Azion, but want to use it with a zone created in Intelligent DNS, you must also create TXT record to add the information.
+description: When creating a Let's Encrypt certificate externally, such as using Let's Encrypt official tool Certbot, for a hostname that is hosted in Intelligent DNS, you must add the TXT record required for the DNS challenge.
 meta_tags: secure, intelligent dns, record, certificate, domain, let's encrypt
 namespace: docs_guides_secure_intelligent_dns_lets_encrypt_record
 permalink: /documentation/products/guides/secure/lets-encrypt-record/

--- a/src/content/docs/en/pages/secure-journey/intelligent-dns-advanced-configurations/add-lets-encrypt-txt-record.mdx
+++ b/src/content/docs/en/pages/secure-journey/intelligent-dns-advanced-configurations/add-lets-encrypt-txt-record.mdx
@@ -22,9 +22,9 @@ While creating the Let’s Encrypt certificate over [DNS challenge](https://lets
 ## Via RTM
 
 1. Follow the general steps described in the [How to add records](/en/documentation/products/guides/secure/add-records/) guide.
-2. In **Name**, provide the new record’s name in a string (text) format. Limited to *100 characters*. Example: `lets-encrypt-challenge`.
+2. In **Name**, provide the new record’s name required by the Let's Encrypt certification request, such as the Certbot tool, in a string format. Limited to *100 characters*. Example: `_acme-challenge.<YOUR_DOMAIN>`.
 3. In the **Type** dropdown menu, select **TXT**.
-4. In **Value**, add a text with the ACME challenge provided by the Let's Encrypt provider and the value. For example: `Deploy a DNS TXT record under the name _acme-challenge.<YOUR_DOMAIN> with the following value: ekgH9kW242Vbt99P27agtr07I09iLsiZZx`.
+4. In **Value**, input the value for the ACME challenge provided by the Let's Encrypt provider. Example: `ekgH9kW242Vbt99P27agtr07I09iLsiZZx`.
 5. In **TTL (seconds)**, choose the time, in seconds, a response can be cached for on a resolver server. Maximum value: `2147483647`.
 6. Click the **Save** button.
 
@@ -50,9 +50,9 @@ curl --location 'https://api.azionapi.net/intelligent_dns/<hosted_zone_id>/recor
 --header 'Accept: application/json; version=3' \
 --data-raw '{
     "record_type": "TXT",
-    "entry": "lets-encrypt-challenge",
+    "entry": "_acme-challenge.<YOUR_DOMAIN>",
     "answers_list": [
-        "Deploy a DNS TXT record under the name _acme-challenge.<YOUR_DOMAIN> with the following value: ekgH9kW242Vbt99P27agtr07I09iLsiZZx"
+        "ekgH9kW242Vbt99P27agtr07I09iLsiZZx"
     ],
     "ttl": 20
 }'
@@ -64,13 +64,13 @@ curl --location 'https://api.azionapi.net/intelligent_dns/<hosted_zone_id>/recor
 {
   "results": {
     "answers_list": [
-      "Deploy a DNS TXT record under the name _acme-challenge.<YOUR_DOMAIN> with the following value: ekgH9kW242Vbt99P27agtr07I09iLsiZZx"
+      "ekgH9kW242Vbt99P27agtr07I09iLsiZZx"
     ],
     "zone_id": 1234,
     "record_type": "TXT",
     "ttl": 20,
     "policy": "simple",
-    "entry": "lets-encrypt-challenge",
+    "entry": "_acme-challenge.<YOUR_DOMAIN>",
     "id": 56506,
     "description": ""
   },


### PR DESCRIPTION

### Related issue: [EDU-3692]

### Changes

* Added guide explaining how to add a TXT record in Intelligent DNS if you have a Let's Encrypt certificate generated from outside Azion.
* Fixed a letter in another guide.

[EDU-3692]: https://aziontech.atlassian.net/browse/EDU-3692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ