### PR TITLE
[EDU-4096] cli describe command (en + pt)

### DIFF
--- a/src/content/docs/en/pages/devtools/cli/azion-cli-alpha/create/create.mdx
+++ b/src/content/docs/en/pages/devtools/cli/azion-cli-alpha/create/create.mdx
@@ -483,4 +483,4 @@ The `--file` flag informs the file path to the file containing all attributes of
 
 #### help
 
-The `--help` option displays more information about the `create` subcommand.
+The `--help` option displays more information about the `azion create variables` command.

--- a/src/content/docs/en/pages/devtools/cli/azion-cli-alpha/describe/describe.mdx
+++ b/src/content/docs/en/pages/devtools/cli/azion-cli-alpha/describe/describe.mdx
@@ -1,0 +1,271 @@
+---
+title: Azion CLI describe
+description: Retrieve information about your edge applications, edge functions and other resources through Azion CLI.
+meta_tags: cli, edge, describe, development
+namespace: documentation_cli_describe
+menu_namespace: cliMenuAlpha
+permalink: /documentation/devtools/cli/describe/
+---
+
+With the `azion describe [resource]` command you can describe:
+
+- [Edge applications](#edge-applications).
+    - [Edge functions](#edge-functions). 
+    - [Rules engine](#rules-engine). 
+    - [Cache settings](#cache-settings).
+    - [Domains](#domains).
+    - [Origins](#origins). 
+    - [Variables](#variables).
+
+:::note 
+In case one or more required fields aren't informed through the specific flags, an interactive message prompts and asks for the missing information.
+:::
+
+---
+
+## Edge applications
+
+#### Usage
+
+```bash
+azion describe edge-application --application-id <application_id> [flags]
+```
+
+#### Required flags
+
+##### application-id
+
+The `--application-id` flag specifies the unique identifier of the edge application to display its attributes in detail.
+
+#### Optional flags
+
+##### format
+
+The `--format` flag changes the output format by passing the `json` value to the flag.
+
+##### help
+
+The `--help` flag displays more information about the describe command.
+
+##### id
+
+The `--id` flag specifies the unique identifier of the edge application.
+
+##### out
+
+The `--out` flag exports the output to the given `<file_path/file_name.ext>`.
+
+:::note
+Replace `<application_id>` in the `--application-id` flag with the actual ID of the edge application you want to describe.
+:::
+
+---
+
+## Edge functions
+
+#### Usage
+
+```bash
+$ azion describe edge-function --function-id <function_id> 
+```
+
+#### Required flags
+
+##### function-id
+
+The `--function-id` flag is the unique identifier of the edge function.
+
+#### Optional flags
+
+##### format
+
+The `--format` flag changes the output format. Options include `json` and other supported formats.
+
+##### out
+
+The `--out` flag exports the output to the given `<file_path/file_name.ext>`.
+
+##### with-code
+
+The `--with-code` flag displays the edge function's code; disabled by default.
+
+##### help
+
+The `--help` option displays more information about the `azion describe edge-function` command.
+
+---
+
+## Rules engine
+
+#### Usage
+
+```bash
+azion describe rules-engine --application-id <application-id> --rule-id <rule-id> --phase <phase> [--format <format>] [--out <output-file>]
+```
+
+#### Required flags
+
+##### application-id
+
+The `--application-id` flag specifies your edge application ID.
+
+##### rule-id
+
+The `--rule-id` flag specifies your Rules Engine's rule ID.
+
+##### phase
+
+The `--phase` flag specifies the phase of your Rules Engine's rule. It's either `request` or `response`. The default is `request`.
+
+#### Optional flags
+
+##### format
+
+The `--format` flag changes the output format, and you can use `json` as a value to specify JSON format.
+
+##### out
+
+The `--out` flag exports the output of the command to the given file path, including the file name and extension.
+
+##### help
+
+The `-h` or `--help` flag displays more information about the `azion describe rules-engine` command.
+
+---
+
+## Cache settings
+
+#### Usage
+
+```bash
+$ azion describe cache-setting --application-id 1673635839 --cache-setting-id 107313
+```
+
+#### Required flags
+
+##### application-id
+
+The `--application-id` flag sets the unique identifier for the edge application.
+
+##### cache-setting-id
+
+The `--cache-setting-id` flag sets the unique identifier for a Cache Settings configuration.
+
+#### Optional flags
+
+##### format
+
+The `--format` option changes the output format. Pass the value `json` to the flag to get the output in JSON format.
+
+##### help
+
+The `--help` option displays more information about the `azion describe cache-setting` command.
+
+##### out
+
+The `--out` option exports the output to the given file path or file name with an extension. Example: `--out "./tmp/test.json"`.
+
+---
+
+## Domains
+
+#### Description
+
+Displays information about the domain via a given ID to show the application's attributes in detail.
+
+#### Usage
+
+```bash
+azion describe domain --domain-id 4312
+```
+
+#### Required flags
+
+##### domain-id
+
+The `--domain-id` flag specifies the unique identifier of the domain you want to retrieve detailed information from.
+
+#### Optional flags
+
+##### format
+
+The `--format` option changes the output format. You can pass the value `json` to the flag to get the output in JSON format.
+
+##### out
+
+The `--out` option exports the output to the given file path and filename with the specified extension.
+
+##### help
+
+The `-h` or `--help` option displays more information about the `azion describe domain` command.
+
+#### Examples
+
+```bash
+azion describe domain --domain-id 1337 --out "./tmp/test.json"
+azion describe domain --domain-id 1337 --format json
+```
+
+---
+
+## Origins
+
+#### Usage
+
+```bash
+$ azion describe origin --application-id <application-id> --origin-key <origin-key> 
+```
+
+#### Required flags
+
+##### application-id
+
+The `--application-id` flag sets the unique identifier for an edge application. It's a mandatory field.
+
+##### origin-key
+
+The `--origin-key` flag sets the unique identifier for an origin. It's a mandatory field.
+
+#### Optional flags
+
+##### format
+
+The `--format` flag changes the output format. Pass the value `json` to the flag to get the output in JSON format.
+
+##### out
+
+The `--out` flag exports the output to the given file path or filename with extension.
+
+#### help
+
+The `-h` or `--help` option displays more information about the `azion describe origin` action.
+
+---
+
+## Variables
+
+#### Usage
+
+```bash
+  azion describe variables --variable-id 1673635839
+```
+
+#### Required flags
+
+##### variable-id
+
+The `--variable-id` flag gives the UUID for the variable being described.
+
+#### Optional flags
+
+##### out
+
+The `--out` option exports the output of the `describe` command to a given filepath.
+
+##### format
+
+The `--format` option, followed by the value `json`, changes the output format to JSON.
+
+##### help
+
+The `--help` option displays more information about the `azion describe variables` command.

--- a/src/content/docs/pt-br/pages/devtools/cli/azion-cli-alpha/create/create.mdx
+++ b/src/content/docs/pt-br/pages/devtools/cli/azion-cli-alpha/create/create.mdx
@@ -504,5 +504,5 @@ A opção `--file` informa o caminho do arquivo que contém todos os atributos d
 
 ##### help
 
-A opção `--help` exibe mais informações sobre o subcomando `create`.
+A opção `--help` exibe mais informações sobre o comando `azion create variables`.
 

--- a/src/content/docs/pt-br/pages/devtools/cli/azion-cli-alpha/describe/describe.mdx
+++ b/src/content/docs/pt-br/pages/devtools/cli/azion-cli-alpha/describe/describe.mdx
@@ -1,0 +1,231 @@
+---
+title: Azion CLI describe
+description: Acesse informações sobre suas edge applications, edge functions e outros recursos através da Azion CLI.
+meta_tags: cli, edge, describe, development
+namespace: documentation_cli_describe
+menu_namespace: cliMenuAlpha
+permalink: /documentacao/devtools/cli/describe/
+---
+
+Com o comando `azion describe [recurso]` você pode acessar informações de suas:
+
+- [Edge applications](#edge-applications).
+    - [Edge functions](#edge-functions). 
+    - [Rules engine](#rules-engine). 
+    - [Cache settings](#cache-settings).
+    - [Domains](#domains).
+    - [Origins](#origins). 
+    - [Variables](#variables).
+
+:::note
+No caso de um ou mais campos obrigatórios não serem informados através das flags específicas, uma mensagem interativa será exibida, solicitando essas informações.
+:::
+
+---
+
+## Edge applications
+
+### Uso
+
+```bash
+azion describe edge-application --application-id <application_id> [flags]
+```
+
+### Flags obrigatórias
+
+#### application-id
+
+A flag `--application-id` especifica o identificador exclusivo da edge application para exibir seus atributos em detalhes.
+
+### Flags opcionais
+
+#### format
+
+A flag `--format` altera o formato de saída passando o valor `json` para a flag.
+
+#### help
+
+A flag `--help` exibe mais informações sobre o comando de descrição.
+
+#### id
+
+A flag `--id` especifica o identificador exclusivo da edge application.
+
+#### out
+
+A flag `--out` exporta a saída para o caminho/arquivo fornecido `<file_path/file_name.ext>`.
+
+:::note
+Substitua `<application_id>` na flag `--application-id` pelo ID real da edge application que deseja descrever.
+:::
+
+---
+
+## Edge functions
+
+### Uso
+
+```bash
+azion describe edge-function --function-id <id_da_funcao>
+```
+
+### Flags obrigatórias
+
+#### function-id
+
+A flag `--function-id` é o identificador único da edge function.
+
+### Flags opcionais
+
+#### format
+
+A flag `--format` altera o formato de saída. As opções incluem `json` e outros formatos suportados.
+
+#### out
+
+A flag `--out` exporta a saída para o dado `<caminho_do_arquivo/nome_do_arquivo.ext>`.
+
+#### with-code
+
+A flag `--with-code` exibe o código da edge function; desativado por padrão.
+
+#### help
+
+A opção `--help` exibe mais informações sobre o comando `azion describe edge-function`.
+
+---
+
+## Rules engine
+
+### Uso
+
+```bash
+ azion describe rules-engine --application-id <application-id> --rule-id <rule-id> --phase <phase>
+```
+
+### Flags obrigatórias
+
+#### application-id
+
+A flag `--application-id` especifica o ID da sua edge application.
+
+#### rule-id
+
+A flag `--rule-id` especifica o ID da regra do Rules Engine.
+
+#### phase
+
+A flag `--phase` especifica a fase da regra do Rules Engine. Pode ser `request` ou `response`. O padrão é `request`.
+
+### Flags opcionais
+
+#### format
+
+A flag `--format` altera o formato de saída e você pode usar `json` como valor para especificar o formato JSON.
+
+#### out
+
+A flag `--out` exporta a saída do comando para o caminho do arquivo fornecido, incluindo o nome do arquivo e a extensão.
+
+#### help
+
+A flag `-h` ou `--help` exibe mais informações sobre o comando `azion describe rules-engine`.
+
+---
+
+## Cache settings
+
+### Uso
+
+```bash
+$ azion describe cache-setting --application-id 1673635839 --cache-setting-id 107313
+```
+
+### Flags obrigatórias
+
+#### application-id
+
+A flag `--application-id` define o identificador único para a edge application.
+
+#### cache-setting-id
+
+A flag `--cache-setting-id` define o identificador único para uma configuração de cache.
+
+### Flags opcionais
+
+#### format
+
+A opção `--format` altera o formato de saída. Passe o valor `json` para a opção para obter a saída em formato JSON.
+
+#### help
+
+A opção `--help` exibe mais informações sobre o comando `azion describe cache-setting`.
+
+#### out
+
+A opção `--out` exporta a saída para o caminho ou nome do arquivo fornecido com a extensão. Exemplo: `--out "./tmp/test.json"`.
+
+---
+
+## Origins
+
+### Uso
+
+```bash
+$ azion describe origin --application-id <application-id> --origin-key <origin-key>
+```
+
+### Flags obrigatórias
+
+#### application-id
+
+A flag `--application-id` define o identificador único para uma edge application.
+
+#### origin-key
+
+A flag `--origin-key` define o identificador único para uma origem.
+
+### Flags opcionais
+
+#### format
+
+A flag `--format` altera o formato de saída. Passe o valor `json` com a flag para obter a saída em formato JSON.
+
+#### out
+
+A flag `--out` exporta a saída para o caminho ou nome do arquivo fornecido com a extensão.
+
+### help
+
+A opção `-h` ou `--help` exibe mais informações sobre a ação `azion describe origin`.
+
+---
+
+## Variables
+
+### Uso
+
+```bash
+  azion describe variables --variable-id 1673635839
+```
+
+### Flags obrigatórias
+
+#### variable-id
+
+A flag `--variable-id` fornece o UUID da variável que está sendo descrita.
+
+### Flags opcionais
+
+#### out
+
+A opção `--out` exporta a saída do comando `describe` para um determinado caminho de arquivo.
+
+#### format
+
+A opção `--format` , seguida pelo valor `json`, altera o formato de saída para JSON.
+
+#### help
+
+A opção `--help` exibe mais informações sobre o comando `azion describe variables`.
+


### PR DESCRIPTION
Related issue:

[EDU-4096](https://aziontech.atlassian.net/browse/EDU-4096)

Changes:

Place all create commands inside a parent file for the describe command. Each resource had its own page. Now, the page will be based on the CRUDL command.

The content was not altered, only moved.

I avoided using ### because it was uncomfortable to the eye... nor nice.