### PR TITLE
[EDU-4097] add cli list command

### DIFF
--- a/src/content/docs/en/pages/devtools/cli/azion-cli-alpha/list/list.mdx
+++ b/src/content/docs/en/pages/devtools/cli/azion-cli-alpha/list/list.mdx
@@ -1,0 +1,296 @@
+---
+title: Azion CLI list
+description: List your edge applications, edge functions and other resources through Azion CLI.
+meta_tags: cli, edge, list, development
+namespace: documentation_cli_list
+menu_namespace: cliMenuAlpha
+permalink: /documentation/devtools/cli/list/
+---
+
+With the `azion list [resource]` command you can list your:
+
+- [Edge applications](#edge-applications).
+    - [Edge functions](#edge-functions). 
+    - [Rules engine](#rules-engine). 
+    - [Cache settings](#cache-settings).
+    - [Domains](#domains).
+    - [Origins](#origins). 
+    - [Variables](#variables).
+
+:::note 
+In case one or more required fields aren't informed through the specific flags, an interactive message prompts and asks for the missing information.
+:::
+
+---
+
+## Edge applications
+
+#### Usage
+
+```bash
+azion list edge-application [flags]
+```
+
+#### Optional flags
+
+##### details
+
+The `--details` flag displays all relevant fields when listing.
+
+##### page
+
+The `--page` option returns a page of the list according to its number. By default, it's `1`.
+
+##### page_size
+
+The `--page_size` option defines how many items should be returned per page. By default, it's `10`.
+
+##### help
+
+The `--help` option displays more information about the `azion list edge-application` action.
+
+---
+
+## Edge functions
+
+#### Usage
+
+```bash
+$ azion list edge-function 
+```
+
+#### Optional flags
+
+##### details
+
+The `--details` flag displays all relevant fields when listing.
+
+##### filter
+
+The `--filter` flag filters items by their name.
+
+##### order-by
+
+The `--order-by` flag sorts the output based on the selected field.
+
+##### page
+
+The `--page` flag returns a page of the list according to its number. Default is `1`.
+
+##### page-size
+
+The `--page-size` flag defines how many items should be returned per page. Default is `10`.
+
+##### sort
+
+The `--sort` flag defines the order of the items on the list. The value should be either `asc` or `desc`.
+
+##### help
+
+The `--help` option displays more information about the `azion list edge-function` command.
+
+---
+
+## Rules engine
+
+#### Usage
+
+```bash
+azion list rules-engine --application-id <application-id> --phase <phase>
+```
+
+#### Required flags
+
+##### application-id
+
+The `--application-id` flag specifies the unique identifier for the edge application that implements these rules.
+
+##### phase
+
+The `--phase` flag specifies the Rules Engine phase. It's either `request` or `response`.
+
+#### Optional flags
+
+##### details
+
+The `--details` flag displays all relevant fields when listing.
+
+##### filter
+
+The `--filter` flag filters items by their name.
+
+##### order-by
+
+The `--order-by` flag sorts the output based on the selected field.
+
+##### page
+
+The `--page` flag returns a specific page of the list according to its number. By default, it's `1`.
+
+##### page-size
+
+The `--page-size` flag defines how many items should be returned per page. By default, it's `10`.
+
+##### sort
+
+The `--sort` flag defines the order of the items on the list and can be set to either `asc` or `desc`.
+
+##### help
+
+The `-h` or `--help` flag displays more information about the `azion list rules-engine` command.
+
+---
+
+
+## Cache settings
+
+#### Usage
+
+```bash
+$ azion list cache-setting --application-id 16736354321
+```
+
+#### Optional flags
+
+##### application-id
+
+The `--application-id` flag sets the unique identifier for the edge application.
+
+##### details
+
+The `--details` flag displays all relevant fields when listing.
+
+##### filter
+
+The `--filter` option filters items by their name.
+
+##### help
+
+The `--help` option displays more information about the `azion list cache-setting` command.
+
+##### order-by
+
+The `--order-by` option sorts the output based on the selected field.
+
+##### page
+
+The `--page` option returns a page of the list according to its number. The default value is `1`.
+
+##### page-size
+
+The `--page-size` option defines how many items should be returned per page. The default value is `10`.
+
+##### sort
+
+The `--sort` option defines the order of the items on the list. The value should be either `asc` or `desc`.
+
+---
+
+
+## Domains
+
+#### Description
+
+Displays all your domains.
+
+#### Usage
+
+```bash
+azion list domain
+```
+
+#### Optional flags
+
+##### details
+
+The `--details` option displays all relevant fields when listing.
+
+##### filter
+
+The `--filter` option filters items by their name.
+
+##### order-by
+
+The `--order-by` option sorts the output based on the selected field.
+
+##### page
+
+The `--page` option returns a specific page of the list according to its number. The default is `1`.
+
+##### page-size
+
+The `--page-size` option defines how many items should be returned per page. The default is `10`.
+
+##### sort
+
+The `--sort` option defines the order of the items on the list. Options are `asc` or `desc`.
+
+##### help
+
+The `-h` or `--help` option displays more information about the `azion list domain` command.
+
+---
+
+## Origins
+
+#### Usage
+
+```bash
+$ azion list origin --application-id <application-id>
+```
+
+#### Required flags
+
+##### application-id
+
+The `--application-id` flag sets the unique identifier for the edge application. It's a required field.
+
+#### Optional flags
+
+##### details
+
+The `--details` flag displays all relevant fields when listing origin.
+
+##### filter
+
+The `--filter` flag filters items by their name.
+
+##### order-by
+
+The `--order-by` flag sorts the output based on the selected field.
+
+##### page
+
+The `--page` flag returns a specific page of the list according to its number. The default is `1`.
+
+##### page-size
+
+The `--page-size` flag defines how many items should be returned per page. The default is `10`.
+
+##### sort
+
+The `--sort` flag defines the order of the items on the list. The value should be either `asc` or `desc`.
+
+#### help
+
+The `-h` or `--help` option displays more information about the `azion list origin` action.
+
+---
+
+## Variables
+
+#### Usage
+
+```bash
+  azion list variables
+```
+
+#### Optional flags
+
+##### details
+
+The `--details` option displays all relevant fields when listing.
+
+##### help
+
+The `--help` option displays more information about the `list` subcommand.

--- a/src/content/docs/pt-br/pages/devtools/cli/azion-cli-alpha/list/list.mdx
+++ b/src/content/docs/pt-br/pages/devtools/cli/azion-cli-alpha/list/list.mdx
@@ -1,0 +1,292 @@
+---
+title: Azion CLI list
+description: Consulte suas edge applications, edge functions e outros recursos na plataforma através da Azion CLI.
+meta_tags: cli, edge, list, development
+namespace: documentation_cli_list
+menu_namespace: cliMenuAlpha
+permalink: /documentacao/devtools/cli/list/
+---
+
+Com o comando `azion list [recurso]` você pode listar:
+
+- [Edge applications](#edge-applications).
+    - [Edge functions](#edge-functions). 
+    - [Rules engine](#rules-engine). 
+    - [Cache settings](#cache-settings).
+    - [Domains](#domains).
+    - [Origins](#origins). 
+    - [Variables](#variables).
+
+:::note
+No caso de um ou mais campos obrigatórios não serem informados através das flags específicas, uma mensagem interativa será exibida, solicitando essas informações.
+:::
+
+---
+
+## Edge applications
+
+#### Uso
+
+```bash
+azion list edge-application [flags]
+```
+
+#### Flags opcionais
+
+##### details
+
+A flag `--details` exibe todos os campos relevantes ao listar.
+
+##### page
+
+A opção `--page` retorna uma página da lista de acordo com o número especificado. Por padrão, é `1`.
+
+##### page_size
+
+A opção `--page_size` define quantos itens devem ser retornados por página. Por padrão, é `10`.
+
+##### help
+
+A opção `--help` exibe mais informações sobre a ação `azion list edge-application`.
+
+---
+
+## Edge functions
+
+#### Uso
+
+```bash
+azion list edge-function
+```
+
+#### Flags opcionais
+
+##### details
+
+A flag `--details` exibe todos os campos relevantes ao listar.
+
+##### filter
+
+A flag `--filter` filtra itens pelo nome.
+
+##### order-by
+
+A flag `--order-by` ordena a saída com base no campo selecionado.
+
+##### page
+
+A flag `--page` retorna uma página da lista de acordo com seu número. O padrão é `1`.
+
+##### page-size
+
+A flag `--page-size` define quantos itens devem ser retornados por página. O padrão é `10`.
+
+##### sort
+
+A flag `--sort` define a ordem dos itens na lista. O valor deve ser `asc` ou `desc`.
+
+##### help
+
+A opção `--help` exibe mais informações sobre o comando `azion list edge-function`.
+
+---
+
+## Rules engine
+
+#### Uso
+
+```bash
+ azion list rules-engine --application-id <application-id> --phase <phase>
+```
+
+#### Flags obrigatórias
+
+##### application-id
+
+A flag `--application-id` especifica o identificador único da edge application que implementa essas regras.
+
+##### phase
+
+A flag `--phase` especifica a fase do Rules Engine. Pode ser `request` ou `response`.
+
+#### Flags opcionais
+
+##### details
+
+A flag `--details` exibe todos os campos relevantes ao listar.
+
+##### filter
+
+A flag `--filter` filtra os itens pelo nome.
+
+##### order-by
+
+A flag `--order-by` classifica a saída com base no campo selecionado.
+
+##### page
+
+A flag `--page` retorna uma página específica da lista de acordo com seu número. Por padrão, é `1`.
+
+##### page-size
+
+A flag `--page-size` define quantos itens devem ser retornados por página. Por padrão, é `10`.
+
+##### sort
+
+A flag `--sort` define a ordem dos itens na lista e pode ser definida como `asc` (crescente) ou `desc` (decrescente).
+
+##### help
+
+A flag `-h` ou `--help` exibe mais informações sobre o comando `azion list rules-engine`.
+
+---
+
+## Cache settings
+
+#### Uso
+
+```bash
+$ azion list cache-setting --application-id 16736354321
+```
+
+#### Flags opcionais
+
+##### application-id
+
+A flag `--application-id` define o identificador único para a edge application.
+
+##### details
+
+A flag `--details` exibe todos os campos relevantes ao listar.
+
+##### filter
+
+A opção `--filter` filtra itens pelo nome.
+
+##### help
+
+A opção `--help` exibe mais informações sobre o comando `azion list cache-setting`.
+
+##### order-by
+
+A opção `--order-by` ordena a saída com base no campo selecionado.
+
+##### page
+
+A opção `--page` retorna uma página específica da lista de acordo com o número. O valor padrão é `1`.
+
+##### page-size
+
+A opção `--page-size` define quantos itens devem ser retornados por página. O valor padrão é `10`.
+
+##### sort
+
+A opção `--sort` define a ordem dos itens na lista. O valor deve ser `asc` ou `desc`.
+
+---
+
+## Domains
+
+#### Descrição
+
+#### Uso
+
+```bash
+azion list domain
+```
+
+#### Flags opcionais
+
+##### details
+
+A opção `--details` exibe todos os campos relevantes ao listar.
+
+##### filter
+
+A opção `--filter` filtra itens pelo nome deles.
+
+##### order-by
+
+A opção `--order-by` classifica a saída com base no campo selecionado.
+
+##### page
+
+A opção `--page` retorna uma página específica da lista de acordo com o número. O padrão é `1`.
+
+##### page-size
+
+A opção `--page-size` define quantos itens devem ser retornados por página. O padrão é `10`.
+
+##### sort
+
+A opção `--sort` define a ordem dos itens na lista. As opções são `asc` ou `desc`.
+
+##### help
+
+A opção `-h` ou `--help` exibe mais informações sobre o comando `azion list domain`.
+
+---
+
+## Origins
+
+#### Uso
+
+```bash
+$ azion list origin --application-id <application-id>
+```
+
+#### Flags obrigatórias
+
+##### application-id
+
+A flag `--application-id` define o identificador único para a edge application.
+
+#### Flags opcionais
+
+##### details
+
+A flag `--details` exibe todos os campos relevantes ao listar origens.
+
+##### filter
+
+A flag `--filter` filtra itens pelo nome.
+
+##### order-by
+
+A flag `--order-by` ordena a saída com base no campo selecionado.
+
+##### page
+
+A flag `--page` retorna uma página específica da lista de acordo com o número. O padrão é `1`.
+
+##### page-size
+
+A flag `--page-size` define quantos itens devem ser retornados por página. O padrão é `10`.
+
+##### sort
+
+A flag `--sort` define a ordem dos itens na lista. O valor deve ser `asc` ou `desc`.
+
+#### help
+
+A opção `-h` ou `--help` exibe mais informações sobre a ação `azion list origin`.
+
+---
+
+## Variables
+
+#### Uso
+
+```bash
+  azioncli variables list
+```
+
+#### Flags opcionais
+
+##### details
+
+A opção `--details` exibe todos os campos relevantes ao listar.
+
+##### help
+
+A opção `--help` exibe mais informações sobre o subcomando `list`.


### PR DESCRIPTION
Related issue:

[EDU-4097](https://aziontech.atlassian.net/browse/EDU-4097)

Changes:

Place all create commands inside a parent file for the list command. Each resource had its own page. Now, the page will be based on the CRUDL command.

The content was not altered, only moved.

I avoided using ### because it was uncomfortable to the eye... nor nice.

[EDU-4097]: https://aziontech.atlassian.net/browse/EDU-4097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ