### PR TITLE
[EDU-4032] feat: add url copy tip and link playground

### DIFF
--- a/src/content/docs/en/pages/devtools/api-graphql/first-steps/first-steps.mdx
+++ b/src/content/docs/en/pages/devtools/api-graphql/first-steps/first-steps.mdx
@@ -39,7 +39,11 @@ You can use Azion **GraphQL** built-in playground to write, validate, and test G
 
 To interact with the GraphQL playground, you first need to log in to [RTM](https://manager.azion.com/). If you haven't created an account, see the [Creating an account on Azion](/en/documentation/products/accounts/creating-account/) documentation page.
 
-After successfully logging in to **RTM**, go to `https://manager.azion.com/metrics/graphql` or `https://manager.azion.com/events/graphql` and interact with the GraphQL playground.
+After successfully logging in to **RTM**, go to [https://manager.azion.com/metrics/graphql](https://manager.azion.com/metrics/graphql) or [https://manager.azion.com/events/graphql](https://manager.azion.com/events/graphql) and interact with the GraphQL playground.
+
+:::tip
+After you execute a query, the URL path is updated with an encoded parameter of the specific query you're using. You can copy and share the URL with other users so they can use the same query.
+:::
 
 Watch a video tutorial on GraphQL’s first steps on Azion’s YouTube channel:
 

--- a/src/content/docs/en/pages/main-menu/additional-resources/developer-tools/graphql-playground.mdx
+++ b/src/content/docs/en/pages/main-menu/additional-resources/developer-tools/graphql-playground.mdx
@@ -14,6 +14,10 @@ You can see how to access the GraphQL Playground on the GraphQL API first steps 
 
 You can use the playground to run queries or to explore how to build them. If you're just starting, you can copy and paste these queries on the playground and discover what each field represents, available operators, and even get real-time validation for erros.
 
+:::tip
+After you execute a query, the URL path is updated with an encoded parameter of the specific query you're using. You can copy and share the URL with other users so they can use the same query.
+:::
+
 This first query is a type of introspection query, which provides information on fields for datasets:
 
 ```graphql

--- a/src/content/docs/pt-br/pages/devtools/api-graphql/primeiros-passos/primeiros-passo-gql.mdx
+++ b/src/content/docs/pt-br/pages/devtools/api-graphql/primeiros-passos/primeiros-passo-gql.mdx
@@ -41,7 +41,11 @@ Você pode usar o playground da **GraphQL** da Azion para escrever, validar e te
 
 Para interagir com o playground da GraphQL, você deve estar [logado no RTM](https://manager.azion.com/). Se você ainda não criou uma conta, veja a página de documentação [Criar uma conta na Azion](/pt-br/documentacao/produtos/gestao-de-contas/criar-conta/).
 
-Após fazer login no **RTM**, acesse `https://manager.azion.com/metrics/graphql` ou `https://manager.azion.com/events/graphql` para interagir com o playground da **GraphQL**.
+Após fazer login no **RTM**, acesse [https://manager.azion.com/metrics/graphql](https://manager.azion.com/metrics/graphql) ou [https://manager.azion.com/events/graphql](https://manager.azion.com/events/graphql) para interagir com o playground da **GraphQL**.
+
+:::tip
+Após executar uma query, o caminho da URL é atualizado com um parâmetro codificado da query específica que você está utilizando. Você pode copiar e compartilhar a URL com outros usuários para que usem a mesma query que você.
+:::
 
 Assista um tutorial sobre os primeiros passos da GraphQL no canal do YouTube da Azion, com opção de ativar legendas em português:
 

--- a/src/content/docs/pt-br/pages/menu-principal/recursos-adicionais/developer-tools/graphql-playground.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/recursos-adicionais/developer-tools/graphql-playground.mdx
@@ -14,6 +14,10 @@ Você pode ver como acessar o Playground da GraphQL na documentação dos primei
 
 Você pode usar o playground para executar queries ou explorar como construí-las. Se você está recém começando, você pode copiar e colar essas queries no playground e descobrir o que cada campo representa, os operadores disponíveis e até mesmo obter validação em tempo real para erros.
 
+:::tip
+Após executar uma query, o caminho da URL é atualizado com um parâmetro codificado da query específica que você está utilizando. Você pode copiar e compartilhar a URL com outros usuários para que usem a mesma query que você.
+:::
+
 Esta primeira query é um tipo de consulta de introspecção, que fornece informações sobre os campos para conjuntos de dados:
 
 ```graphql


### PR DESCRIPTION

### Related issue: [EDU-4032]

### Changes

* Added a tip for sharing GraphQL API playground URLs after executing a query.
* Added clickable links to access playground.
