### PR TITLE
[NO ISSUE] adjust menu layout

### DIFF
--- a/src/components/LeftSidebar/SidebarContent.scss
+++ b/src/components/LeftSidebar/SidebarContent.scss
@@ -22,7 +22,7 @@
 		}
 		
 		.overline {
-			font-size: 0.8rem;
+			font-size: 1rem;
 			font-weight: 400;
 			color: var(--color-orange);
 			text-transform: uppercase;
@@ -49,7 +49,7 @@
 		.nav-group-title h2 {
 			line-height: 200%;
 			max-width: 100%;
-			text-indent: 2px;
+			text-indent: 10px;
 			justify-content: space-between;
 			margin-bottom: 0;
 		}
@@ -73,7 +73,7 @@
 			display: flex;
 			align-items: center;
 			padding: 0 0.5rem;
-			text-indent: 2px;
+			text-indent: 10px;
 		}
 
 		&:hover {
@@ -86,10 +86,10 @@
 		font: inherit;
 		color: var(--theme-text);
 		text-decoration: none;
-		line-height: 200%;
+		line-height: 125%;
 		margin-right: 0.5rem;
-		text-indent: 2px;
-		line-height: 40px;
+		text-indent: 10px;
+		line-height: 16px;
 
 		&:hover {
 			color: var(--color-orange);


### PR DESCRIPTION
Adjust menu layout requested by design and @robsongajunior 

Request:
.nav-group .overline {
	font-size: 1rem; 
}
.nav-group-title h2 {
	text-ident: 10px;
}
.nav-link a {
line-height: 125%;
}
.nav-link-title a {
	text-ident: 10px;
	line-height: 16px;
}