### PR TITLE
[EDU-4448] feat: enforce HLS caching guide

### DIFF
--- a/src/content/docs/en/pages/architectures/live-streaming/live-streaming-delivery-hls.mdx
+++ b/src/content/docs/en/pages/architectures/live-streaming/live-streaming-delivery-hls.mdx
@@ -42,20 +42,7 @@ This solution is ideal for content providers who require high fidelity and low l
 
 1. [Create an edge application](/en/documentation/products/guides/build/build-an-application/).
 2. [Create a domain](https://www.azion.com/en/documentation/products/guides/configure-a-domain/#create-a-domain-with-azion) and [associate it with the edge application](/en/documentation/products/guides/configure-a-domain/#link-a-custom-domain-to-your-application).
-3. Set up and [enforce cache policies for HLS](/en/documentation/products/build/edge-application/rules-engine/#enforce-hls-cache) in the edge application.
-- [Enable Tiered Cache](/en/documentation/products/guides/billing-and-subscriptions/) in your account.
-- Go to the **Edge Application** page and select your application.
-- Open the **Cache Settings** tab and click the **+ Cache Setting** button.
-    - First, [create a cache policy](/en/documentation/products/build/edge-application/cache-settings/) for the chunks.
-        - For **Browser Cache Settings**, select **Override Cache Setting** and define a **Maximum TTL** of `0`.
-        - For **Edge Cache Settings**, select **Override Cache Setting** and define a **Maximum TTL** of `60`.
-        - Enable the **Tiered Cache** switch.
-        - In the **Advanced Cache Key** section, define the behavior of your application toward cache segmentation of objects. The recommendation is selecting **Content does not vary**, for **Query String** and/or **Cookies**, according to your needs.
-    - Then, create a cache policy for the playlist.
-        - Repeat the previous process, but this time set a **Maximum TTL** of `0` for **Browser Cache Settings** and `5` for **Edge Cache Settings**. Define **Advanced Cache Key** settings too.
-    - Still on the application page, open the **Rules Engine** tab:
-        - Create a rule for the chunks: select `if ${uri}` *matches* `.\*.ts` as criteria and **Set Cache Policy** as behavior, adding the policy for the chunks you created in the previous step.
-        - Create a rule for the playlist: define `if ${uri}` *matches* `\*.m3u8` as criteria and **Set Cache Policy** as behavior, adding the policy for the playlist you created in the previous step.
+3. Set up and [enforce cache policies for HLS](/en/documentation/products/guides/enforce-hls-cache/) in the edge application.
 4.  Configure your source and encoder pointing to Azion Ingest DNS entries.
 5.  Stream your content via Azion Edge Platform.
 

--- a/src/content/docs/en/pages/guides/edge-application/ea-enforce-hls.mdx
+++ b/src/content/docs/en/pages/guides/edge-application/ea-enforce-hls.mdx
@@ -13,15 +13,14 @@ import Tabs from '~/components/tabs/Tabs'
 Azion has two user interfaces: Real-Time Manager and Console, which is in Preview stage. Currently, Console is only available for Developer plans and new accounts. Follow the steps according to the user interface you're using.
 :::
 
-Azion Edge Platform allows you to deliver live streaming content in **HLS format**, being able to easily self-provision and configure your cache policies. This guide covers the step-by-step to enforce HLS cache, managing chunks and playlists caching and setting up rules engines rules.
+Azion Edge Platform allows you to [deliver live streaming content in HLS format](/en/documentation/architecture/live-streaming-delivery/live-streaming-delivery-with-hls/), being able to easily self-provision and configure your cache policies. This guide covers the step-by-step to enforce HLS cache, managing chunks and playlists caching and setting up rules engines rules.
 
-<Button href="/en/documentation/architecture/live-streaming-delivery/live-streaming-delivery-with-hls/" text="go to live streaming delivery architecture" variant="secondary"></Button>
 
 ---
 
 ## Requirements
 
-- An Azion edge application, or [creating a new one](/en/documentation/products/guides/build/build-an-application/).
+- An existing Azion edge application, or [create a new one](/en/documentation/products/guides/build/build-an-application/).
 - [A domain associated with the edge application](/en/documentation/products/guides/configure-a-domain/).
 - [Tiered Cache enabled](/en/documentation/products/guides/billing-and-subscriptions/) in your account.
 
@@ -31,14 +30,26 @@ Azion Edge Platform allows you to deliver live streaming content in **HLS format
 
 To enforce cache policies for HLS in the edge application, follow the steps as explained next.
 
+In this example, an edge application and a domain linked to it has been previously created.
+
 ### Creating a cache policy for the chunks
 
 First, you must to create a cache policy for the chunks:
 
-
 <Tabs client:visible>
+    <Fragment slot="tab.cli">CLI </Fragment>
     <Fragment slot="tab.console">Console </Fragment>
     <Fragment slot="tab.rtm">Real-Time Manager </Fragment>
+
+<Fragment slot="panel.cli">
+1. Install [Azion CLI](/en/documentation/products/azion-cli/overview/).
+2. Get the details of an existing edge application using the [list command](/en/documentation/devtools/cli/list/): `azion list edge-application --details`
+3. Enable Tiered Cache for your application: `$ azion update edge-application --application-id 1234 --l2-caching true`
+4. Create an origin: `$ azion create origin --application-id 1234 --name "origin-edge" --origin-type single_origin --addresses "example.com" --host-header "example.com"`
+5. Configure the cache policy for the chuncks: `$ azion create cache-setting --application-id 1234 --name "chunks-policy" --browser-cache-settings "override" --browser-cache-settings-maximum-ttl 0 --cdn-cache-settings "override" --cnd-cache-settings-maximum-ttl 60`
+- Define **Advanced Cache Key** behavoirs according to your needs. Check the optional flags for the [create command](/en/documentation/devtools/cli/create/#optional-flags-3)
+- The recommendation is selecting **Content does not vary**, for **Query String** and/or **Cookies**, according to your needs.
+</Fragment>
 
 <Fragment slot="panel.console">
 1. Access [Azion Console](https://console.azion.com/).
@@ -75,8 +86,15 @@ First, you must to create a cache policy for the chunks:
 ### Creating cache policies for the playlist
 
 <Tabs client:visible>
+    <Fragment slot="tab.cli">CLI </Fragment>
     <Fragment slot="tab.console">Console </Fragment>
     <Fragment slot="tab.rtm">Real-Time Manager </Fragment>
+
+<Fragment slot="panel.cli">
+Now configure the cache policy for the chuncks: `$ azion create cache-setting --application-id 1234 --name "playlist-policy" --browser-cache-settings "override" --browser-cache-settings-maximum-ttl 0 --cdn-cache-settings "override" --cnd-cache-settings-maximum-ttl 5`
+- Define **Advanced Cache Key** behavoirs according to your needs. Check the optional flags for the [create command](/en/documentation/devtools/cli/create/#optional-flags-3).
+- The recommendation is selecting **Content does not vary**, for **Query String** and/or **Cookies**, according to your needs.
+</Fragment>
 
 <Fragment slot="panel.console">
 Still on the **Cache Settings** tab, click the **+ Cache Setting** button again to create a new cache policy for the playlist:
@@ -159,6 +177,8 @@ Done! Now you can configure your source and encoder pointing to Azion and stream
 :::tip
 Go to the [Rules Engine for Edge Application](/en/documentation/products/build/edge-application/rules-engine/) documentation for more details.
 :::
+
+<Button href="/en/documentation/architecture/live-streaming-delivery/live-streaming-delivery-with-hls/" text="go to live streaming delivery architecture" variant="secondary"></Button>
 
 ---
 

--- a/src/content/docs/en/pages/guides/edge-application/ea-enforce-hls.mdx
+++ b/src/content/docs/en/pages/guides/edge-application/ea-enforce-hls.mdx
@@ -15,7 +15,6 @@ Azion has two user interfaces: Real-Time Manager and Console, which is in Previe
 
 Azion Edge Platform allows you to [deliver live streaming content in HLS format](/en/documentation/architecture/live-streaming-delivery/live-streaming-delivery-with-hls/), being able to easily self-provision and configure your cache policies. This guide covers the step-by-step to enforce HLS cache, managing chunks and playlists caching and setting up rules engines rules.
 
-
 ---
 
 ## Requirements
@@ -47,7 +46,7 @@ First, you must to create a cache policy for the chunks:
 3. Enable Tiered Cache for your application: `$ azion update edge-application --application-id 1234 --l2-caching true`
 4. Create an origin: `$ azion create origin --application-id 1234 --name "origin-edge" --origin-type single_origin --addresses "example.com" --host-header "example.com"`
 5. Configure the cache policy for the chuncks: `$ azion create cache-setting --application-id 1234 --name "chunks-policy" --browser-cache-settings "override" --browser-cache-settings-maximum-ttl 0 --cdn-cache-settings "override" --cnd-cache-settings-maximum-ttl 60`
-- Define **Advanced Cache Key** behavoirs according to your needs. Check the optional flags for the [create command](/en/documentation/devtools/cli/create/#optional-flags-3)
+- Define **Advanced Cache Key** behavoirs according to your needs. Check the optional flags for the [create command](/en/documentation/devtools/cli/create/#optional-flags-3).
 - The recommendation is selecting **Content does not vary**, for **Query String** and/or **Cookies**, according to your needs.
 </Fragment>
 
@@ -91,7 +90,7 @@ First, you must to create a cache policy for the chunks:
     <Fragment slot="tab.rtm">Real-Time Manager </Fragment>
 
 <Fragment slot="panel.cli">
-Now configure the cache policy for the chuncks: `$ azion create cache-setting --application-id 1234 --name "playlist-policy" --browser-cache-settings "override" --browser-cache-settings-maximum-ttl 0 --cdn-cache-settings "override" --cnd-cache-settings-maximum-ttl 5`
+Now configure the cache policy for the playlist: `$ azion create cache-setting --application-id 1234 --name "playlist-policy" --browser-cache-settings "override" --browser-cache-settings-maximum-ttl 0 --cdn-cache-settings "override" --cnd-cache-settings-maximum-ttl 5`
 - Define **Advanced Cache Key** behavoirs according to your needs. Check the optional flags for the [create command](/en/documentation/devtools/cli/create/#optional-flags-3).
 - The recommendation is selecting **Content does not vary**, for **Query String** and/or **Cookies**, according to your needs.
 </Fragment>
@@ -129,8 +128,67 @@ Read more about setting up [cache settings](/en/documentation/products/build/edg
 ### Creating Rules Engine rules
 
 <Tabs client:visible>
+    <Fragment slot="tab.cli">CLI </Fragment>
     <Fragment slot="tab.console">Console </Fragment>
     <Fragment slot="tab.rtm">Real-Time Manager </Fragment>
+
+<Fragment slot="panel.cli">
+1. First, create a rule for the chunks: 
+`$ azion create rules-engine --application-id 1234 --phase "request" --file ./chunks-rule.json`
+
+In the `chunks-rule.json` file, include:
+
+```
+{
+    "name": "chunks-rule",
+    "description": "This is a description for your chunks rule",
+    "criteria": [
+        [
+            {
+                "conditional": "if",
+                "variable": "${uri}",
+                "operator": "matches",
+                "input_value": ".\*.ts"
+            }
+        ]
+    ],
+    "behaviors": [
+        {
+            "name": "set_cache_policy",
+            "target": "chunks-policy"
+        }
+    ]
+}
+```
+
+2. Now, create a rule for the playlist:
+`$ azion create rules-engine --application-id 1234 --phase "request" --file ./playlist-rule.json`
+
+In the `playlist-rule.json` file, include:
+
+```
+{
+    "name": "playlist-cache-rule",
+    "description": "This is a description for your playlist rule",
+    "criteria": [
+        [
+            {
+                "conditional": "if",
+                "variable": "${uri}",
+                "operator": "matches",
+                "input_value": "\*.m3u8"
+            }
+        ]
+    ],
+    "behaviors": [
+        {
+            "name": "set_cache_policy",
+            "target": "playlist-policy"
+        }
+    ]
+}
+```
+</Fragment>
 
 <Fragment slot="panel.console">
 Still on the application page, open the **Rules Engine** tab:

--- a/src/content/docs/en/pages/guides/edge-application/ea-enforce-hls.mdx
+++ b/src/content/docs/en/pages/guides/edge-application/ea-enforce-hls.mdx
@@ -1,0 +1,96 @@
+---
+title: How to enforce HLS cache for live streaming delivery
+description: This guide covers the step-by-step to enforcing HLS cache, managing chunks and playlists caching, and setting up rules engines rules.
+meta_tags: architecture, content delivery, hls, edge computing
+namespace: docs_guides_enforce_hls_cache
+permalink: /documentation/products/guides/enforce-hls-cache/
+---
+
+import Button from '~/components/Button.astro';
+import Tabs from '~/components/tabs/Tabs'
+
+:::caution[important]
+Azion has two user interfaces: Real-Time Manager and Console, which is in Preview stage. Currently, Console is only available for Developer plans and new accounts. Follow the steps according to the user interface you're using.
+:::
+
+Azion Edge Platform allows you to deliver live streaming content in **HLS format**, being able to easily self-provision and configure your cache policies. This guide covers the step-by-step to enforcing HLS cache, managing chunks and playlists caching, and setting up rules engines rules.
+
+<Button href="/en/documentation/architecture/live-streaming-delivery/live-streaming-delivery-with-hls/" text="go to live streaming delivery architecture"></Button>
+
+---
+
+## Requirements
+
+- An Azion edge application, or [creating a new one](/en/documentation/products/guides/build/build-an-application/).
+- [A domain associated with the edge application](/en/documentation/products/guides/configure-a-domain/).
+- [Tiered Cache enabled](/en/documentation/products/guides/billing-and-subscriptions/) in your account.
+
+---
+
+## Enforcing cache policies for HLS
+
+To enforce cache policies for HLS in the edge application, follow the steps as explained next.
+
+### Creating a cache policy for the chunks
+
+First, you must to create a cache policy for the chunks:
+
+1. Access [Azion Console](https://console.azion.com/).
+2. Go to **Products menu** > **Edge Application**.
+3. Select your application.
+4. Open the **Cache Settings** tab and click the **+ Cache Setting** button to create the new cache policy:
+- For **Browser Cache Settings**, select **Override Cache Setting** and define a **Maximum TTL** of `0`.
+- For **Edge Cache Settings**, select **Override Cache Setting** and define a **Maximum TTL** of `60`.
+- Enable the **Tiered Cache** switch.
+- In the **Advanced Cache Key** section, define the behavior of your application toward cache segmentation of objects.
+    - The recommendation is selecting **Content does not vary**, for **Query String** and/or **Cookies**, according to your needs.
+5. Click the **Save** button.
+    
+### Creating cache policies for the playlist
+
+Still on the **Cache Settings** tab, click the **+ Cache Setting** button again to create a new cache policy for the playlist:
+
+- For **Browser Cache Settings**, select **Override Cache Setting** and define a **Maximum TTL** of `0`.
+- For **Edge Cache Settings**, select **Override Cache Setting** and define a **Maximum TTL** of `5`.
+- Enable the **Tiered Cache** switch.
+- In the **Advanced Cache Key** section, define the behavior of your application toward cache segmentation of objects.
+    - The recommendation is selecting **Content does not vary**, for **Query String** and/or **Cookies**, according to your needs.
+
+Then, click the **Save** button.
+
+:::tip
+Read more about setting up [cache settings](/en/documentation/products/build/edge-application/cache-settings/) for your edge applications.
+:::
+
+### Creating Rules Engine rules
+
+ - Still on the application page, open the **Rules Engine** tab:
+
+First, create a rule for the chunks: 
+1. Click the **+ Rule** button.
+2. Give a name and a description (optional) to your rule.
+3. Select the **Request Phase** option.
+4. In **Criteria**, define `if ${uri}` *matches* `.\*.ts`.
+5. In **Behaviors**, select **Set Cache Policy** and add the policy for the chunks you created in the previous step.
+6. Click the **Save** button.
+
+Now, create a rule for the playlist: 
+1. Click the **+ Rule** button.
+2. Give a name and a description (optional) to your rule.
+3. Select the **Request Phase** option.
+4. In **Criteria**, define `if ${uri}` *matches* `\*.m3u8`.
+5. In **Behaviors**, select **Set Cache Policy** and add the policy for the playlist you created in the previous step.
+6. Click the **Save** button.
+
+
+Done! Now you can configure your source and encoder pointing to Azion and stream your content, enforcing HLS cache.
+
+:::tip
+Go to the [Rules Engine for Edge Application](/en/documentation/products/build/edge-application/rules-engine/) documentation.
+:::
+
+---
+
+import ContributorList from '~/components/ContributorList.astro'
+
+**Contributors** <ContributorList>Contributor</ContributorList>

--- a/src/content/docs/en/pages/guides/edge-application/ea-enforce-hls.mdx
+++ b/src/content/docs/en/pages/guides/edge-application/ea-enforce-hls.mdx
@@ -1,6 +1,6 @@
 ---
 title: How to enforce HLS cache for live streaming delivery
-description: This guide covers the step-by-step to enforce HLS cache, managing chunks and playlists caching and setting up Rules Engine rules.
+description: This guide covers the step-by-step to enforce HLS cache, managing chunks and playlists caching, and setting up Rules Engine rules.
 meta_tags: architecture, content delivery, hls, edge computing
 namespace: docs_guides_enforce_hls_cache
 permalink: /documentation/products/guides/enforce-hls-cache/
@@ -13,7 +13,7 @@ import Tabs from '~/components/tabs/Tabs'
 Azion has two user interfaces: Real-Time Manager and Console, which is in Preview stage. Currently, Console is only available for Developer plans and new accounts. Follow the steps according to the user interface you're using.
 :::
 
-Azion Edge Platform allows you to [deliver live streaming content in HLS format](/en/documentation/architecture/live-streaming-delivery/live-streaming-delivery-with-hls/), being able to easily self-provision and configure your cache policies. This guide covers the step-by-step to enforce HLS cache, managing chunks and playlists caching and setting up rules engines rules.
+Azion Edge Platform allows you to [deliver live streaming content in HLS format](/en/documentation/architecture/live-streaming-delivery/live-streaming-delivery-with-hls/), being able to easily self-provision and configure your cache policies. This guide covers the step-by-step to enforce HLS cache, managing chunks and playlists caching, and setting up rules engines rules.
 
 ---
 

--- a/src/content/docs/en/pages/guides/edge-application/ea-enforce-hls.mdx
+++ b/src/content/docs/en/pages/guides/edge-application/ea-enforce-hls.mdx
@@ -1,6 +1,6 @@
 ---
 title: How to enforce HLS cache for live streaming delivery
-description: This guide covers the step-by-step to enforcing HLS cache, managing chunks and playlists caching, and setting up rules engines rules.
+description: This guide covers the step-by-step to enforce HLS cache, managing chunks and playlists caching and setting up rules engines rules.
 meta_tags: architecture, content delivery, hls, edge computing
 namespace: docs_guides_enforce_hls_cache
 permalink: /documentation/products/guides/enforce-hls-cache/
@@ -13,9 +13,9 @@ import Tabs from '~/components/tabs/Tabs'
 Azion has two user interfaces: Real-Time Manager and Console, which is in Preview stage. Currently, Console is only available for Developer plans and new accounts. Follow the steps according to the user interface you're using.
 :::
 
-Azion Edge Platform allows you to deliver live streaming content in **HLS format**, being able to easily self-provision and configure your cache policies. This guide covers the step-by-step to enforcing HLS cache, managing chunks and playlists caching, and setting up rules engines rules.
+Azion Edge Platform allows you to deliver live streaming content in **HLS format**, being able to easily self-provision and configure your cache policies. This guide covers the step-by-step to enforce HLS cache, managing chunks and playlists caching and setting up rules engines rules.
 
-<Button href="/en/documentation/architecture/live-streaming-delivery/live-streaming-delivery-with-hls/" text="go to live streaming delivery architecture"></Button>
+<Button href="/en/documentation/architecture/live-streaming-delivery/live-streaming-delivery-with-hls/" text="go to live streaming delivery architecture" variant="secondary"></Button>
 
 ---
 
@@ -35,19 +35,50 @@ To enforce cache policies for HLS in the edge application, follow the steps as e
 
 First, you must to create a cache policy for the chunks:
 
+
+<Tabs client:visible>
+    <Fragment slot="tab.console">Console </Fragment>
+    <Fragment slot="tab.rtm">Real-Time Manager </Fragment>
+
+<Fragment slot="panel.console">
 1. Access [Azion Console](https://console.azion.com/).
 2. Go to **Products menu** > **Edge Application**.
 3. Select your application.
 4. Open the **Cache Settings** tab and click the **+ Cache Setting** button to create the new cache policy:
-- For **Browser Cache Settings**, select **Override Cache Setting** and define a **Maximum TTL** of `0`.
-- For **Edge Cache Settings**, select **Override Cache Setting** and define a **Maximum TTL** of `60`.
+- Give it a unique name.
+- In **Cache Expiration Policies**:
+    - For **Browser Cache Settings**, select **Override Cache Setting** and define a **Maximum TTL** of `0`.
+    - For **Edge Cache Settings**, select **Override Cache Setting** and define a **Maximum TTL** of `60`.
 - Enable the **Tiered Cache** switch.
 - In the **Advanced Cache Key** section, define the behavior of your application toward cache segmentation of objects.
     - The recommendation is selecting **Content does not vary**, for **Query String** and/or **Cookies**, according to your needs.
 5. Click the **Save** button.
+</Fragment>
+
+<Fragment slot="panel.rtm">
+1. Access [Real-Time Manager](https://manager.azion.com/).
+2. Go to **Products menu** > **Edge Application**.
+3. Select your application.
+4. Open the **Cache Settings** tab and click the **Add Cache Settings** button to create the new cache policy:
+- Give it a unique name.
+- In **Expiration Settings**:
+    - For **Browser Cache Settings**, select **Override Cache Setting** and define a **Maximum TTL** of `0`.
+    - For **CDN Cache Settings**, select **Override Cache Setting** and define a **Maximum TTL** of `60`.
+- Enable the **Tiered Cache** switch.
+- In the **Advanced Cache Key** section, define the behavior of your application toward cache segmentation of objects.
+    - The recommendation is selecting **Content does not vary**, for **Query String** and/or **Cookies**, according to your needs.
+5. Click the **Save** button.
+</Fragment>
+
+</Tabs>
     
 ### Creating cache policies for the playlist
 
+<Tabs client:visible>
+    <Fragment slot="tab.console">Console </Fragment>
+    <Fragment slot="tab.rtm">Real-Time Manager </Fragment>
+
+<Fragment slot="panel.console">
 Still on the **Cache Settings** tab, click the **+ Cache Setting** button again to create a new cache policy for the playlist:
 
 - For **Browser Cache Settings**, select **Override Cache Setting** and define a **Maximum TTL** of `0`.
@@ -57,6 +88,21 @@ Still on the **Cache Settings** tab, click the **+ Cache Setting** button again 
     - The recommendation is selecting **Content does not vary**, for **Query String** and/or **Cookies**, according to your needs.
 
 Then, click the **Save** button.
+</Fragment>
+
+<Fragment slot="panel.rtm">
+Still on the **Cache Settings** tab, click the **Add Cache Settings** button again to create a new cache policy for the playlist:
+
+- For **Browser Cache Settings**, select **Override Cache Setting** and define a **Maximum TTL** of `0`.
+- For **CDN Cache Settings**, select **Override Cache Setting** and define a **Maximum TTL** of `5`.
+- Enable the **Tiered Cache** switch.
+- In the **Advanced Cache Key** section, define the behavior of your application toward cache segmentation of objects.
+    - The recommendation is selecting **Content does not vary**, for **Query String** and/or **Cookies**, according to your needs.
+
+Then, click the **Save** button.
+</Fragment>
+
+</Tabs>
 
 :::tip
 Read more about setting up [cache settings](/en/documentation/products/build/edge-application/cache-settings/) for your edge applications.
@@ -64,7 +110,12 @@ Read more about setting up [cache settings](/en/documentation/products/build/edg
 
 ### Creating Rules Engine rules
 
- - Still on the application page, open the **Rules Engine** tab:
+<Tabs client:visible>
+    <Fragment slot="tab.console">Console </Fragment>
+    <Fragment slot="tab.rtm">Real-Time Manager </Fragment>
+
+<Fragment slot="panel.console">
+Still on the application page, open the **Rules Engine** tab:
 
 First, create a rule for the chunks: 
 1. Click the **+ Rule** button.
@@ -81,12 +132,32 @@ Now, create a rule for the playlist:
 4. In **Criteria**, define `if ${uri}` *matches* `\*.m3u8`.
 5. In **Behaviors**, select **Set Cache Policy** and add the policy for the playlist you created in the previous step.
 6. Click the **Save** button.
+</Fragment>
 
+<Fragment slot="panel.rtm">
+Still on the application page, open the **Rules Engine** tab:
+
+First, create a rule for the chunks: 
+1. Click the **New Rule** button and select the **Request Phase** option.
+2. Give a name and a description (optional) to your rule.
+3. In **Criteria**, define `if ${uri}` *matches* `.\*.ts`.
+4. In **Behaviors**, select **Set Cache Policy** and add the policy for the chunks you created in the previous step.
+5. Click the **Save** button.
+
+Now, create a rule for the playlist: 
+1. Click the **New Rule** button and select the **Request Phase** option.
+2. Give a name and a description (optional) to your rule.
+3. In **Criteria**, define `if ${uri}` *matches* `\*.m3u8`.
+4. In **Behaviors**, select **Set Cache Policy** and add the policy for the playlist you created in the previous step.
+5. Click the **Save** button.
+</Fragment>
+
+</Tabs>
 
 Done! Now you can configure your source and encoder pointing to Azion and stream your content, enforcing HLS cache.
 
 :::tip
-Go to the [Rules Engine for Edge Application](/en/documentation/products/build/edge-application/rules-engine/) documentation.
+Go to the [Rules Engine for Edge Application](/en/documentation/products/build/edge-application/rules-engine/) documentation for more details.
 :::
 
 ---

--- a/src/content/docs/en/pages/guides/edge-application/ea-enforce-hls.mdx
+++ b/src/content/docs/en/pages/guides/edge-application/ea-enforce-hls.mdx
@@ -1,6 +1,6 @@
 ---
 title: How to enforce HLS cache for live streaming delivery
-description: This guide covers the step-by-step to enforce HLS cache, managing chunks and playlists caching and setting up rules engines rules.
+description: This guide covers the step-by-step to enforce HLS cache, managing chunks and playlists caching and setting up Rules Engine rules.
 meta_tags: architecture, content delivery, hls, edge computing
 namespace: docs_guides_enforce_hls_cache
 permalink: /documentation/products/guides/enforce-hls-cache/
@@ -41,11 +41,11 @@ First, you must to create a cache policy for the chunks:
     <Fragment slot="tab.rtm">Real-Time Manager </Fragment>
 
 <Fragment slot="panel.cli">
-1. Install [Azion CLI](/en/documentation/products/azion-cli/overview/).
+1. Open [Azion CLI](/en/documentation/products/azion-cli/overview/) in your terminal.
 2. Get the details of an existing edge application using the [list command](/en/documentation/devtools/cli/list/): `azion list edge-application --details`
 3. Enable Tiered Cache for your application: `$ azion update edge-application --application-id 1234 --l2-caching true`
 4. Create an origin: `$ azion create origin --application-id 1234 --name "origin-edge" --origin-type single_origin --addresses "example.com" --host-header "example.com"`
-5. Configure the cache policy for the chuncks: `$ azion create cache-setting --application-id 1234 --name "chunks-policy" --browser-cache-settings "override" --browser-cache-settings-maximum-ttl 0 --cdn-cache-settings "override" --cnd-cache-settings-maximum-ttl 60`
+5. Configure the cache policy for the chunks: `$ azion create cache-setting --application-id 1234 --name "chunks-policy" --browser-cache-settings "override" --browser-cache-settings-maximum-ttl 0 --cdn-cache-settings "override" --cnd-cache-settings-maximum-ttl 60`
 - Define **Advanced Cache Key** behavoirs according to your needs. Check the optional flags for the [create command](/en/documentation/devtools/cli/create/#optional-flags-3).
 - The recommendation is selecting **Content does not vary**, for **Query String** and/or **Cookies**, according to your needs.
 </Fragment>
@@ -96,27 +96,27 @@ Now configure the cache policy for the playlist: `$ azion create cache-setting -
 </Fragment>
 
 <Fragment slot="panel.console">
-Still on the **Cache Settings** tab, click the **+ Cache Setting** button again to create a new cache policy for the playlist:
+Still on the **Cache Settings** tab:
 
+1. Click the **+ Cache Setting** button again to create a new cache policy for the playlist:
 - For **Browser Cache Settings**, select **Override Cache Setting** and define a **Maximum TTL** of `0`.
 - For **Edge Cache Settings**, select **Override Cache Setting** and define a **Maximum TTL** of `5`.
 - Enable the **Tiered Cache** switch.
 - In the **Advanced Cache Key** section, define the behavior of your application toward cache segmentation of objects.
     - The recommendation is selecting **Content does not vary**, for **Query String** and/or **Cookies**, according to your needs.
-
-Then, click the **Save** button.
+2. Click the **Save** button.
 </Fragment>
 
 <Fragment slot="panel.rtm">
-Still on the **Cache Settings** tab, click the **Add Cache Settings** button again to create a new cache policy for the playlist:
+Still on the **Cache Settings** tab:
 
+1. Click the **Add Cache Settings** button again to create a new cache policy for the playlist:
 - For **Browser Cache Settings**, select **Override Cache Setting** and define a **Maximum TTL** of `0`.
 - For **CDN Cache Settings**, select **Override Cache Setting** and define a **Maximum TTL** of `5`.
 - Enable the **Tiered Cache** switch.
 - In the **Advanced Cache Key** section, define the behavior of your application toward cache segmentation of objects.
     - The recommendation is selecting **Content does not vary**, for **Query String** and/or **Cookies**, according to your needs.
-
-Then, click the **Save** button.
+2. Click the **Save** button.
 </Fragment>
 
 </Tabs>

--- a/src/content/docs/en/pages/guides/index.mdx
+++ b/src/content/docs/en/pages/guides/index.mdx
@@ -28,6 +28,7 @@ permalink: /documentation/products/guides/
 - [How to use an Edge Storage bucket as the origin of a static edge application](/en/documentation/products/guides/use-bucket-as-origin/)
 - [How to configure HTTP and HTTPS ports for origins and delivery address](/en/documentation/products/guides/configure-ports/)
 - [How to access Edge Storage using the S3 protocol](/en/documentation/products/guides/s3-protocol-for-edge-storage/)
+- [How to enforce HLS cache for live streaming delivery](/en/documentation/products/guides/enforce-hls-cache/)
 
 ---
 

--- a/src/content/docs/en/pages/main-menu/reference/build/edge-application/rules-engine.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/build/edge-application/rules-engine.mdx
@@ -142,7 +142,7 @@ Add these variables inside the **Rules Engine** of your edge application to conf
 Most mTLS services rely on receiving the user certificate. By using [Azion Console](https://console.azion.com), you can send the `${ssl_client_escaped_cert}` variable in the `X-Forward-Client-Cert` (XFCC) header in the request to the origin, and then configure your edge application to use this header with the certificate data.
 :::
 
-<Button href="/en/documentation/products/build/edge-application/domains/mtls/" text="Learn more about support for mTLS"></Button>
+<Button href="/en/documentation/products/build/edge-application/domains/mtls/" text="Learn more about support for mTLS" variant="secondary"></Button>
 
 ## Variables as arguments
 
@@ -304,6 +304,8 @@ Enables Gzip data compression, if supported by the user's browser. See the guide
 This behavior is automatically included by Azion every time you select a Live Ingest source. Two actions are performed in this situation: the bypass of all your Cache Phase rules and the imposition of the cache policy defined by Azion for live transmissions in HLS.
 
 Azion's cache policy for live HLS streams is 5 seconds of cache for playlists (`.m3u8`) and 60 seconds of cache for chunks (`.ts`).
+
+<Button href="/en/documentation/products/guides/enforce-hls-cache/" text="go to enforce HLS cache guide" variant="secondary"></Button>
 
 ### Filter Cookie
 <Badge>Request Phase</Badge> <Badge>Response Phase</Badge>

--- a/src/content/docs/pt-br/pages/arquiteturas/live-streaming-delivery/live-streming-delivery-com-hls.mdx
+++ b/src/content/docs/pt-br/pages/arquiteturas/live-streaming-delivery/live-streming-delivery-com-hls.mdx
@@ -42,7 +42,7 @@ Esta solução é ideal para provedores de conteúdo que necessitam de alta fide
 
 1. [Crie uma edge application](/pt-br/documentacao/produtos/guias/build/criar-uma-aplicacao/).
 2. [Crie um domínio](/pt-br/documentacao/produtos/guias/configurar-dominio/#criar-um-dominio-com-a-azion) e [associe-o à edge application](/pt-br/documentacao/produtos/guias/configurar-dominio/#vincular-um-dominio-personalizado-a-sua-application).
-3. Configure [políticas de cache para HLS](/pt-br/documentacao/produtos/guias/impor-cache-hls/) na edge application.
+3. Configure [políticas de cache para HLS](/pt-br/documentacao/produtos/guias/implementar-cache-hls/) na edge application.
 4. Configure sua fonte e codificador apontando para as entradas DNS de ingestão da Azion.
 5. Transmita seu conteúdo via Plataforma de Edge da Azion.
 

--- a/src/content/docs/pt-br/pages/arquiteturas/live-streaming-delivery/live-streming-delivery-com-hls.mdx
+++ b/src/content/docs/pt-br/pages/arquiteturas/live-streaming-delivery/live-streming-delivery-com-hls.mdx
@@ -42,20 +42,7 @@ Esta solução é ideal para provedores de conteúdo que necessitam de alta fide
 
 1. [Crie uma edge application](/pt-br/documentacao/produtos/guias/build/criar-uma-aplicacao/).
 2. [Crie um domínio](/pt-br/documentacao/produtos/guias/configurar-dominio/#criar-um-dominio-com-a-azion) e [associe-o à edge application](/pt-br/documentacao/produtos/guias/configurar-dominio/#vincular-um-dominio-personalizado-a-sua-application).
-3. Configure [políticas de cache para HLS](/pt-br/documentacao/produtos/build/edge-application/rules-engine/#enforce-hls-cache) na edge application.
-- [Ative o Tiered Cache](/pt-br/documentacao/produtos/guias/billing-and-subscriptions/) em sua conta.
-- Acesse a página da **Edge Application** e selecione sua aplicação.
-- Abra a aba **Cache Settings** e clique no botão **+ Cache Setting**.
-    - Primeiro, [crie uma política de cache](/pt-br/documentacao/produtos/build/edge-application/cache-settings/) para os chunks.
-        - Para **Browser Cache Settings**, selecione **Override Cache Setting** e defina um **Maximum TTL** de `0`.
-        - Para **Edge Cache Settings**, selecione **Override Cache Setting** e defina um **Maximum TTL** de `60`.
-        - Ative o switch do **Tiered Cache**.
-        - Na seção **Advanced Cache Key**, defina o comportamento de sua aplicação em relação à segmentação de objetos em cache. A recomendação é selecionar **Content does not vary**, para **Query String** e/ou **Cookies**, de acordo com suas necessidades.
-    - Em seguida, crie uma política de cache para a playlist.
-        - Repita o processo anterior, mas desta vez defina um **Maximum TTL** de `0` para **Browser Cache Settings** e `5` para **Edge Cache Settings**. Defina também as configurações da **Advanced Cache Key**.
-    - Ainda na página da aplicação, abra a aba **Rules Engine**:
-        - Crie uma regra para os chunks: selecione `if ${uri}` *matches* `.\*.ts` como critério (criteria) e **Set Cache Policy** como comportamento (behavior), adicionando a política para os chunks criada no passo anterior.
-        - Crie uma regra para a playlist: defina `if ${uri}` *matches* `\*.m3u8` como critério (criteria) e **Set Cache Policy** como comportamento (behavior), adicionando a política para a playlist criada no passo anterior.
+3. Configure [políticas de cache para HLS](/pt-br/documentacao/produtos/guias/impor-cache-hls/) na edge application.
 4. Configure sua fonte e codificador apontando para as entradas DNS de ingestão da Azion.
 5. Transmita seu conteúdo via Plataforma de Edge da Azion.
 

--- a/src/content/docs/pt-br/pages/guias/edge-application/ea-enforce-hls.mdx
+++ b/src/content/docs/pt-br/pages/guias/edge-application/ea-enforce-hls.mdx
@@ -1,0 +1,10 @@
+---
+title: How to enforce HLS cache for live streaming delivery
+description: This guide covers the step-by-step to enforce HLS cache, managing chunks and playlists caching and setting up rules engines rules.
+meta_tags: architecture, content delivery, hls, edge computing
+namespace: docs_guides_enforce_hls_cache
+permalink: /documentacao/produtos/guias/enforce-hls-cache/
+---
+
+import Button from '~/components/Button.astro';
+import Tabs from '~/components/tabs/Tabs'

--- a/src/content/docs/pt-br/pages/guias/edge-application/ea-enforce-hls.mdx
+++ b/src/content/docs/pt-br/pages/guias/edge-application/ea-enforce-hls.mdx
@@ -10,18 +10,18 @@ import Button from '~/components/Button.astro';
 import Tabs from '~/components/tabs/Tabs'
 
 :::caution[importante]
-A Azion possui duas interfaces de usuário: o Real-Time Manager (RTM)e o Console, que está em fase de Preview. Atualmente, o Console está disponível apenas para planos Developer e novas contas. Siga os passos de acordo com a interface de usuário que você está usando.
+A Azion possui duas interfaces de usuário: o Real-Time Manager (RTM) e o Console, que está em fase de Preview. Atualmente, o Console está disponível apenas para planos Developer e novas contas. Siga os passos de acordo com a interface de usuário que você está usando.
 :::
 
-A Plataforma de Edge da Azion permite que você [entregue conteúdo de transmissão ao vivo no formato HLS](/en/documentation/architecture/live-streaming-delivery/live-streaming-delivery-with-hls/), capacitando-lhe a autoprovisionar e configurar suas política de cache facilmente. Este guia abrange o passo a passo para impor o cache HLS, gerenciando o cache de chunks e playlists e configurando regras no Rules Engine.
+A Plataforma de Edge da Azion permite que você [entregue conteúdo de transmissão ao vivo no formato HLS](/pt-br/documentacao/arquitetura/live-streaming-delivery/live-streaming-delivery-com-hls/), capacitando-lhe a autoprovisionar e configurar suas política de cache facilmente. Este guia abrange o passo a passo para impor o cache HLS, gerenciando o cache de chunks e playlists e configurando regras no Rules Engine.
 
 ---
 
 ## Pré-requisitos
 
-- Uma edge application existente na Azion, ou [crie uma nova]().
-- [Um domínio associado à edge application]().
-- [Tiered Cache habilitado] em sua conta.
+- Uma edge application existente na Azion, ou [crie uma nova](/pt-br/documentacao/produtos/guias/build/criar-uma-aplicacao/).
+- [Um domínio associado à edge application](/pt-br/documentacao/produtos/guias/configurar-dominio/).
+- [Tiered Cache habilitado](/pt-br/documentacao/produtos/guias/billing-and-subscriptions/) em sua conta.
 
 ---
 
@@ -41,12 +41,12 @@ Primeiro, você deve criar uma política de cache para os chunks:
     <Fragment slot="tab.rtm">Real-Time Manager </Fragment>
 
 <Fragment slot="panel.cli">
-1. Abra a [Azion CLI](/en/documentation/products/azion-cli/overview/) no seu terminal.
-2. Obtenha os detalhes de uma aplicação edge existente usando o [comando list](/en/documentation/devtools/cli/list/): `azion list edge-application --details`
+1. Abra a [Azion CLI](/pt-br/documentacao/produtos/azion-cli/visao-geral/) no seu terminal.
+2. Obtenha os detalhes de uma aplicação edge existente usando o [comando list](/pt-br/documentacao/devtools/cli/list/): `azion list edge-application --details`
 3. Habilite o Tiered Cache para sua application: `$ azion update edge-application --application-id 1234 --l2-caching true`
 4. Crie uma origem: `$ azion create origin --application-id 1234 --name "origin-edge" --origin-type single_origin --addresses "example.com" --host-header "example.com"`
 5. Configure a política de cache para os chunk: `$ azion create cache-setting --application-id 1234 --name "chunks-policy" --browser-cache-settings "override" --browser-cache-settings-maximum-ttl 0 --cdn-cache-settings "override" --cnd-cache-settings-maximum-ttl 60`
-- Defina os comportamentos de **Advanced Cache Key** de acordo com suas necessidades. Verifique as flags opcionais para o [comando create](/en/documentation/devtools/cli/create/#optional-flags-3).
+- Defina os comportamentos de **Advanced Cache Key** de acordo com suas necessidades. Verifique as flags opcionais para o [comando create](/pt-br/documentacao/devtools/cli/create/#flags-opcionais-3).
 - A recomendação é selecionar **Content does not vary**, para **Query String** and/or **Cookies**, conforme suas necessidades.
 </Fragment>
 
@@ -91,7 +91,7 @@ Primeiro, você deve criar uma política de cache para os chunks:
 
 <Fragment slot="panel.cli">
 Agora configure a política de cache para a playlist: `$ azion create cache-setting --application-id 1234 --name "playlist-policy" --browser-cache-settings "override" --browser-cache-settings-maximum-ttl 0 --cdn-cache-settings "override" --cnd-cache-settings-maximum-ttl 5`
-- Defina os comportamentos de **Advanced Cache Key** de acordo com suas necessidades. Verifique as flags opcionais para o [comando create](/en/documentation/devtools/cli/create/#optional-flags-3).
+- Defina os comportamentos de **Advanced Cache Key** de acordo com suas necessidades. Verifique as flags opcionais para o [comando create](/pt-br/documentacao/devtools/cli/create/#flags-opcionais-3).
 - A recomendação é selecionar **Content does not vary**, para **Query String** and/or **Cookies**, conforme suas necessidades.
 </Fragment>
 
@@ -126,7 +126,7 @@ Ainda na aba **Cache Settings**:
 </Tabs>
 
 :::tip
-Leia mais sobre a configuração de [cache settings](/en/documentation/products/build/edge-application/cache-settings/) para suas edge applications.
+Leia mais sobre a configuração de [cache settings](/pt-br/documentacao/produtos/build/edge-application/cache-settings/) para suas edge applications.
 :::
 
 ### Crie regras no Rules Engine
@@ -214,10 +214,6 @@ Agora, crie uma regra para a playlist:
 6. Clique no botão **Save**.
 </Fragment>
 
-<Fragment slot="rtm">
-
-</Fragment>
-
 <Fragment slot="panel.rtm">
 Ainda na página da aplicação, abra a aba **Rules Engine**:
 
@@ -241,10 +237,10 @@ Agora, crie uma regra para a playlist:
 Pronto! Agora você pode configurar sua fonte e codificador apontando para a Azion e transmitir seu conteúdo, impondo o cache HLS.
 
 :::tip
-Acesse a documentação do [Rules Engine for Edge Application](/en/documentation/products/build/edge-application/rules-engine/) para mais detalhes.
+Acesse a documentação do [Rules Engine for Edge Application](/pt-br/documentacao/produtos/build/edge-application/rules-engine/) para mais detalhes.
 :::
 
-<Button href="/en/documentation/architecture/live-streaming-delivery/live-streaming-delivery-with-hls/" text="go to live streaming delivery architecture" variant="secondary"></Button>
+<Button href="/pt-br/documentacao/arquitetura/live-streaming-delivery/live-streaming-delivery-com-hls/" text="consulte a arquitetura de live streaming delivery" variant="secondary"></Button>
 
 ---
 

--- a/src/content/docs/pt-br/pages/guias/edge-application/ea-enforce-hls.mdx
+++ b/src/content/docs/pt-br/pages/guias/edge-application/ea-enforce-hls.mdx
@@ -1,5 +1,5 @@
 ---
-title: Como impor cache HLS para entrega de transmissão ao vivo
+title: Como impor cache HLS para entrega de streaming ao vivo
 description: Este guia abrange o passo a passo para impor cache HLS, gerenciando o cache de chunks e playlists e configurando regras no Rules Engine.
 meta_tags: architecture, content delivery, hls, edge computing
 namespace: docs_guides_enforce_hls_cache
@@ -13,7 +13,7 @@ import Tabs from '~/components/tabs/Tabs'
 A Azion possui duas interfaces de usuário: o Real-Time Manager (RTM) e o Console, que está em fase de Preview. Atualmente, o Console está disponível apenas para planos Developer e novas contas. Siga os passos de acordo com a interface de usuário que você está usando.
 :::
 
-A Plataforma de Edge da Azion permite que você [entregue conteúdo de transmissão ao vivo no formato HLS](/pt-br/documentacao/arquitetura/live-streaming-delivery/live-streaming-delivery-com-hls/), capacitando-lhe a autoprovisionar e configurar suas política de cache facilmente. Este guia abrange o passo a passo para impor o cache HLS, gerenciando o cache de chunks e playlists e configurando regras no Rules Engine.
+A Plataforma de Edge da Azion permite que você [entregue conteúdo de streaming ao vivo no formato HLS](/pt-br/documentacao/arquitetura/live-streaming-delivery/live-streaming-delivery-com-hls/), capacitando-lhe a autoprovisionar e configurar suas política de cache facilmente. Este guia abrange o passo a passo para impor o cache HLS, gerenciando o cache de chunks e playlists e configurando regras no Rules Engine.
 
 ---
 

--- a/src/content/docs/pt-br/pages/guias/edge-application/ea-enforce-hls.mdx
+++ b/src/content/docs/pt-br/pages/guias/edge-application/ea-enforce-hls.mdx
@@ -1,10 +1,253 @@
 ---
-title: How to enforce HLS cache for live streaming delivery
-description: This guide covers the step-by-step to enforce HLS cache, managing chunks and playlists caching and setting up rules engines rules.
+title: Como impor cache HLS para entrega de transmissão ao vivo
+description: Este guia abrange o passo a passo para impor cache HLS, gerenciando o cache de chunks e playlists e configurando regras no Rules Engine.
 meta_tags: architecture, content delivery, hls, edge computing
 namespace: docs_guides_enforce_hls_cache
-permalink: /documentacao/produtos/guias/enforce-hls-cache/
+permalink: /documentacao/produtos/guias/impor-cache-hls/
 ---
 
 import Button from '~/components/Button.astro';
 import Tabs from '~/components/tabs/Tabs'
+
+:::caution[importante]
+A Azion possui duas interfaces de usuário: o Real-Time Manager (RTM)e o Console, que está em fase de Preview. Atualmente, o Console está disponível apenas para planos Developer e novas contas. Siga os passos de acordo com a interface de usuário que você está usando.
+:::
+
+A Plataforma de Edge da Azion permite que você [entregue conteúdo de transmissão ao vivo no formato HLS](/en/documentation/architecture/live-streaming-delivery/live-streaming-delivery-with-hls/), capacitando-lhe a autoprovisionar e configurar suas política de cache facilmente. Este guia abrange o passo a passo para impor o cache HLS, gerenciando o cache de chunks e playlists e configurando regras no Rules Engine.
+
+---
+
+## Pré-requisitos
+
+- Uma edge application existente na Azion, ou [crie uma nova]().
+- [Um domínio associado à edge application]().
+- [Tiered Cache habilitado] em sua conta.
+
+---
+
+## Imponha políticas de cache HLS
+
+Para impor políticas de cache HLS na edge application, siga os passos explicados embaixo.
+
+Neste exemplo, uma edge application e um domínio vinculado a ela já foram previamente criados.
+
+### Crie uma política de cache para os chunks
+
+Primeiro, você deve criar uma política de cache para os chunks:
+
+<Tabs client:visible>
+    <Fragment slot="tab.cli">CLI </Fragment>
+    <Fragment slot="tab.console">Console </Fragment>
+    <Fragment slot="tab.rtm">Real-Time Manager </Fragment>
+
+<Fragment slot="panel.cli">
+1. Abra a [Azion CLI](/en/documentation/products/azion-cli/overview/) no seu terminal.
+2. Obtenha os detalhes de uma aplicação edge existente usando o [comando list](/en/documentation/devtools/cli/list/): `azion list edge-application --details`
+3. Habilite o Tiered Cache para sua application: `$ azion update edge-application --application-id 1234 --l2-caching true`
+4. Crie uma origem: `$ azion create origin --application-id 1234 --name "origin-edge" --origin-type single_origin --addresses "example.com" --host-header "example.com"`
+5. Configure a política de cache para os chunk: `$ azion create cache-setting --application-id 1234 --name "chunks-policy" --browser-cache-settings "override" --browser-cache-settings-maximum-ttl 0 --cdn-cache-settings "override" --cnd-cache-settings-maximum-ttl 60`
+- Defina os comportamentos de **Advanced Cache Key** de acordo com suas necessidades. Verifique as flags opcionais para o [comando create](/en/documentation/devtools/cli/create/#optional-flags-3).
+- A recomendação é selecionar **Content does not vary**, para **Query String** and/or **Cookies**, conforme suas necessidades.
+</Fragment>
+
+<Fragment slot="panel.console">
+1. Acesse o [Azion Console](https://console.azion.com/).
+2. Vá para **Products menu** > **Edge Application**.
+3. Selecione sua aplicação.
+4. Abra a aba **Cache Settings** e clique no botão **+ Cache Setting** para criar a nova política de cache:
+- Dê um nome único.
+- Na seção **Cache Expiration Policies**:
+    - Para **Browser Cache Settings**, selecione **Override Cache Setting** e defina um **Maximum TTL** de `0`.
+    - Para **Edge Cache Settings**, selecione **Override Cache Setting** e defina um **Maximum TTL** de `60`.
+- Ative o interruptor do **Tiered Cache**.
+- Na seção **Advanced Cache Key**, defina o comportamento da sua aplicação em relação à segmentação de cache dos objetos.
+    - A recomendação é selecionar **Content does not vary**, para **Query String** and/or **Cookies**, conforme suas necessidades.
+5. Clique no botão **Save**.
+</Fragment>
+
+<Fragment slot="panel.rtm">
+1. Acesse o [Real-Time Manager](https://manager.azion.com/).
+2. Vá para **Products menu** > **Edge Application**.
+3. Selecione sua aplicação.
+4. Abra a aba **Cache Settings** e clique no botão **Add Cache Settings** para criar a nova política de cache:
+- Dê um nome único.
+- Na seção **Expiration Settings**:
+    - Para **Browser Cache Settings**, selecione **Override Cache Setting** e defina um **Maximum TTL** de `0`.
+    - Para **CDN Cache Settings**, selecione **Override Cache Setting** e defina um **Maximum TTL** de `60`.
+- Ative o interruptor do **Tiered Cache**.
+- Na seção **Advanced Cache Key** section, defina o comportamento da sua aplicação em relação à segmentação de cache dos objetos.
+    - A recomendação é selecionar **Content does not vary**, para **Query String** and/or **Cookies**, conforme suas necessidades.
+5. Clique no botão **Save**.
+</Fragment>
+
+</Tabs>
+
+### Crie uma política de cache para a playlist
+
+<Tabs client:visible>
+    <Fragment slot="tab.cli">CLI </Fragment>
+    <Fragment slot="tab.console">Console </Fragment>
+    <Fragment slot="tab.rtm">Real-Time Manager </Fragment>
+
+<Fragment slot="panel.cli">
+Agora configure a política de cache para a playlist: `$ azion create cache-setting --application-id 1234 --name "playlist-policy" --browser-cache-settings "override" --browser-cache-settings-maximum-ttl 0 --cdn-cache-settings "override" --cnd-cache-settings-maximum-ttl 5`
+- Defina os comportamentos de **Advanced Cache Key** de acordo com suas necessidades. Verifique as flags opcionais para o [comando create](/en/documentation/devtools/cli/create/#optional-flags-3).
+- A recomendação é selecionar **Content does not vary**, para **Query String** and/or **Cookies**, conforme suas necessidades.
+</Fragment>
+
+<Fragment slot="panel.console">
+Ainda na aba **Cache Settings**:
+
+1. Clique o botão **+ Cache Setting** de novo para criar a nova política de cache para a playlist:
+- Dê um nome único.
+- Na seção **Cache Expiration Policies**:
+    - Para **Browser Cache Settings**, selecione **Override Cache Setting** e defina um **Maximum TTL** de `0`.
+    - Para **Edge Cache Settings**, selecione **Override Cache Setting** e defina um **Maximum TTL** de `5`.
+- Ative o interruptor do **Tiered Cache**.
+- Na seção **Advanced Cache Key**, defina o comportamento da sua aplicação em relação à segmentação de cache dos objetos.
+    - A recomendação é selecionar **Content does not vary**, para **Query String** and/or **Cookies**, conforme suas necessidades.
+2. Clique no botão **Save**.
+</Fragment>
+
+<Fragment slot="panel.rtm">
+Ainda na aba **Cache Settings**:
+
+1. Clique o botão **Add Cache Settings** de novo para criar a nova política de cache para a playlist:
+- Dê um nome único.
+- Na seção **Cache Expiration Policies**:
+    - Para **Browser Cache Settings**, selecione **Override Cache Setting** e defina um **Maximum TTL** de `0`.
+    - Para **Edge Cache Settings**, selecione **Override Cache Setting** e defina um **Maximum TTL** de `5`.
+- Ative o interruptor do **Tiered Cache**.
+- Na seção **Advanced Cache Key**, defina o comportamento da sua aplicação em relação à segmentação de cache dos objetos.
+    - A recomendação é selecionar **Content does not vary**, para **Query String** and/or **Cookies**, conforme suas necessidades.
+2. Clique no botão **Save**.
+</Fragment>
+
+</Tabs>
+
+:::tip
+Leia mais sobre a configuração de [cache settings](/en/documentation/products/build/edge-application/cache-settings/) para suas edge applications.
+:::
+
+### Crie regras no Rules Engine
+
+<Tabs client:visible>
+    <Fragment slot="tab.cli">CLI </Fragment>
+    <Fragment slot="tab.console">Console </Fragment>
+    <Fragment slot="tab.rtm">Real-Time Manager </Fragment>
+
+<Fragment slot="panel.cli">
+1. Primeiro, crie uma regra para os chunks: 
+`$ azion create rules-engine --application-id 1234 --phase "request" --file ./chunks-rule.json`
+
+No arquivo `chunks-rule.json`, inclua:
+
+```
+{
+    "name": "chunks-rule",
+    "description": "This is a description for your chunks rule",
+    "criteria": [
+        [
+            {
+                "conditional": "if",
+                "variable": "${uri}",
+                "operator": "matches",
+                "input_value": ".\*.ts"
+            }
+        ]
+    ],
+    "behaviors": [
+        {
+            "name": "set_cache_policy",
+            "target": "chunks-policy"
+        }
+    ]
+}
+```
+
+2. Logo, crie uma regra para a playlist:
+`$ azion create rules-engine --application-id 1234 --phase "request" --file ./playlist-rule.json`
+
+No arquivo `playlist-rule.json`, inclua:
+
+```
+{
+    "name": "playlist-cache-rule",
+    "description": "This is a description for your playlist rule",
+    "criteria": [
+        [
+            {
+                "conditional": "if",
+                "variable": "${uri}",
+                "operator": "matches",
+                "input_value": "\*.m3u8"
+            }
+        ]
+    ],
+    "behaviors": [
+        {
+            "name": "set_cache_policy",
+            "target": "playlist-policy"
+        }
+    ]
+}
+```
+</Fragment>
+
+<Fragment slot="panel.console">
+Ainda na página da aplicação, abra a aba **Rules Engine**:
+
+Primeiro, crie uma regra para os chunks:
+1. Clique no botão **+ Rule** button.
+2. Dê um nome e uma descrição (opcional) à sua regra.
+3. Selecione a opção **Request Phase**.
+4. Em **Criteria**, defina `if ${uri}` *matches* `.\*.ts`.
+5. En **Behaviors**, selecione **Set Cache Policy** e adicione a política para os chunks que você criou no passo anterior.
+6. Clique no botão **Save**.
+
+Agora, crie uma regra para a playlist:
+1. Clique no botão **+ Rule**.
+2. Dê um nome e uma descrição (opcional) à sua regra.
+3. Selecione a opção **Request Phase**.
+4. Em **Criteria**, defina `if ${uri}` *matches* `\*.m3u8`.
+5. Em **Behaviors**, selecione **Set Cache Policy** e adicione a política para a playlist que você criou no passo anterior.
+6. Clique no botão **Save**.
+</Fragment>
+
+<Fragment slot="rtm">
+
+</Fragment>
+
+<Fragment slot="panel.rtm">
+Ainda na página da aplicação, abra a aba **Rules Engine**:
+
+Primeiro, crie uma regra para os chunks:
+1. Clique no botão **New Rule** button e selecione a opção **Request Phase**.
+2. Dê um nome e uma descrição (opcional) à sua regra.
+3. Em **Criteria**, defina `if ${uri}` *matches* `.\*.ts`.
+4. En **Behaviors**, selecione **Set Cache Policy** e adicione a política para os chunks que você criou no passo anterior.
+5. Clique no botão **Save**.
+
+Agora, crie uma regra para a playlist:
+1. Clique no botão **New Rule** button e selecione a opção **Request Phase**.
+2. Dê um nome e uma descrição (opcional) à sua regra.
+3. Em **Criteria**, defina `if ${uri}` *matches* `\*.m3u8`.
+4. Em **Behaviors**, selecione **Set Cache Policy** e adicione a política para a playlist que você criou no passo anterior.
+5. Clique no botão **Save**.
+</Fragment>
+
+</Tabs>
+
+Pronto! Agora você pode configurar sua fonte e codificador apontando para a Azion e transmitir seu conteúdo, impondo o cache HLS.
+
+:::tip
+Acesse a documentação do [Rules Engine for Edge Application](/en/documentation/products/build/edge-application/rules-engine/) para mais detalhes.
+:::
+
+<Button href="/en/documentation/architecture/live-streaming-delivery/live-streaming-delivery-with-hls/" text="go to live streaming delivery architecture" variant="secondary"></Button>
+
+---
+
+import ContributorList from '~/components/ContributorList.astro'
+
+**Contribuidores** <ContributorList>Contributor</ContributorList>

--- a/src/content/docs/pt-br/pages/guias/edge-application/ea-enforce-hls.mdx
+++ b/src/content/docs/pt-br/pages/guias/edge-application/ea-enforce-hls.mdx
@@ -1,6 +1,6 @@
 ---
 title: Como implementar cache HLS para entrega de streaming ao vivo
-description: Este guia abrange o passo a passo para impor cache HLS, gerenciando o cache de chunks e playlists e configurando regras no Rules Engine.
+description: Este guia abrange o passo a passo para implementar cache HLS, gerenciando o cache de chunks e playlists e configurando regras no Rules Engine.
 meta_tags: architecture, content delivery, hls, edge computing
 namespace: docs_guides_enforce_hls_cache
 permalink: /documentacao/produtos/guias/implementar-cache-hls/

--- a/src/content/docs/pt-br/pages/guias/edge-application/ea-enforce-hls.mdx
+++ b/src/content/docs/pt-br/pages/guias/edge-application/ea-enforce-hls.mdx
@@ -1,9 +1,9 @@
 ---
-title: Como impor cache HLS para entrega de streaming ao vivo
+title: Como implementar cache HLS para entrega de streaming ao vivo
 description: Este guia abrange o passo a passo para impor cache HLS, gerenciando o cache de chunks e playlists e configurando regras no Rules Engine.
 meta_tags: architecture, content delivery, hls, edge computing
 namespace: docs_guides_enforce_hls_cache
-permalink: /documentacao/produtos/guias/impor-cache-hls/
+permalink: /documentacao/produtos/guias/implementar-cache-hls/
 ---
 
 import Button from '~/components/Button.astro';
@@ -13,7 +13,7 @@ import Tabs from '~/components/tabs/Tabs'
 A Azion possui duas interfaces de usuário: o Real-Time Manager (RTM) e o Console, que está em fase de Preview. Atualmente, o Console está disponível apenas para planos Developer e novas contas. Siga os passos de acordo com a interface de usuário que você está usando.
 :::
 
-A Plataforma de Edge da Azion permite que você [entregue conteúdo de streaming ao vivo no formato HLS](/pt-br/documentacao/arquitetura/live-streaming-delivery/live-streaming-delivery-com-hls/), capacitando-lhe a autoprovisionar e configurar suas política de cache facilmente. Este guia abrange o passo a passo para impor o cache HLS, gerenciando o cache de chunks e playlists e configurando regras no Rules Engine.
+A Plataforma de Edge da Azion permite que você [entregue conteúdo de streaming ao vivo no formato HLS](/pt-br/documentacao/arquitetura/live-streaming-delivery/live-streaming-delivery-com-hls/), capacitando-lhe a autoprovisionar e configurar suas política de cache facilmente. Este guia abrange o passo a passo para implementar o cache HLS, gerenciando o cache de chunks e playlists e configurando regras no Rules Engine.
 
 ---
 
@@ -25,9 +25,9 @@ A Plataforma de Edge da Azion permite que você [entregue conteúdo de streaming
 
 ---
 
-## Imponha políticas de cache HLS
+## Implemente políticas de cache HLS
 
-Para impor políticas de cache HLS na edge application, siga os passos explicados embaixo.
+Para implementar políticas de cache HLS na edge application, siga os passos explicados embaixo.
 
 Neste exemplo, uma edge application e um domínio vinculado a ela já foram previamente criados.
 
@@ -234,7 +234,7 @@ Agora, crie uma regra para a playlist:
 
 </Tabs>
 
-Pronto! Agora você pode configurar sua fonte e codificador apontando para a Azion e transmitir seu conteúdo, impondo o cache HLS.
+Pronto! Agora você pode configurar sua fonte e codificador apontando para a Azion e transmitir seu conteúdo, implementando o cache HLS.
 
 :::tip
 Acesse a documentação do [Rules Engine for Edge Application](/pt-br/documentacao/produtos/build/edge-application/rules-engine/) para mais detalhes.

--- a/src/content/docs/pt-br/pages/guias/guides.mdx
+++ b/src/content/docs/pt-br/pages/guias/guides.mdx
@@ -29,7 +29,7 @@ permalink: /documentacao/produtos/guias/
 - [Como usar um bucket do Edge Storage como origem de uma edge application estática](/pt-br/documentacao/produtos/guias/usar-bucket-como-origem/)
 - [Como configurar portas HTTP e HTTPS para origens e endereço de entrega](/pt-br/documentacao/produtos/guias/configurar-portas/)
 - [Como acessar o Edge Storage usando o protocolo S3](/pt-br/documentacao/produtos/guias/protocolo-s3-para-edge-storage/)
-- [Como impor cache HLS para entrega de streaming ao vivo](/pt-br/documentacao/produtos/guias/impor-cache-hls/)
+- [Como implementar cache HLS para entrega de streaming ao vivo](/pt-br/documentacao/produtos/guias/implementar-cache-hls/)
 
 ---
 

--- a/src/content/docs/pt-br/pages/guias/guides.mdx
+++ b/src/content/docs/pt-br/pages/guias/guides.mdx
@@ -29,6 +29,7 @@ permalink: /documentacao/produtos/guias/
 - [Como usar um bucket do Edge Storage como origem de uma edge application estática](/pt-br/documentacao/produtos/guias/usar-bucket-como-origem/)
 - [Como configurar portas HTTP e HTTPS para origens e endereço de entrega](/pt-br/documentacao/produtos/guias/configurar-portas/)
 - [Como acessar o Edge Storage usando o protocolo S3](/pt-br/documentacao/produtos/guias/protocolo-s3-para-edge-storage/)
+- [Como impor cache HLS para entrega de streaming ao vivo](/pt-br/documentacao/produtos/guias/impor-cache-hls/)
 
 ---
 

--- a/src/content/docs/pt-br/pages/menu-principal/referencia/build/edge-application/rules-engine-edge-app.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/referencia/build/edge-application/rules-engine-edge-app.mdx
@@ -142,7 +142,7 @@ Utilize essas variáveis no **Rules Engine** da sua edge application para config
 A maioria dos serviços mTLS depende do recebimento do certificado do usuário. Usando o [Azion Console](https://console.azion.com), você pode enviar a variável `${ssl_client_escaped_cert}` no cabeçalho `X-Forward-Client-Cert` (XFCC) na requisição para a origem e, em seguida, configurar sua edge application para usar esse header com os dados do certificado.
 :::
 
-<Button href="/pt-br/documentacao/produtos/build/edge-application/domains/mtls/" text="Saiba mais sobre suporte para mTLS"></Button>
+<Button href="/pt-br/documentacao/produtos/build/edge-application/domains/mtls/" text="Saiba mais sobre suporte para mTLS" variant="secondary"></Button>
 
 ### Variáveis como argumentos
 
@@ -316,6 +316,8 @@ Caso sua origem não tenha suporte a range requests, a Azion só poderá iniciar
 Este behavior é incluído automaticamente pela Azion toda vez que você selecionar uma origem do tipo Live Ingest. Duas ações são executadas nessa situação: o bypass de todas suas regras da Cache Phase e a imposição da política de cache definida pela Azion para transmissões live em HLS.
 
 A política de cache da Azion para transmissões live em HLS é de 5 segundos de cache para playlists (`.m3u8`) e 60 segundos de cache para chunks (`.ts`).
+
+<Button href="/pt-br/documentacao/produtos/guias/impor-cache-hls/" text="consulte o guia para impor cache HLS" variant="secondary"></Button>
 
 ### Filter Cookie 
 <Badge>Request Phase</Badge> <Badge>Response Phase</Badge>

--- a/src/content/docs/pt-br/pages/menu-principal/referencia/build/edge-application/rules-engine-edge-app.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/referencia/build/edge-application/rules-engine-edge-app.mdx
@@ -317,7 +317,7 @@ Este behavior é incluído automaticamente pela Azion toda vez que você selecio
 
 A política de cache da Azion para transmissões live em HLS é de 5 segundos de cache para playlists (`.m3u8`) e 60 segundos de cache para chunks (`.ts`).
 
-<Button href="/pt-br/documentacao/produtos/guias/impor-cache-hls/" text="consulte o guia para impor cache HLS" variant="secondary"></Button>
+<Button href="/pt-br/documentacao/produtos/guias/implementar-cache-hls/" text="consulte o guia para implementar cache HLS" variant="secondary"></Button>
 
 ### Filter Cookie 
 <Badge>Request Phase</Badge> <Badge>Response Phase</Badge>


### PR DESCRIPTION
### Related issue:

[EDU-4448]

### Changes

- Add enforce HLS caching guide.
- Refactor Live Streaming arch and link to guide.
- Add the link to the guides page.
- Add button to Rules Engine reference.

### Additional links

n/a.

[EDU-4448]: https://aziontech.atlassian.net/browse/EDU-4448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ