### PR TITLE
[EDU-4463] refactor: add options to Match Zone table

### DIFF
--- a/src/content/docs/en/pages/main-menu/reference/secure/edge-firewall/web-application-firewall/web-application-firewall.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/secure/edge-firewall/web-application-firewall/web-application-firewall.mdx
@@ -87,21 +87,24 @@ The Allowed Rules are composed of the fields:
 | `Reason` | Alternative manual textual description |
 | `URI` | *Uniform Resource Identifier (URI)* is the path that goes after the domain in the URL |
 | `Path` | When specified, restricts the application of the `Match Zone` only to the defined path. The path delimits the scope of action of the rule | 
-| `Match Zone` | Parts or fields of the requisition that'll be compared with the `match pattern`. It can be `Path`, `Query String`, `Request Header`, `Request Body`, `File Name`, or `Raw Body` | 
+| `Match Zone` | Parts or fields of the requisition that'll be compared with the `match pattern`. Read more about each option in the [Match Zones table](#match-zone-dropdown-options) below | 
 | `Active` | Allowed Rule active status switch |
 
 ### Match Zone dropdown options
 
 The **Match Zone** dropdown opens the options available to complete this field. Each option has a specific behavior, as explained in the table below.
 
-| Field | Description  |
-| ----- | ---------- |
-| `Path` | `Match pattern` will be compared with the request path |
-| `Query String` | `Match pattern` will be compared to the *query string*, also called `GET arguments` |
-| `Request Header` | `Match pattern` will be compared to the HTTP headers of the request |
-| `Request Body` | `Match pattern` will be compared to the body of a POST, also called `POST arguments` |
-| `File Name` (Multipart Body) | `Match pattern` will be compared with the name of the files in *multipart POSTs* |
-| `Raw Body` | `Match pattern` will be compared to the uninterpreted body of a requisition, also called the *unparsed body* |
+| Field | Description | Field example | Matches on |
+| ----- | ---------- | ---------- | ---------- |
+| `Conditional Query String` | `Match pattern` will be compared with query string parameters of the request | `?id=123&user=admin` | You can select to add either the key name or the value in the allowed rule |
+| `Conditional Request Body` | `Match pattern` will be compared with the body of the request under certain conditions | `{"username": "admin", "password": "123456"}` | You can select to add either the key name or the value in the allowed rule |
+| `Conditional Request Header` | `Match pattern` will be compared with the HTTP headers of the request under certain conditions | `User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.71 Safari/537.36` | You can select to add either the header name or the value in the allowed rule |
+| `File Name (Multipart body)` | `Match pattern` will be compared with the name of the files in *multipart POSTs* | - | - |
+| `Path` | `Match pattern` will be compared with the request path | - | - |
+| `Query String` | `Match pattern` will be compared to the *query string*, also called `GET arguments` | - | You can select to add either the key name or the value in the allowed rule |
+| `Raw Body` | `Match pattern` will be compared to the uninterpreted body of a requisition, also called the *unparsed body* | - | - |
+| `Request Body` | `Match pattern` will be compared to the body of a POST, also called `POST arguments` | - | You can select to add either the key name or the value in the allowed rule |
+| `Request Header` | `Match pattern` will be compared to the HTTP headers of the request | - | You can select to add either the header name or the value in the allowed rule |
 
 :::note
 The `Last Editor` and `Last Modified` fields are only available through the [API](https://api.azion.com).

--- a/src/content/docs/pt-br/pages/menu-principal/referencia/secure/edge-firewall/web-application-firewall/web-application-firewall.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/referencia/secure/edge-firewall/web-application-firewall/web-application-firewall.mdx
@@ -24,7 +24,7 @@ Se tráfego interno, testes e falsos positivos estiverem sendo bloqueados pelo W
 
 | Escopo | Fonte |
 | ------ | ----- |
-| Criar WAF rule set | [Como verificar o modo do seu WAF](/pt-br/documentacao/produtos/guias/secure/criar-waf-rule-set) |
+| Criar WAF rule set | [Como criar um WAF rule set](/pt-br/documentacao/produtos/guias/secure/criar-waf-rule-set/) |
 | Modo WAF | [Como verificar o modo do seu WAF](/pt-br/documentacao/produtos/guias/como-verificar-modo-do-seu-waf/) |
 | Score WAF | [Como encontrar o score de requisições bloqueadas pelo WAF](/pt-br/documentacao/produtos/guias/como-encontrar-score-de-requisicoes-bloqueadas-pelo-waf/) |
 | Integrar WAF com SIEMs | [Como integrar WAF com SIEMs](/pt-br/documentacao/produtos/secure/automarizar/integrar-siems/) |

--- a/src/content/docs/pt-br/pages/menu-principal/referencia/secure/edge-firewall/web-application-firewall/web-application-firewall.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/referencia/secure/edge-firewall/web-application-firewall/web-application-firewall.mdx
@@ -86,21 +86,24 @@ Allowed Rules são compostas pelos seguintes campos:
 | `Reason` | Campo de descrição textual alternativa |
 | `URI` | *Uniform Resource Identifier (URI)* é o caminho (*path*) após o domínio na URL |
 | `Path` | Delimita o escopo de atuação da regra. Se especificado, restringe a aplicação da `Match Zone` somente ao `path` definido |
-| `Match Zone` | Partes ou campos da requisição que serão comparados com o `match pattern`. Pode ser `Path`, `Query String`, `Request Header`, `Request Body`, `File Name` or `Raw Body` |
+| `Match Zone` | Partes ou campos da requisição que serão comparados com o `match pattern`. Saiba mais sobre cada opção na [tabela de Match Zones](#opcoes-de-match-zone) abaixo |
 | `Active` | Switch de ativação da Allowed Rule |
-
-Saiba mais sobre cada opção de Match Zone na tabela de *opções de Match Zone* abaixo.
 
 ### Opções de Match Zone
 
-| Campo | Descrição |
-| ----- | --------- |
-| `Path` | `Match pattern` será comparado com o caminho (*path*) da requisição |
-| `Query String` | `Match pattern` será comparado à string de consulta (*query string*), também chamada de *GET arguments* |
-| `Request Header` | `Match pattern` será comparado aos headers HTTP da requisição | 
-| `Request Body` | `Match pattern` será comparado ao *body* de um POST, também chamado de *POST arguments* |
-| `File Name` (Multipart Body) | `Match pattern` será comparado com o nome dos arquivos em *multipart POSTs* |
-| `Raw Body` | `Match pattern` será comparado ao body não interpretado (*unparsed body*) de uma requisição |
+O menu suspenso da **Match Zone** abre as opções disponíveis para preencher este campo. Cada opção tem um comportamento específico, conforme explicado na tabela abaixo.
+
+| Campo | Descrição | Exemplo para o campo | Matches on |
+| ----- | ---------- | ---------- | ---------- |
+| `Conditional Query String` | `Match pattern` será comparado com os parâmetros da string de consulta da requisição | `?id=123&user=admin` | Você pode selecionar para adicionar ou o nome da chave ou o valor na allowed rule |
+| `Conditional Request Body` | `Match pattern` será comparado com os cabeçalhos HTTP da requisição sob certas condições | `{"username": "admin", "password": "123456"}` | Você pode selecionar para adicionar ou o nome da chave ou o valor na allowed rule |
+| `Conditional Request Header` | `Match pattern` será comparado com os cabeçalhos HTTP da requisição sob certas condições | `User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.71 Safari/537.36` | Você pode selecionar para adicionar ou o nome do cabeçalho ou o valor na allowed rule |
+| `File Name (Multipart body)` | `Match pattern` será comparado com o nome dos arquivos em *multipart POSTs* | - | - |
+| `Path` | `Match pattern` será comparado com o caminho (path) da requisição | - | - |
+| `Query String` | `Match pattern` será comparado à string de consulta (*query string*), também chamada de *GET arguments* | - | Você pode selecionar para adicionar ou o nome da chave ou o valor na allowed rule |
+| `Raw Body` | `Match pattern` será comparado ao body não interpretado (*unparsed body*) de uma requisição | - | - |
+| `Request Body` | `Match pattern` será comparado ao *body* de um POST, também chamado de *POST arguments* | - | Você pode selecionar para adicionar ou o nome da chave ou o valor na allowed rule |
+| `Request Header` | `Match pattern` será comparado aos headers HTTP da requisição | - | Você pode selecionar para adicionar ou o nome do cabeçalho ou o valor na allowed rule |
 
 :::note[nota]
 Os campos `Last Editor` e `Last Modified` estão disponíveis apenas pela [API](https://api.azion.com).


### PR DESCRIPTION
### Related issue: 

[EDU-4463] 

### Changes

- Add options to the Match Zone table in WAF reference, including examples and Match on* field.

### Additional links

n/a.

[EDU-4463]: https://aziontech.atlassian.net/browse/EDU-4463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ