### PR TITLE
fix: og:images and sitemap get to GET and skip_og validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "check-memory": "node -e 'console.log(v8.getHeapStatistics().heap_size_limit/(1024*1024))'",
     "set-memory-5gb": "export NODE_OPTIONS='--max-old-space-size=8120'",
+    "enable-og-build": "export SKIP_OG=true",
+    "disable-og-build": "export SKIP_OG=false",
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro build",

--- a/src/pages/[lang]/sitemap/docs.xml.js
+++ b/src/pages/[lang]/sitemap/docs.xml.js
@@ -43,7 +43,7 @@ function createXml(data) {
 	return response
 }
 
-export async function get({ params }) {
+export async function GET({ params }) {
 	const lang = params.lang ? params.lang : 'en'
 	const response = createXml(data[lang])
 	return response

--- a/src/pages/docs-open-graph/[...path].ts
+++ b/src/pages/docs-open-graph/[...path].ts
@@ -4,12 +4,13 @@ import { rtlLanguages } from '~/i18n/languages';
 import { getLanguageFromURL } from '~/util';
 
 /** Paths for all of our Markdown content we want to generate OG images for. */
-const paths = process.env.SKIP_OG ? [] : allPages;
+const skip_og = process.env.SKIP_OG?.toLocaleLowerCase() === 'true';
+const paths =  skip_og ? [] : allPages;
 
 /** An object mapping file paths to file metadata. */
 const pages = Object.fromEntries(paths.map(({ id, slug, data }) => [id, { data, slug }]));
 
-export const { getStaticPaths, get } = OGImageRoute({
+export const { getStaticPaths, GET } = OGImageRoute({
 	param: 'path',
 	pages,
 	getImageOptions: async (_, { data, slug }: (typeof pages)[string]) => {


### PR DESCRIPTION
## FIX
- og:image compilation
  - getStaticPath get to GET
  - SKIP_OG validation
- sitemap
  - getStaticPath get to GET
 
## ADDED
- export SKIP_OG inside package.json

```
"enable-og-build": "export SKIP_OG=true",
"disable-og-build": "export SKIP_OG=false",
```