### PR TITLE
[EDU-4903] feature: add Vitepress JavaScript Boilerplate guide

### DIFF
--- a/src/content/docs/en/pages/guides/index.mdx
+++ b/src/content/docs/en/pages/guides/index.mdx
@@ -88,6 +88,7 @@ permalink: /documentation/products/guides/
 - [How to deploy the Next.js Pages + Middleware template](/en/documentation/products/guides/nextjs-pages-middleware/)
 - [How to deploy the Static Cache template](/en/documentation/products/guides/static-cache-template/)
 - [How to deploy the Upstash Rate Limiting template](/en/documentation/products/guides/upstash-rate-limiting/)
+- [How to deploy the VitePress JavaScript Boilerplate](/en/documentation/products/guides/vitepress-javascript-boilerplate/)
 - [How to integrate a Turso database with Azion using a template](/en/documentation/products/guides/turso-starter-kit/)
 - [How to migrate a WordPress website to the edge with WordPress EdgeAccelerator](/en/documentation/products/guides/wordpress-edgeaccelerator/)
 - [How to test Bot Manager using a template](/en/documentation/products/guides/bot-manager-starter-kit/)

--- a/src/content/docs/en/pages/guides/marketplace/templates/vitepress-javascript-boilerplate.mdx
+++ b/src/content/docs/en/pages/guides/marketplace/templates/vitepress-javascript-boilerplate.mdx
@@ -1,0 +1,92 @@
+---
+title: How to deploy the VitePress JavaScript Boilerplate
+description: This template allows you to easily deploy a static project based on VitePress and written in Javascript.
+meta_tags: templates, guides, Azion Marketplace
+namespace: docs_guides_vitepress_javascript_boilerplate
+permalink: /documentation/products/guides/vitepress-javascript-boilerplate/
+---
+
+import Tag from 'primevue/tag';
+
+<Tag severity="info" client:only="vue">
+Preview
+</Tag>
+
+**VitePress JavaScript Boilerplate** allows you to deploy a static project on the edge quickly and easily. VitePress, a static site generator built on top of Vite and Vue.js, is ideal for creating documentation websites with features including a markdown-based content system, a built-in theming system, and fast hot module replacement.
+
+This template, *written in JavaScript*, creates a GitHub repository containing your project, as well as an edge application and a domain to facilitate your access and management through Azion Edge Platform.
+
+VitePress JavaScript Boilerplate uses VitePress version `1.3.0`.
+
+---
+
+## Requirements
+
+- A [GitHub account](https://github.com/signup) to connect with Azion and create your new repository.
+  - Every push will be deployed automatically to the main branch in this repository to keep your project updated.
+- Enable [Application Accelerator](/en/documentation/products/build/edge-application/application-accelerator/) in your account. 
+    - To do so, go to the [Billing & Subscriptions](/en/documentation/products/guides/billing-and-subscriptions/#subscriptions) section and activate the switch for each module.
+    - If this module isn't activated, the execution will fail and a log explaining the reason will be printed.
+    - If this module is activated, deploying this template could generate usage-related costs. Check the [pricing page](/en/documentation/products/pricing/) for more information.
+
+---
+
+## Getting the template
+
+To start using the **VitePress JavaScript Boilerplate**:
+
+1. Access [Console](https://console.azion.com/).
+2. Click the **+ Create** button on the homepage.
+3. In the modal, select the **Templates** option. 
+4. Browse and select the **VitePress JavaScript Boilerplate** card.
+
+---
+
+## Setting up the template
+
+In the configuration form, you must provide the information to configure your application. Fill in the presented fields. 
+
+Fields identified with an asterisk are mandatory.
+
+1. Connect Azion with your GitHub account.
+- A pop-up window will open to confirm the installation of the [Azion GitHub App](/en/documentation/products/guides/azion-github-app/), a tool that connects your GitHub account with Azion's platform.
+- Define your permissions and repository access as desired.
+2. Select the **Git Scope** to work with.
+3. Define a name for your edge application.
+- The bucket for storage will use the same name.
+- Use a unique and easy-to-remember name. If the name has already been used, the platform returns an error message.
+4. Click the **Deploy** button to start the deployment process.
+
+During the deployment, you'll be able to follow the process through a window showing off the logs. When it's complete, the page shows information about the application and some options to continue your journey.
+
+:::note
+The link to the edge application allows you to see it on the browser. However, it takes a certain time to propagate and configure the application in Azion's edge locations. It may be necessary to wait a few minutes for the URL to be activated and for the application page to be effectively displayed in the browser.
+:::
+
+---
+
+## Managing the template
+
+Considering that this initial setup may not be optimal for your specific edge application, all settings can be customized any time you need by using Azion's platform.
+
+To manage and edit your edge application's settings, follow these steps:
+
+1. [Access Azion Console](https://console.azion.com/).
+2. On the upper-left corner, select **Products menu** > **Edge Application**.
+- You'll be redirected to the **Edge Application** page. It lists all the edge applications you've created.
+3. Find the edge application related to your template and select it.
+- The list is organized alphabetically. You can also use the **search bar** located in the upper-left corner of the list; currently, it filters only by **Application Name**.
+
+After selecting the edge application you'll work on, you'll be directed to a page containing all the settings you can configure.
+
+:::tip
+Read the documentation about [managing edge applications](/en/documentation/products/build/edge-application/first-steps/) for more details.
+:::
+
+### Adding a custom domain
+
+The edge application created during the deployment has an assigned Azion domain to make it accessible through the browser. The domain has the following format: `xxxxxxxxxx.map.azionedge.net/`. However, you can add a custom domain for users to access your edge application through it.
+
+import LinkButton from '@aziontech/webkit/linkbutton';
+
+<LinkButton link="/en/documentation/products/guides/configure-a-domain/" label="Go to configuring a domain guide" outlined /> 

--- a/src/content/docs/en/pages/main-menu/additional-resources/templates-and-integrations/understand-azion-templates.mdx
+++ b/src/content/docs/en/pages/main-menu/additional-resources/templates-and-integrations/understand-azion-templates.mdx
@@ -230,6 +230,12 @@ The **Svelte Boilerplate** streamlines the deployment of a static application ba
 
 <LinkButton link="/en/documentation/products/guides/svelte-boilerplate/" label="go to the Svelte Boilerplate guide" outlined />
 
+#### VitePress JavaScript Boilerplate
+
+This template allows you to easily deploy a static project based on VitePress and written in Javascript.
+
+<LinkButton link="/en/documentation/products/guides/vitepress-javascript-boilerplate/" label="go to the VitePress JavaScript Boilerplate guide" outlined />
+
 #### Vue Boilerplate
 
 The Azion Vue Boilerplate provides an automation solution to build a Vue Single-Page Application (SPA) directly on the edge of the network, encapsulating and automating several steps, from repository management to edge deployment.

--- a/src/content/docs/pt-br/pages/guias/guides.mdx
+++ b/src/content/docs/pt-br/pages/guias/guides.mdx
@@ -87,6 +87,7 @@ permalink: /documentacao/produtos/guias/
 - [Como implantar o template Image Optimization](/pt-br/documentacao/produtos/guias/image-optimization-template/)
 - [Como implantar o template Static Cache](/pt-br/documentacao/produtos/guias/static-cache-template/)
 - [Como implantar o template Upstash Rate Limiting](/pt-br/documentacao/produtos/guias/upstash-rate-limiting/)
+- [Como implantar o VitePress JavaScript Boilerplate](/pt-br/documentacao/produtos/guias/vitepress-javascript-boilerplate/)
 - [Como implantar um blog Astro usando um template](/pt-br/documentacao/produtos/guias/astro-blog-starter-kit/)
 - [Como implantar um blog baseado no Gatsby usando um template](/pt-br/documentacao/produtos/guias/gatsby-blog-starter-kit/)
 - [Como integrar um banco de dados Turso com Azion usando um template](/pt-br/documentacao/produtos/guias/turso-starter-kit/)

--- a/src/content/docs/pt-br/pages/guias/marketplace/templates/vitepress-javascript-boilerplate.mdx
+++ b/src/content/docs/pt-br/pages/guias/marketplace/templates/vitepress-javascript-boilerplate.mdx
@@ -1,0 +1,92 @@
+---
+title: Como implantar o VitePress JavaScript Boilerplate
+description: Este template  permite implantar facilmente um projeto estático baseado no VitePress e escrito em JavaScript.
+meta_tags: templates, guias, Azion Marketplace
+namespace: docs_guides_vitepress_javascript_boilerplate
+permalink: /documentacao/produtos/guias/vitepress-javascript-boilerplate/
+---
+
+import Tag from 'primevue/tag';
+
+<Tag severity="info" client:only="vue">
+Preview
+</Tag>
+
+O **VitePress JavaScript Boilerplate** permite implantar rapidamente e facilmente um projeto estático no edge. VitePress, um gerador de site estático construído em cima do Vite e Vue.js, é ideal para criar sites de documentação com recursos como um sistema de conteúdo baseado em markdown, um sistema de temas integrado e substituição rápida de módulos.
+
+Este template, *escrito em JavaScript*, cria um repositório GitHub contendo seu projeto, bem como uma edge application e um domínio para facilitar seu acesso e gerenciamento por meio da Plataforma de Edge da Azion.
+
+O VitePress JavaScript Boilerplate utiliza a versão `1.3.0` do VitePress.
+
+---
+
+## Pré-requisitos
+
+- Uma [conta no GitHub](https://github.com/signup) para conectar com a Azion e criar seu novo repositório.
+  - Cada push será implantado automaticamente neste repositório para manter seu projeto atualizado.
+- Habilitar o [Application Accelerator](/pt-br/documentacao/produtos/build/edge-application/application-accelerator/) na sua conta.
+    - Para fazer isso, vá para a seção [Billing & Subscriptions](/pt-br/documentacao/produtos/guias/billing-and-subscriptions/) e ative o interruptor para cada módulo.
+    - Se este módulo não estiver ativado, a execução falhará e um log explicando o motivo será mostrado.
+    - Se este módulo estiver ativado, implantar este template pode gerar custos relacionados ao uso. Consulte a [página de preços](/pt-br/documentacao/produtos/precos/) para mais informações.
+
+---
+
+## Obtenha o template
+
+Para começar a usar o **VitePress JavaScript Boilerplate**:
+
+1. Acesse o [Azion Console](/pt-br/documentacao/produtos/guias/como-acessar-o-rtm/).
+2. Clique no botão **+ Create** na página inicial.
+3. No modal, selecione a opção **Templates**.
+4. Navegue e selecione o card do **VitePress JavaScript Boilerplate**.
+
+---
+
+## Configure o template
+
+No formulário de configuração, forneça as informações para configurar sua aplicação. Preencha os campos apresentados.
+
+Os campos identificados com asterisco são obrigatórios.
+
+1. Conecte a Azion com sua conta no GitHub.
+- Uma janela pop-up será aberta para confirmar a instalação da [Azion GitHub App](/pt-br/documentacao/produtos/guias/azion-github-app/), uma ferramenta que conecta sua conta do GitHub com a plataforma da Azion.
+- Defina suas permissões e acesso ao repositório conforme desejado.
+2. Selecione o **Git Scope** com o qual trabalhar.
+3. Defina um nome para sua edge application.
+- O bucket para armazenamento usará o mesmo nome.
+- Use um nome único e fácil de lembrar. Se o nome já tiver sido usado, a plataforma retornará uma mensagem de erro.
+4. Clique no botão **Deploy** para iniciar o processo de implantação.
+
+Durante a implantação, você poderá acompanhar o processo através de uma janela mostrando os logs. Quando estiver concluída, a página mostra informações sobre a aplicação e algumas opções para continuar sua jornada.
+
+:::note
+O link para sua edge application permite que você veja como ela fica no navegador. No entanto, leva um certo tempo para propagar e configurá-la nas edge locations da Azion. Pode ser necessário aguardar alguns minutos para que a URL seja ativada e para que a página da aplicação seja efetivamente exibida no navegador.
+:::
+
+---
+
+## Gerencie o template
+
+Considerando que essa configuração inicial pode não ser ideal para sua aplicação, todas as configurações podem ser personalizadas sempre que você precisar usando o Azion Console.
+
+Para gerenciar e editar as configurações da sua aplicação, siga estas etapas:
+
+1. [Acesse o Azion Console](https://console.azion.com/).
+2. No canto superior esquerdo, selecione **Products menu** > **Edge Application**.
+- Você será redirecionado para a página de **Edge Application**. Ela lista todas as edge applications que você criou.
+3. Encontre a edge application relacionada ao template e selecione-a.
+- A lista é organizada em ordem alfabética. Você também pode usar a **barra de busca** localizada no canto superior esquerdo da lista; atualmente, ela é filtrada apenas pelo **Application Name**, ou nome da edge application.
+
+Depois de selecionar a aplicação em que você trabalhará, você será direcionado para uma página que contém todas as configurações que você pode configurar.
+
+:::tip
+Leia a documentação sobre o [gerenciamento de edge applications](/pt-br/documentacao/produtos/build/edge-application/primeiros-passos/) para obter mais detalhes.
+:::
+
+### Adicione um domínio personalizado
+
+A edge application criada tem um domínio Azion atribuído para torná-la acessível através do navegador. O domínio tem o seguinte formato: `xxxxxxxxxx.map.azionedge.net/`. No entanto, você pode adicionar um domínio personalizado para que os usuários acessem sua aplicação por meio dele.
+
+import LinkButton from '@aziontech/webkit/linkbutton';
+
+<LinkButton link="/pt-br/documentacao/produtos/guias/configurar-dominio/" label="Consulte o guia para configurar domínios" outlined /> 

--- a/src/content/docs/pt-br/pages/menu-principal/recursos-adicionais/templates-e-integracoes/templates-visao-geral.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/recursos-adicionais/templates-e-integracoes/templates-visao-geral.mdx
@@ -226,6 +226,12 @@ O **Svelte Boilerplate** simplifica a implantação de uma aplicação estática
 
 <LinkButton link="/pt-br/documentacao/produtos/guias/svelte-boilerplate/" label="consulte o guia do Svelte Boilerplate" outlined />
 
+#### VitePress JavaScript Boilerplate
+
+Este template  permite implantar facilmente um projeto estático baseado no VitePress e escrito em JavaScript.
+
+<LinkButton link="/pt-br/documentacao/produtos/guias/vitepress-javascript-boilerplate/" label="consulte o guia do VitePress JavaScript Boilerplate" outlined />
+
 #### Vue Boilerplate
 
 O **Vue Boilerplate** da Azion fornece uma solução de automação para criar uma Single-Page Application (SPA) do Vue diretamente no edge da rede, encapsulando e automatizando várias etapas, desde o gerenciamento do repositório até a implantação.


### PR DESCRIPTION
### Related issue:

[EDU-4903]

### Changes

- Add Vitepress JavaScript Boilerplate guide. EN-PT.
- Add links to the Guides page and the Templates reference.

### Additional links

n/a.

[EDU-4903]: https://aziontech.atlassian.net/browse/EDU-4903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ