### PR TITLE
[EDU-4911] feature: add VitePress templates launch to Release Notes

### DIFF
--- a/src/content/docs/en/pages/main-menu/release-notes/release-notes.mdx
+++ b/src/content/docs/en/pages/main-menu/release-notes/release-notes.mdx
@@ -7,6 +7,23 @@ permalink: /documentation/products/release-notes/
 ---
 import Tag from 'primevue/tag'
 
+## July 16, 2024
+
+### Marketplace
+
+#### Azion Templates
+
+<Tag severity="info" client:only="vue">Preview</Tag>
+
+The two new Azion Templates allow you to quickly and easily deploy a static project based on **VitePress** on the edge. VitePress, a static site generator built on top of Vite and Vue.js, is ideal for creating documentation websites. It features a markdown-based content system, a built-in theming system, and fast hot module replacement.
+
+Read more in the documentation:
+
+- [How to deploy the VitePress JavaScript Boilerplate](/en/documentation/products/guides/vitepress-javascript-boilerplate/)
+- [How to deploy the VitePress TypeScript Boilerplate](/en/documentation/products/guides/vitepress-typescript-boilerplate/)
+
+---
+
 ## July 10, 2024
 
 ### Marketplace

--- a/src/content/docs/pt-br/pages/menu-principal/release-notes/release-notes.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/release-notes/release-notes.mdx
@@ -7,6 +7,23 @@ permalink: /documentacao/produtos/release-notes/
 ---
 import Tag from 'primevue/tag'
 
+## 16 de julho, 2024
+
+### Marketplace 
+
+#### Azion Templates
+
+<Tag severity="info" client:only="vue">Preview</Tag>
+
+Os dois novos Azion Templates permitem implantar rapidamente e facilmente um projeto estático baseado no **VitePress** no edge. VitePress, um gerador de site estático construído em cima do Vite e Vue.js, é ideal para criar sites de documentação com recursos como um sistema de conteúdo baseado em markdown, um sistema de temas integrado e substituição rápida de módulos.
+
+Consulte a documentação para mais detalhes:
+
+- [Como implantar o VitePress JavaScript Boilerplate](/pt-br/documentacao/produtos/guias/vitepress-javascript-boilerplate/)
+- [Como implantar o VitePress TyeScript Boilerplate](/pt-br/documentacao/produtos/guias/vitepress-typescript-boilerplate/)
+
+---
+
 ## 10 de julho, 2024
 
 ### Marketplace 


### PR DESCRIPTION
### Related issue:

[EDU-4911] 

### Changes

- Add item to Release Notes: VitePress templates launch.

### Additional links

n/a.

[EDU-4911]: https://aziontech.atlassian.net/browse/EDU-4911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ