### PR TITLE
fix: github contribute menu typo

### DIFF
--- a/src/components/RightSidebar/ContributeMenu.astro
+++ b/src/components/RightSidebar/ContributeMenu.astro
@@ -17,7 +17,7 @@ const isTranslatable = (lang === 'en' || isFallback) && i18nReady;
 <div class="flex flex-col gap-2">
 	<p class="text-base">
 		<strong class="font-medium">
-			Github
+			GitHub
 		</strong>
 	</p>
 	<EditButton editHref={editHref} />


### PR DESCRIPTION
Typo: Github > GitHub