### PR TITLE
[EDU-4900] feature: add Docusaurus JavaScript Boilerplate guide

### DIFF
--- a/src/content/docs/en/pages/guides/index.mdx
+++ b/src/content/docs/en/pages/guides/index.mdx
@@ -74,6 +74,8 @@ permalink: /documentation/products/guides/
 - [How to deploy edge applications with the Vue Boilerplate](/en/documentation/products/guides/vue-boilerplate/)
 - [How to deploy edge applications with the Vue3/Vite Boilerplate](/en/documentation/products/guides/vue-vite-boilerplate/)
 - [How to deploy the Azion Starter Kit](/en/documentation/products/guides/azion-starter-kit/)
+- [How to deploy the Docusaurus JavaScript Boilerplate](/en/documentation/products/guides/docusaurus-javascript-boilerplate/)
+- [How to deploy the Docusaurus TypeScript Boilerplate](/en/documentation/products/guides/docusaurus-typescript-boilerplate/)
 - [How to deploy the Dynamic and Static File Optimization template](/en/documentation/products/guides/dynamic-and-static-file-optimization-template/)
 - [How to deploy the Edge Application Proxy template](/en/documentation/products/guides/edge-application-proxy-template/)
 - [How to deploy the Fauna Boilerplate](/en/documentation/products/guides/fauna-template/)

--- a/src/content/docs/en/pages/guides/marketplace/templates/docusaurus-javascript-boilerplate.mdx
+++ b/src/content/docs/en/pages/guides/marketplace/templates/docusaurus-javascript-boilerplate.mdx
@@ -12,7 +12,7 @@ import Tag from 'primevue/tag';
 Preview
 </Tag>
 
-**Docusaurus JavaScript Boilerplate** is a starter example to deploy a basic static project based on the Docusaurus framework and written in Javascript.
+**Docusaurus JavaScript Boilerplate** is a starter example to deploy a basic static project based on the Docusaurus framework and written in JavaScript.
 
 Docusaurus is a static-site generator, building a single-page application with fast client-side navigation and leveraging React to make the site interactive. It's ideal for documentation features and other cases, including website, product pages, blog, and landing pages.
 

--- a/src/content/docs/en/pages/guides/marketplace/templates/docusaurus-javascript-boilerplate.mdx
+++ b/src/content/docs/en/pages/guides/marketplace/templates/docusaurus-javascript-boilerplate.mdx
@@ -1,0 +1,94 @@
+---
+title: How to deploy the Docusaurus JavaScript Boilerplate
+description: This template is written in JavaScript using the Docusaurus framework, a static-site generator.
+meta_tags: templates, guides, Azion Marketplace, Docusaurus, React, Jamstack, JavaScript
+namespace: docs_guides_docusaurus_javascript_boilerplate
+permalink: /documentation/products/guides/docusaurus-javascript-boilerplate/
+---
+
+import Tag from 'primevue/tag';
+
+<Tag severity="info" client:only="vue">
+Preview
+</Tag>
+
+**Docusaurus JavaScript Boilerplate** is a starter example to deploy a basic static project based on the Docusaurus framework and written in Javascript.
+
+Docusaurus is a static-site generator, building a single-page application with fast client-side navigation and leveraging React to make the site interactive. It's ideal for documentation features and other cases, including website, product pages, blog, and landing pages.
+
+The deployment of this template creates a GitHub repository containing your project, as well as an edge application and a domain to facilitate your access and management through Azion Edge Platform.
+
+This template uses `Docusaurus 3`.
+
+---
+
+## Requirements
+
+- A [GitHub account](https://github.com/signup) to connect with Azion and create your new repository.
+  - Every push will be deployed automatically to the main branch in this repository to keep your project updated.
+- Enable [Application Accelerator](/en/documentation/products/build/edge-application/application-accelerator/) in your account. 
+    - To do so, go to the [Billing & Subscriptions](/en/documentation/products/guides/billing-and-subscriptions/#subscriptions) section and activate the switch for each module.
+    - If this module isn't activated, the execution will fail and a log explaining the reason will be printed.
+    - If this module is activated, deploying this template could generate usage-related costs. Check the [pricing page](/en/documentation/products/pricing/) for more information.
+
+---
+
+## Getting the template
+
+To start using the **Docusaurus JavaScript Boilerplate**:
+
+1. Access [Console](https://console.azion.com).
+2. Click the **+ Create** button on the homepage.
+3. In the modal, select the **Templates** option. 
+4. Browse and select the **Docusaurus JavaScript Boilerplate** card.
+
+---
+
+## Setting up the template
+
+In the configuration form, you must provide the information to configure your application. Fill in the presented fields. 
+
+Fields identified with an asterisk are mandatory.
+
+1. Connect Azion with your GitHub account.
+- A pop-up window will open to confirm the installation of the [Azion GitHub App](/en/documentation/products/guides/azion-github-app/), a tool that connects your GitHub account with Azion's platform.
+- Define your permissions and repository access as desired.
+2. Select the **Git Scope** to work with.
+3. Define a name for your edge application.
+- The bucket for storage will use the same name.
+- Use a unique and easy-to-remember name. If the name has already been used, the platform returns an error message.
+4. Click the **Deploy** button to start the deployment process.
+
+During the deployment, you'll be able to follow the process through a window showing off the logs. When it's complete, the page shows information about the application and some options to continue your journey.
+
+:::note
+The link to the edge application allows you to see it on the browser. However, it takes a certain time to propagate and configure the application in Azion's edge locations. It may be necessary to wait a few minutes for the URL to be activated and for the application page to be effectively displayed in the browser.
+:::
+
+---
+
+## Managing the template
+
+Considering that this initial setup may not be optimal for your specific edge application, all settings can be customized any time you need by using Azion's platform.
+
+To manage and edit your edge application's settings, follow these steps:
+
+1. [Access Azion Console](https://console.azion.com).
+2. On the upper-left corner, select **Products menu** > **Edge Application**.
+- You'll be redirected to the **Edge Application** page. It lists all the edge applications you've created.
+3. Find the edge application related to your template and select it.
+- The list is organized alphabetically. You can also use the **search bar** located in the upper-left corner of the list; currently, it filters only by **Application Name**.
+
+After selecting the edge application you'll work on, you'll be directed to a page containing all the settings you can configure.
+
+:::tip
+Read the documentation about [managing edge applications](/en/documentation/products/build/edge-application/first-steps/) for more details.
+:::
+
+### Adding a custom domain
+
+The edge application created during the deployment has an assigned Azion domain to make it accessible through the browser. The domain has the following format: `xxxxxxxxxx.map.azionedge.net/`. However, you can add a custom domain for users to access your edge application through it.
+
+import LinkButton from '@aziontech/webkit/linkbutton';
+
+<LinkButton link="/en/documentation/products/guides/configure-a-domain/" label="Go to configuring a domain guide" outlined /> 

--- a/src/content/docs/en/pages/main-menu/additional-resources/templates-and-integrations/understand-azion-templates.mdx
+++ b/src/content/docs/en/pages/main-menu/additional-resources/templates-and-integrations/understand-azion-templates.mdx
@@ -121,13 +121,25 @@ The Azion Astro Boilerplate encapsulates and automates several steps, from repos
 <LinkButton link="/en/documentation/products/guides/azion-starter-kit/" label="go to the Azion Starter Kit guide" outlined /> 
 
 
+#### Docusaurus JavaScript Boilerplate
+
+**Docusaurus JavaScript Boilerplate** is a starter example to deploy a basic static project based on the Docusaurus framework and written in JavaScript.
+
+<LinkButton link="/en/documentation/products/guides/docusaurus-javascript-boilerplate/" label="go to the Docusaurus JavaScript Boilerplate guide" outlined /> 
+
+
+#### Docusaurus TypeScript Boilerplate
+
+**Docusaurus TypeScript Boilerplate** is a starter example to deploy a basic static project based on the Docusaurus framework and written in TypeScript.
+
+<LinkButton link="/en/documentation/products/guides/docusaurus-typescript-boilerplate/" label="go to the Docusaurus TypeScript Boilerplate guide" outlined /> 
+
 
 #### Gatsby Blog Starter Kit
 
 This template contains the configurations to create a new blog page based on the Gatsby framework. After the deployment, you can interact with the default posts and interface that already exist in this template and customize them.
 
 <LinkButton link="/en/documentation/products/guides/gatsby-blog-starter-kit/" label="go to the Gatsby Blog Starter Kit guide" outlined /> 
-
 
 
 #### Gatsby Boilerplate 

--- a/src/content/docs/pt-br/pages/guias/guides.mdx
+++ b/src/content/docs/pt-br/pages/guias/guides.mdx
@@ -77,6 +77,8 @@ permalink: /documentacao/produtos/guias/
 - [Como criar um website WordPress do zero com WordPress InstaCreator](/pt-br/documentacao/produtos/guias/wordpress-instacreator/)
 - [Como implantar e testar o HTMX no edge usando um template](/pt-br/documentacao/produtos/guias/htmx-boilerplate/)
 - [Como implantar o Azion Starter Kit](/pt-br/documentacao/produtos/guias/azion-starter-kit/)
+- [Como implantar o Docusaurus JavaScript Boilerplate](/pt-br/documentacao/produtos/guias/docusaurus-javascript-boilerplate/)
+- [Como implantar o Docusaurus TypeScript Boilerplate](/pt-br/documentacao/produtos/guias/docusaurus-typescript-boilerplate/)]
 - [Como implantar o Fauna Boilerplate](/pt-br/documentacao/produtos/guias/fauna-template/)
 - [Como implantar o Hugo Boilerplate](/pt-br/documentacao/produtos/guias/hugo-boilerplate/)
 - [Como implantar o Jekyll Boilerplate](/pt-br/documentacao/produtos/guias/jekyll-boilerplate/)

--- a/src/content/docs/pt-br/pages/guias/marketplace/templates/docusaurus-javascript-boilerplate.mdx
+++ b/src/content/docs/pt-br/pages/guias/marketplace/templates/docusaurus-javascript-boilerplate.mdx
@@ -1,0 +1,94 @@
+---
+title: Como implantar o Docusaurus JavaScript Boilerplate
+description: Este template está escrito em JavaScript usando o framework Docusaurus, um gerador de sites estáticos.
+meta_tags: templates, guias, Azion Marketplace, Docusaurus, React, Jamstack, JavaScript
+namespace: docs_guides_docusaurus_javascript_boilerplate
+permalink: /documentacao/produtos/guias/docusaurus-javascript-boilerplate/
+---
+
+import Tag from 'primevue/tag';
+
+<Tag severity="info" client:only="vue">
+Preview
+</Tag>
+
+O **Docusaurus JavaScript Boilerplate** é um exemplo inicial para implantar um projeto estático básico baseado no framework Docusaurus e escrito em Javascript.
+
+O Docusaurus é um gerador de sites estáticos, que constrói uma single-page application (SPA) com navegação rápida do lado do cliente e aproveita o React para tornar o site interativo. É ideal para recursos de documentação e outros casos, incluindo sites, páginas de produtos, blogs e páginas de destino.
+
+A implantação deste template cria um repositório no GitHub contendo seu projeto, bem como uma edge application e um domínio para facilitar seu acesso e gerenciamento através da Plataforma de Edge da Azion.
+
+Este template usa o `Docusaurus 3`.
+
+---
+
+## Pré-requisitos
+
+- Uma [conta no GitHub](https://github.com/signup) para conectar com a Azion e criar seu novo repositório.
+  - Cada push será implantado automaticamente neste repositório para manter seu projeto atualizado.
+- Habilitar o [Application Accelerator](/pt-br/documentacao/produtos/build/edge-application/application-accelerator/) na sua conta.
+    - Para fazer isso, vá para a seção [Billing & Subscriptions](/pt-br/documentacao/produtos/guias/billing-and-subscriptions/) e ative o interruptor para cada módulo.
+    - Se este módulo não estiver ativado, a execução falhará e um log explicando o motivo será mostrado.
+    - Se este módulo estiver ativado, implantar este template pode gerar custos relacionados ao uso. Consulte a [página de preços](/pt-br/documentacao/produtos/precos/) para mais informações.
+
+---
+
+## Obtenha o template
+
+Para começar a usar o **Docusaurus JavaScript Boilerplate**:
+
+1. Acesse o [Azion Console](/pt-br/documentacao/produtos/guias/como-acessar-o-rtm/).
+2. Clique no botão **+ Create** na página inicial.
+3. No modal, selecione a opção **Templates**.
+4. Navegue e selecione o card do **Docusaurus JavaScript Boilerplate**.
+
+---
+
+## Configure o template
+
+No formulário de configuração, forneça as informações para configurar sua aplicação. Preencha os campos apresentados.
+
+Os campos identificados com asterisco são obrigatórios.
+
+1. Conecte a Azion com sua conta no GitHub.
+- Uma janela pop-up será aberta para confirmar a instalação da [Azion GitHub App](/pt-br/documentacao/produtos/guias/azion-github-app/), uma ferramenta que conecta sua conta do GitHub com a plataforma da Azion.
+- Defina suas permissões e acesso ao repositório conforme desejado.
+2. Selecione o **Git Scope** com o qual trabalhar.
+3. Defina um nome para sua edge application.
+- O bucket para armazenamento usará o mesmo nome.
+- Use um nome único e fácil de lembrar. Se o nome já tiver sido usado, a plataforma retornará uma mensagem de erro.
+4. Clique no botão **Deploy** para iniciar o processo de implantação.
+
+Durante a implantação, você poderá acompanhar o processo através de uma janela mostrando os logs. Quando estiver concluída, a página mostra informações sobre a aplicação e algumas opções para continuar sua jornada.
+
+:::note
+O link para sua edge application permite que você veja como ela fica no navegador. No entanto, leva um certo tempo para propagar e configurá-la nas edge locations da Azion. Pode ser necessário aguardar alguns minutos para que a URL seja ativada e para que a página da aplicação seja efetivamente exibida no navegador.
+:::
+
+---
+
+## Gerencie o template
+
+Considerando que essa configuração inicial pode não ser ideal para sua aplicação, todas as configurações podem ser personalizadas sempre que você precisar usando o Azion Console.
+
+Para gerenciar e editar as configurações da sua aplicação, siga estas etapas:
+
+1. [Acesse o Azion Console](https://console.azion.com).
+2. No canto superior esquerdo, selecione **Products menu** > **Edge Application**.
+- Você será redirecionado para a página de **Edge Application**. Ela lista todas as edge applications que você criou.
+3. Encontre a edge application relacionada ao template e selecione-a.
+- A lista é organizada em ordem alfabética. Você também pode usar a **barra de busca** localizada no canto superior esquerdo da lista; atualmente, ela é filtrada apenas pelo **Application Name**, ou nome da edge application.
+
+Depois de selecionar a aplicação em que você trabalhará, você será direcionado para uma página que contém todas as configurações que você pode configurar.
+
+:::tip
+Leia a documentação sobre o [gerenciamento de edge applications](/pt-br/documentacao/produtos/build/edge-application/primeiros-passos/) para obter mais detalhes.
+:::
+
+### Adicione um domínio personalizado
+
+A edge application criada tem um domínio Azion atribuído para torná-la acessível através do navegador. O domínio tem o seguinte formato: `xxxxxxxxxx.map.azionedge.net/`. No entanto, você pode adicionar um domínio personalizado para que os usuários acessem sua aplicação por meio dele.
+
+import LinkButton from '@aziontech/webkit/linkbutton';
+
+<LinkButton link="/pt-br/documentacao/produtos/guias/configurar-dominio/" label="Consulte o guia para configurar domínios" outlined /> 

--- a/src/content/docs/pt-br/pages/guias/marketplace/templates/docusaurus-javascript-boilerplate.mdx
+++ b/src/content/docs/pt-br/pages/guias/marketplace/templates/docusaurus-javascript-boilerplate.mdx
@@ -12,7 +12,7 @@ import Tag from 'primevue/tag';
 Preview
 </Tag>
 
-O **Docusaurus JavaScript Boilerplate** é um exemplo inicial para implantar um projeto estático básico baseado no framework Docusaurus e escrito em Javascript.
+O **Docusaurus JavaScript Boilerplate** é um exemplo inicial para implantar um projeto estático básico baseado no framework Docusaurus e escrito em JavaScript.
 
 O Docusaurus é um gerador de sites estáticos, que constrói uma single-page application (SPA) com navegação rápida do lado do cliente e aproveita o React para tornar o site interativo. É ideal para recursos de documentação e outros casos, incluindo sites, páginas de produtos, blogs e páginas de destino.
 

--- a/src/content/docs/pt-br/pages/menu-principal/recursos-adicionais/templates-e-integracoes/templates-visao-geral.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/recursos-adicionais/templates-e-integracoes/templates-visao-geral.mdx
@@ -121,6 +121,19 @@ O **Astro Boilerplate** da Azion encapsula e automatiza várias etapas, desde o 
 <LinkButton link="/pt-br/documentacao/produtos/guias/azion-starter-kit/" label="consulte o guia do Azion Starter Kit" outlined /> 
 
 
+#### Docusaurus JavaScript Boilerplate
+
+O **Docusaurus JavaScript Boilerplate** é um exemplo inicial para implantar um projeto estático básico baseado no framework Docusaurus e escrito em JavaScript.
+
+<LinkButton link="/pt-br/documentacao/produtos/guias/docusaurus-javascript-boilerplate/" label="consulte o guia do Docusaurus JavaScript Boilerplate" outlined /> 
+
+
+#### Docusaurus TypeScript Boilerplate
+
+O **Docusaurus TypeScript Boilerplate** é um exemplo inicial para implantar um projeto estático básico baseado no framework Docusaurus e escrito em TypeScript.
+
+<LinkButton link="/pt-br/documentacao/produtos/guias/docusaurus-typescript-boilerplate/" label="consulte o guia do Docusaurus TypeScript Boilerplate" outlined /> 
+
 
 #### Gatsby Blog Starter Kit
 


### PR DESCRIPTION
### Related issue: 

[EDU-4900]

### Changes

- add Docusaurus JavaScript Boilerplate guide (EN-PT).
- Add links to the Guides page and Templates reference (EN-PT / JavaScript-TypeScript)

### Additional links

https://github.com/aziontech/docs/pull/1107

[EDU-4900]: https://aziontech.atlassian.net/browse/EDU-4900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ