### PR TITLE
[EDU-2917] refactor: PT - review and refine Rules Engine for Edge Firewall reference

### DIFF
--- a/src/content/docs/pt-br/pages/menu-principal/referencia/build/edge-application/rules-engine-edge-app.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/referencia/build/edge-application/rules-engine-edge-app.mdx
@@ -12,7 +12,7 @@ import RulesExecution from '~/includes/snippets/RulesEngineExecution/pt/snippet.
 
 O **Rules Engine** é uma funcionalidade do **Edge Application** controla a execução de comportamentos através de operadores lógicos. Através do Rules Engine, você pode construir uma arquitetura que proporciona melhor performance para seus usuários consumindo menos recursos e processando na origem.
 
-Cada requisição de uma aplicação criada com o Azion [Azion Console](https://console.azion.com) é processada numa sequência fixa de duas fases: 
+Cada requisição de uma aplicação criada com o [Azion Console](https://console.azion.com/) é processada numa sequência fixa de duas fases: 
 
 1. **Request Phase**: ocorre quando um usuário submete uma requisição à edge application.
 2. **Response Phase**: ocorre quando um usuário recebe uma resposta da edge application.
@@ -54,6 +54,12 @@ Na **Response Phase**, sua aplicação trata do conteúdo que será entregue a s
 
 ---
 
+## Nome
+
+Cada regra deve ter um nome único e fácil de lembrar, permitindo que você a referencie e gerencie facilmente dentro do seu sistema.
+
+---
+
 ### Descrição
 
 Além do nome da regra, você pode adicionar uma descrição para ela usando o campo **Description**. Sua descrição ficará visível na lista de regras e pode ser usada para identificar o que a regra faz.
@@ -64,9 +70,10 @@ Além do nome da regra, você pode adicionar uma descrição para ela usando o c
 
 A seção **Criteria** do **Rules Engine** é onde você define os critérios para a execução da regra. Critérios são compostos de:
 
-- variáveis
-- operadores de comparação
-- argumentos, quando aplicável
+- Variáveis
+- Operadores de comparação
+- Operadores lógicos
+- Argumentos, quando aplicável
 
 A inclusão de argumentos em um critério depende dos operadores de comparação escolhidos, e seus formatos estão descritos nas seções [variáveis](#variaveis) e [operadores de comparação](#operadores-de-comparacao). [Operadores lógicos](#operadores-logicos) servem para incrementar a quantidade de comparações que a regra irá executar.
 
@@ -76,9 +83,7 @@ Por exemplo, o seguinte critério identifica se um usuário está usando um nave
 | --- | ---- | --- | --- |
 | If | `${http_user_agent}` | *matches* | `(Chrome\|Mozilla)` |
 
----
-
-## Variáveis
+### Variáveis
 
 Confira a lista completa de variáveis disponíveis e sua fase de processamento:
 
@@ -167,9 +172,7 @@ A Azion também disponibiliza variáveis especiais que agem como funções e lev
 | `${cookie_time_offset(number)}` | Retorna a data atual acrescida de um offset em segundos, informado como argumento, para ser utilizado na definição do tempo de expiração de um cookie | Utilize o behavior *Add Response Cookie* com o argumento `cookie-name=cookie-value; Expires=${cookie_time_offset(3600)}` para determinar o TTL do cookie expire em 1 hora a partir do momento que for criado |
 | `${encode_base64(string)}` | Retorna o argumento codificado em base64 | `${encode_base64 (www.domain.com)}` assume `d3d3LmRvbWFpbi5jb20K` |
 
----
-
-## Operadores de comparação
+### Operadores de comparação
 
 | Operador | Descrição | Tipo de argumento |
 | --- | --- | --- |
@@ -182,13 +185,19 @@ A Azion também disponibiliza variáveis especiais que agem como funções e lev
 | exists | A variável tem valor definido. Exemplo: `${arg_search}` existe se foi enviado um argumento *search* na query string da requisição | - |
 | does not exist | A variável não tem valor definido. Exemplo: `${arg_search}` não existe se não foi enviado um argumento *search* na query string da requisição | - |
 
----
+:::note
+Esses operadores podem variar de acordo com os Critérios selecionados.
+:::
 
-## Operadores lógicos
+### Operadores lógicos
 
-Múltiplos critérios podem ser adicionados por meio dos operadores lógicos **AND** e **OR**. Com isso, cada regra pode conter até 10 critérios.
+Múltiplos critérios podem ser adicionados por meio dos operadores lógicos `And` e `Or`. Com isso, cada regra pode conter até 10 critérios.
 
-O operador **AND** tem precedência implícita sobre o operador **OR**. Se for necessária precedência explícita, você pode adicionar múltiplos grupos de critérios apenas sob a lógica **AND**.
+:::note
+O operador **AND** tem precedência implícita sobre o operador **OR**.
+:::
+
+Se for necessária precedência explícita, você pode adicionar múltiplos grupos de critérios apenas sob a lógica **AND**.
 
 ---
 
@@ -468,6 +477,3 @@ Estes são os **limites default**:
 | Criteria por regra | 5 |
 | Behaviors por regra | 10 |
 | Variables por criteria | 10 |
-
----
-

--- a/src/content/docs/pt-br/pages/menu-principal/referencia/build/edge-application/rules-engine-edge-app.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/referencia/build/edge-application/rules-engine-edge-app.mdx
@@ -60,7 +60,7 @@ Cada regra deve ter um nome único e fácil de lembrar, permitindo que você a r
 
 ---
 
-### Descrição
+## Descrição
 
 Além do nome da regra, você pode adicionar uma descrição para ela usando o campo **Description**. Sua descrição ficará visível na lista de regras e pode ser usada para identificar o que a regra faz.
 

--- a/src/content/docs/pt-br/pages/menu-principal/referencia/secure/edge-firewall/rules-engine-edge-firewall.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/referencia/secure/edge-firewall/rules-engine-edge-firewall.mdx
@@ -130,7 +130,7 @@ A condição para a execução de uma regra deve ser a comparação de uma vari�
 Esses operadores podem variar de acordo com a Criteria selecionada.
 :::
 
-#### Operadores Lógicos
+### Operadores lógicos
 
 Múltiplas critérios podem ser definidos por meio dos operadores lógicos `And` e `Or`. 
 
@@ -202,6 +202,6 @@ Permite uma resposta personalizada quando a requisição atende aos critérios. 
 
 ---
 
-## Depuração de regras
+## Debug de regras 
 
 Você pode [depurar regras criadas com o Rules Engine para Edge Firewall](/pt-br/documentacao/produtos/guias/debug-regras/) através da GraphQL API, Data Stream ou Real-Time Events.

--- a/src/content/docs/pt-br/pages/menu-principal/referencia/secure/edge-firewall/rules-engine-edge-firewall.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/referencia/secure/edge-firewall/rules-engine-edge-firewall.mdx
@@ -8,10 +8,11 @@ permalink: /documentacao/produtos/secure/edge-firewall/rules-engine/
 
 import LinkButton from '@aziontech/webkit/linkbutton'
 import RulesExecution from '~/includes/snippets/RulesEngineExecution/pt/snippet.mdx'
+import Tag from 'primevue/tag'
 
 **Rules Engine para Edge Firewall** é uma ferramenta projetada para implementação de lógicas de segurança no Edge Firewall. A aba de configurações do Rules Engine aparece dentro de um edge firewall criado.
 
-O Rules Engine para Edge Firewall da Azion é programável. Dessa forma, você define quais são as condições (**Criteria**) e comandos (**Behaviors**). Se as Criteria forem atendidas, os Behaviors serão executados.
+O Rules Engine para Edge Firewall da Azion é programável. Dessa forma, você define quais são as condições (**Criteria**) e ações (**Behaviors**). Se as Criteria forem atendidas, os Behaviors serão executados.
 
 Você pode usar o Rules Engine para Edge Firewall para configurar todos os aspectos operacionais dos firewalls de suas edge applications. Aqui estão alguns exemplos de implementações para as quais você pode utilizá-lo:
 
@@ -24,9 +25,20 @@ Você pode usar o Rules Engine para Edge Firewall para configurar todos os aspec
 
 Um edge firewall pode ter quantas regras forem necessárias. Essas regras também são intercambiáveis, e você pode compartilhar a mesma regra com outras configurações de edge firewall.
 
-<LinkButton link="/pt-br/documentacao/produtos/edge-firewall/" label="saiba mais sobre Edge Firewall" severity="secondary" />
+<LinkButton link="/pt-br/documentacao/produtos/edge-firewall/" label="Saiba mais sobre o Edge Firewall" severity="secondary" />
 
-<LinkButton link="/pt-br/documentacao/produtos/guias/secure/trabalhar-com-rules-engine/" label="consulte o guia trabalhar com rules engine" severity="secondary" />
+<LinkButton link="/pt-br/documentacao/produtos/guias/secure/trabalhar-com-rules-engine/" label="Consulte o guia para trabalhar com Rules Engine" severity="secondary" />
+
+## Implementação
+
+| Escopo | Recurso |
+| --- | --- |
+| Proteja sua aplicação | [Como proteger uma aplicação](/pt-br/documentacao/produtos/secure/proteja-aplicacao/) |
+| Configure as main settings | [Como definir as main settings de um edge firewall](/pt-br/documentacao/produtos/guias/secure/edge-firewall-definir-main-settings/) |
+| Crie um WAF rule set | [Como criar um WAF rule set](/pt-br/documentacao/produtos/guias/secure/criar-waf-rule-set/) |
+| Bloqueie endereços IP de exit nodes Tor | [Como bloquear endereços IP de exit nodes Tor](/pt-br/documentacao/produtos/guias/secure/bloquear-redes-tor/) |
+
+---
 
 ## Como funciona o Rules Engine para o Edge Firewall
 
@@ -36,58 +48,83 @@ As regras são compostas por *Criteria*, que representam as condições para exe
 
 O processamento das regras é sequencial e você pode usá-las aliadas a um poderoso conjunto de variáveis e operadores de comparação. Se as condições forem atendidas, os *Behaviors* de cada regra são executados até todas as regras serem processadas.
 
-## Detalhes de um edge firewall
+:::note
+Um edge firewall é composto por vários componentes-chave que definem sua funcionalidade e operação. Ao configurar um edge firewall, você pode definir suas configurações principais, incluindo: um **Nome**, os **Domínios** que serão protegidos pelo firewall e os **Módulos** que serão usados para ampliar a usabilidade do **Rules Engine**, além de habilitar o recurso **Debug Rules**.
 
-Um edge firewall é composto por:
+Depois disso, você poderá adicionar [Functions Instances](/pt-br/documentacao/produtos/secure/edge-firewall/edge-functions-instances/) e regras do **Rules Engine**. Os campos e requisitos para usar o **Rules Engine para Edge Firewall** são explicados nas seções abaixo.
+:::
 
-- Nome identificador.
-- Descrição.
-- Criteria.
-- Behaviors.
-- Active switch, para ativar/desativar sem excluir o edge firewall todo.
+---
 
-### Criteria
+## Nome
 
-As **Criteria** determinam as condições que precisam ser atendidas para a execução dos **Behaviors**. A disponibilidade de Criteria e Behaviors dependem dos módulos de Edge Firewall ativados.
+Cada regra deve ter um nome único e fácil de lembrar, permitindo que você a referencie e gerencie facilmente dentro do seu sistema.
 
-<LinkButton link="/pt-br/documentacao/produtos/edge-firewall/" label="saiba mais sobre Edge Firewall" severity="secondary" />
+---
 
-#### Variáveis disponíveis para Criteria
+## Descrição
+
+Além do nome da regra, você pode adicionar uma descrição para ela usando o campo **Description**. Sua descrição ficará visível na lista de regras e pode ser usada para identificar o que a regra faz.
+
+---
+
+## Criteria
+
+A seção de **Criteria** no **Rules Engine for Edge Firewall** serve para determinar as condições que precisam ser atendidas para a execução dos **Behaviors**. Critérios são compostos de:
+
+- Variáveis
+- Operadores de comparação
+- Operadores lógicos
+- Argumentos, quando aplicável
+
+A inclusão de argumentos em um critério depende dos operadores de comparação escolhidos. O formato dos argumentos é descrito nas seções de [variáveis](#variáveis) e [operadores de comparação](#operadores-de-comparação) abaixo. Você também pode adicionar [operadores lógicos](#operadores-lógicos) para aumentar a quantidade de comparações que a regra irá executar.
+
+Por exemplo, este critério identifica requisições onde o URI começa com uma barra ("/") para que o comportamento definido possa ser aplicado a elas.
+
+| | Variável | Operador de comparação | Argumento |
+| --- | ---- | --- | --- |
+| If | `Request URI` | *starts with* | `/` |
+
+:::note 
+A disponibilidade de certos critérios depende dos módulos de Edge Firewall ativados. Acesse a [referência dos módulos do Edge Firewall](/pt-br/documentacao/produtos/secure/edge-firewall/#sobre-os-modulos-do-edge-firewall) para mais detalhes.
+:::
+
+### Variáveis
 
 Esta é a lista de todas as variáveis de Criteria disponíveis:
 
-| Criteria | Descrição | Requisitos |
-| -------- | --------- | ---------- |
-| Header Accept | Header que informa quais tipos de dado que o cliente aceita como resposta | Web Application Firewall |
-| Header Accept-Encoding | Header que informa quais os tipos de codificação de conteúdo, geralmente algoritmos de compressão, que o cliente aceita como resposta | Web Application Firewall |
-| Header Accept-Language | Header que informa a linguagem esperada | Web Application Firewall |
-| Header Cookie | Header que contém os cookies enviados pelo cliente na requisição para o servidor | Web Application Firewall |
-| Header Origin | Header que informa a origem de uma requisição de acesso *cross-site* ou de uma requisição *preflight*. A origem é uma URI indicando o nome do servidor, sem nenhuma informação de caminho | Web Application Firewall |
-| Header Referer | Header que indica o endereço do documento, ou elemento em um documento, a partir do qual a URI da requisição foi obtida | Web Application Firewall |
-| Header User Agent | Header com uma sequência característica que permite que servidores identifiquem o aplicativo, sistema operacional, fornecedor e/ou versão do dispositivo | Web Application Firewall |
-| Hostname | Em ordem de precedência: o *hostname* da linha de requisição, ou o valor do campo de header *host* da requisição, ou o nome do servidor atendendo a requisição | -                        |
-| Network | O endereço IP do cliente que está realizando a requisição HTTP, que poderá ser utilizado para qualquer comparação de rede (CIDR, ASN ou Country) | Network Layer Protection |
-| Request Args | Todos os argumentos enviados pelo usuário na linha de requisição (*query string*). | Web Application Firewall |
-| Request Method | O método HTTP da requisição. Por exemplo: `GET`, `POST`, `PUT`, etc. | -                       |
-| Request URI | Refere-se à variável `uri` da Rules Engine para Edge Applications. O URI normalizado (urldecoded) da requisição. O valor de `uri` pode mudar durante o processamento de uma requisição, por exemplo, quando ocorre um redirecionamento interno ou quando são utilizados arquivos de índice. Ele não carrega os parâmetros da Query String como `request_uri` faz | -                        |
-| *Scheme* | O scheme da requisição: http ou https  | -                        |
-| Client Certificate Validation | Processo do servidor para autenticar o certificado digital do cliente | - |
-| SSL Verification Status | Resultado do servidor para validação do certificado do cliente. Pode ser `Success`, quando a validação do certificado do cliente foi aprovada; `Certificate Verification Error`, quando o certificado do cliente não era válido; e `Missing Client Certificate`, quando o certificado do cliente não foi enviado na solicitação | - |
+| Criteria | Descrição | Exemplo | Requisitos |
+| -------- | --------- | ---------- | ---------- |
+| Header Accept | Header que informa quais tipos de dado que o cliente aceita como resposta | `application/json` | Web Application Firewall |
+| Header Accept Encoding | Header que informa quais os tipos de codificação de conteúdo, geralmente algoritmos de compressão, que o cliente aceita como resposta | `gzip` | Web Application Firewall |
+| Header Accept Language | Header que informa a linguagem esperada | `en-US` | Web Application Firewall |
+| Header Cookie | Header que contém os cookies enviados pelo cliente na requisição para o servidor | `session_id=abc123` | Web Application Firewall |
+| Header Origin | Header que informa a origem de uma requisição de acesso *cross-site* ou de uma requisição *preflight*. A origem é uma URI indicando o nome do servidor, sem nenhuma informação de caminho | `https://example.com` | Web Application Firewall |
+| Header Referer | Header que indica o endereço do documento, ou elemento em um documento, a partir do qual a URI da requisição foi obtida | `https://example.com/landing-page` | Web Application Firewall |
+| Header User Agent | Header com uma sequência característica que permite que servidores identifiquem o aplicativo, sistema operacional, fornecedor e/ou versão do dispositivo | `Mozilla/5.0` | Web Application Firewall |
+| Host | Em ordem de precedência: o *hostname* da linha de requisição, ou o valor do campo de header *host* da requisição, ou o nome do servidor atendendo a requisição |  `api.example.com` | -                        |
+| Network | O endereço IP do cliente que está realizando a requisição HTTP, que poderá ser utilizado para qualquer comparação de rede (CIDR, ASN ou Country) | `1xx.xxx.x.0` | Network Layer Protection |
+| Request Args | Todos os argumentos enviados pelo usuário na linha de requisição (*query string*) | `page=1` | Web Application Firewall |
+| Request Method | O método HTTP da requisição. Por exemplo: `GET`, `POST`, `PUT`, etc. | `POST` | -                       |
+| Request URI | Refere-se à variável `uri` da Rules Engine para Edge Applications. O URI normalizado (urldecoded) da requisição. O valor de `uri` pode mudar durante o processamento de uma requisição, por exemplo, quando ocorre um redirecionamento interno ou quando são utilizados arquivos de índice. Ele não carrega os parâmetros da Query String como `request_uri` faz | `/api/v1/` | -                        |
+| Scheme | O scheme da requisição: http ou https | `https` | -                        |
+| Client Certificate Validation | Processo do servidor para autenticar o certificado digital do cliente | `true` | - |
+| SSL Verification Status | Resultado do servidor para validação do certificado do cliente. Pode ser `Success`, quando a validação do certificado do cliente foi aprovada; `Certificate Verification Error`, quando o certificado do cliente não era válido; e `Missing Client Certificate`, quando o certificado do cliente não foi enviado na solicitação | `Certificate Verification Error` | - |
 
-#### Operadores de Comparação
+### Operadores de comparação
 
 A condição para a execução de uma regra deve ser a comparação de uma variável com um argumento. Os operadores de comparação são:
 
-| Operador | Descrição | Argumento |
+| Operador | Descrição | Tipo de argumento |
 | -------- | --------- | --------- |
-| is equal | O valor da variável é igual ao argumento, comparado caractere a caractere | string |
-| is not equal | O valor da variável não é exatamente igual ao argumento | string |
-| starts with | O valor da variável inicia pelo argumento | string |
-| does not start with | O valor da variável não inicia pelo argumento | string |
-| matches | O valor da variável coincide com a expressão regular ou lista informada como argumento | regular expression<br />lista |
-| does not match | O valor da variável não coincide com a expressão regular ou lista informada como argumento | regular expression<br />lista |
-| exists | A variável tem valor definido. Por exemplo, Request Args existe se for enviado um argumento na query string da requisição | - |
-| does not exist | A variável não tem valor definido. Por exemplo, Request Args não existe se não for enviado um argumento na query string da requisição | - |
+| is equal | O valor da variável é igual ao argumento, comparado caractere a caractere | String |
+| is not equal | O valor da variável não é exatamente igual ao argumento | String |
+| starts with | O valor da variável inicia pelo argumento | String |
+| does not start with | O valor da variável não inicia pelo argumento | String |
+| matches | O valor da variável coincide com a expressão regular ou lista informada como argumento | Regular expression ou lista |
+| does not match | O valor da variável não coincide com a expressão regular ou lista informada como argumento | Regular expression ou lista |
+| exists | A variável tem valor definido. Por exemplo, `Request Args` existe se for enviado um argumento na query string da requisição | - |
+| does not exist | A variável não tem valor definido. Por exemplo, `Request Args` não existe se não for enviado um argumento na query string da requisição | - |
 
 :::note[nota]
 Esses operadores podem variar de acordo com a Criteria selecionada.
@@ -95,36 +132,69 @@ Esses operadores podem variar de acordo com a Criteria selecionada.
 
 #### Operadores Lógicos
 
-Múltiplas condições podem ser definidas por meio dos operadores lógicos `and` e `or`. 
+Múltiplas critérios podem ser definidos por meio dos operadores lógicos `And` e `Or`. 
 
 :::note[nota]
-O operador `and` tem precedência implícita sobre o operador `or`.
+O operador `And` tem precedência implícita sobre o operador `Or`.
 :::
 
-Se necessária precedência explícita, você pode adicionar múltiplos grupos de critérios sob a lógica `and`.
+Se necessária precedência explícita, você pode adicionar múltiplos grupos de critérios sob a lógica `And`.
 
-### Behaviors
+---
+
+## Behaviors
 
 Em **Behaviors**, você adiciona os comandos de ação que deseja executar se as Criteria forem atendidas.
 
-Está é uma lista de todos os Behaviors disponíveis:
+Por exemplo, este comportamento executa a função especificada, permitindo que você execute lógica personalizada para o tratamento de requisições.
 
-| Behavior | Descrição | Requisitos|
-| -------- | --------- | --------- |
-| Deny (403 Forbidden) | Encerra a requisição com resposta HTTP *403 Forbidden* | - |
-| Drop (Close Without Response) | Encerra a requisição sem responder ao cliente | - |
-| Set Rate Limit | Define um limite de taxa de acesso que, se excedido, resultará em resposta HTTP *429 Too Many Requests*. Para configurar *Rate Limit*, você deverá informar: <br />`Type`, é o campo para selecionar o tipo de requisição do Rate Limit, optando por `Req/s` (requisições por segundo) ou `Req/Min` (requisições por minuto). <br />`Average Rate Limit`, que é a taxa limite por segundo, propriamente dita. <br />`Client IP address`, se você deseja que a contabilização da taxa de acesso seja por endereço `IP do cliente` ou `Global`, caso deseje contabilização total da taxa de acesso. <br />`Maximum burst size`, que indica o tamanho máximo da rajada de requisições HTTP enviadas simultaneamente, as quais serão enfileiradas e despachadas gradualmente, respeitando-se a taxa limite. <br />O valor configurado será o Rate Limit em cada Azion Edge Node, implementado por meio do algoritmo de Leaky Bucket. Recomendamos que você utilize *Maximum burst size* no máximo 10 vezes o valor configurado em *Average Rate Limit*, o que resultaria em penalizar a última requisição de uma rajada com até 10 segundos de atraso. <br /> **Nota**: o Rate Limite é aplicado por endereço de IP ou por Global e por regra, e se uma regra possui *mais de uma URI* especificada e possui o *condicional Or*, o limite de taxa de acesso será compartilhado entre as URIs. Crie diferentes regras se você deseja ter um limite de taxa de acesso para cada URI | - |
-| Set WAF Rule Set | Associa a Rule Set de WAF que deve ser utilizada na requisição. As políticas de WAF devem ser previamente configuradas no menu **Edge Libraries** > **WAF Rules* | Web Application Firewall |
-| Run Function | Executa uma função especificada como parâmetro. A função deve ter sido previamente instanciada e parametrizada na aba Functions para poder ser utilizada | Edge Functions |
-| Set Custom Response | Permite uma resposta personalizada quando a solicitação atende aos critérios. Você pode personalizar o `Status Code` alterando-o de 200 para 499, por exemplo, e o header `Content Type` e o `Content Body` da sua solicitação com no máximo `500` caracteres | - |
+| Behavior | Argumento |
+| --- | ---- |
+| `Run Function` | `<name-of-the-instantiated-function>` |
+
+### Deny (403 Forbidden)
+
+O comportamento encerra a requisição com resposta HTTP *403 Forbidden*. Nenhum argumento é necessário.
+
+### Drop (Close Without Response)
+
+O comportamento encerra a requisição sem responder ao cliente. Nenhum argumento é necessário.
+
+### Set Rate Limit
+
+Define um limite de taxa de acesso que, se excedido, resultará em resposta HTTP *429 Too Many Requests*. Para configurar *Rate Limit*, você deverá informar:
+
+- `Type`, é o campo para selecionar o tipo de requisição do Rate Limit, optando por `Req/s` (requisições por segundo) ou `Req/Min` (requisições por minuto).
+- `Average Rate Limit`, que é a taxa limite por segundo, propriamente dita.
+- `Client IP address`, se você deseja que a contabilização da taxa de acesso seja por endereço `IP do cliente` ou `Global`, caso deseje contabilização total da taxa de acesso.
+- `Maximum burst size`, que indica o tamanho máximo da rajada de requisições HTTP enviadas simultaneamente, as quais serão enfileiradas e despachadas gradualmente, respeitando-se a taxa limite.
+    - O valor configurado será o Rate Limit em cada Azion Edge Node, implementado por meio do algoritmo de Leaky Bucket. Recomendamos que você utilize `Maximum burst size` no máximo 10 vezes o valor configurado em `Average Rate Limit`, o que resultaria em penalizar a última requisição de uma rajada com até 10 segundos de atraso.
+    
+O Rate Limite é aplicado por endereço de IP ou por Global e por regra, e se uma regra possui *mais de uma URI* especificada e possui o *condicional Or*, o limite de taxa de acesso será compartilhado entre as URIs. Crie diferentes regras se você deseja ter um limite de taxa de acesso para cada URI.
 
 :::note[nota]
-`Maximum Burst size` está disponível apenas para o tipo de requisição `Req/s` (requisição por segundo).
+`Maximum Burst size` está disponível apenas para o tipo de requisição `Req/s` (requisições por segundo).
 :::
+
+### Set WAF Rule Set
+
+<Tag severity="info" client:only="vue">Requer WAF</Tag>
+
+Associa a Rule Set de WAF que deve ser utilizada na requisição. As políticas de WAF devem ser previamente configuradas no menu **Edge Libraries** > **WAF Rules*. Você também deve definir o **modo WAF**: **Learning** ou **Blocking**. Leia mais sobre [WAF Rule Sets](/pt-br/documentacao/produtos/secure/edge-firewall/web-application-firewall/rule-sets/).
 
 :::caution[atenção]
 A plataforma da Azion mantém apenas uma configuração do behavior `Set WAF Rule Set` para cada lógica de criteria. Se você tiver dois edge firewall diferentes, configurados com a mesma criteria, mas com behaviors `Set WAF Rule Set` diferentes, apenas o mais recente será processado. Isso pode ser útil caso sua aplicação precise trocar o behavior de `Set WAF Rule Set` constantemente, com base na mesma criteria.
 :::
+
+### Run Function
+
+<Tag severity="info" client:only="vue">Requer Edge Functions</Tag>
+
+Executa uma função especificada como parâmetro. A função deve ter sido previamente instanciada e parametrizada na aba Functions para poder ser utilizada.
+
+### Set Custom Response
+
+Permite uma resposta personalizada quando a requisição atende aos critérios. Você pode personalizar o `Status Code` alterando-o de 200 para 499, por exemplo, e o header `Content Type` e o `Content Body` da sua solicitação com no máximo `500` caracteres.
 
 ### Lógica e execução de behaviors
 
@@ -132,5 +202,6 @@ A plataforma da Azion mantém apenas uma configuração do behavior `Set WAF Rul
 
 ---
 
+## Depuração de regras
 
-
+Você pode [depurar regras criadas com o Rules Engine para Edge Firewall](/pt-br/documentacao/produtos/guias/debug-regras/) através da GraphQL API, Data Stream ou Real-Time Events.


### PR DESCRIPTION
### Related issue: 

[EDU-2917]

### Changes

- Review and refine the Rules Engine for Edge Firewall reference in PT, including adjusting tables, adding examples, and reorganizing h2/h3.
- Minor improvements on the Rules Engine for Edge Application reference to align both files.

### Additional links

https://github.com/aziontech/docs/pull/1097

[EDU-2917]: https://aziontech.atlassian.net/browse/EDU-2917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ