### PR TITLE
[No-issue] fix: broken urls to Docusaurus Material template guide

### DIFF
--- a/src/content/docs/en/pages/main-menu/additional-resources/templates-and-integrations/understand-azion-templates.mdx
+++ b/src/content/docs/en/pages/main-menu/additional-resources/templates-and-integrations/understand-azion-templates.mdx
@@ -124,7 +124,7 @@ The Azion Astro Boilerplate encapsulates and automates several steps, from repos
 
 This template helps you deploy a Docusaurus website integrated with Material UI directly on the edge.
 
-<LinkButton link="/en/documentation/products/guides/documentation/products/guides/docusaurus-material-ui-template/" label="go to the Docusaurus with Material UI guide" severity="secondary" /> 
+<LinkButton link="/en/documentation/products/guides/docusaurus-material-ui-template/" label="go to the Docusaurus with Material UI guide" severity="secondary" /> 
 
 #### Docusaurus JavaScript Boilerplate
 

--- a/src/content/docs/pt-br/pages/menu-principal/release-notes/release-notes.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/release-notes/release-notes.mdx
@@ -17,7 +17,7 @@ import Tag from 'primevue/tag'
 
 A Azion amplia o suporte ao framework Docusaurus com un novo template, cobrindo mais casos de uso:
 
-- O template [Docusaurus with Material UI](/pt-br/documentation/products/guides/docusaurus-material-ui-template/) ajuda você a implantar um site Docusaurus integrado com o Material UI diretamente no edge.
+- O template [Docusaurus with Material UI](/pt-br/documentacao/produtos/guias/docusaurus-material-ui-template/) ajuda você a implantar um site Docusaurus integrado com o Material UI diretamente no edge.
 
 ---
 


### PR DESCRIPTION
### Related issue: 

[No-issue]

### Changes

- Fix broken URLs to the Docusaurus Material template guide: Templates reference (EN) and Release Notes (PT)

### Additional links

n/a.