### PR TITLE
[EDU-5185] fix: update endpoint URL in Lockout Policy guides

### DIFF
--- a/src/content/docs/en/pages/guides/account-lockout-policy/logs-account-lockout-policy.mdx
+++ b/src/content/docs/en/pages/guides/account-lockout-policy/logs-account-lockout-policy.mdx
@@ -28,7 +28,7 @@ If you aren't an *Account Owner* or if the account doesn't have the feature acti
 
 ```bash
 curl --request GET \
-  --url https://api.azion.com/v4/users/?locked=true \
+  --url https://api.azion.com/v4/identity/users/?locked=true \
   --header 'Accept: application/json' \
   --header 'Authorization: 123'
 ```
@@ -63,7 +63,7 @@ Where:
 
 ```bash
 curl --request GET \
-  --url https://api.azion.com/v4/users/?locked=false \
+  --url https://api.azion.com/v4/identity/users/?locked=false \
   --header 'Accept: application/json' \
   --header 'Authorization: 123'
 ```

--- a/src/content/docs/en/pages/guides/account-lockout-policy/logs-account-lockout-policy.mdx
+++ b/src/content/docs/en/pages/guides/account-lockout-policy/logs-account-lockout-policy.mdx
@@ -28,7 +28,7 @@ If you aren't an *Account Owner* or if the account doesn't have the feature acti
 
 ```bash
 curl --request GET \
-  --url https://api.azion.com/v4/identity/users/?locked=true \
+  --url https://api.azion.com/v4/identity/users?locked=true \
   --header 'Accept: application/json' \
   --header 'Authorization: 123'
 ```
@@ -63,7 +63,7 @@ Where:
 
 ```bash
 curl --request GET \
-  --url https://api.azion.com/v4/identity/users/?locked=false \
+  --url https://api.azion.com/v4/identity/users?locked=false \
   --header 'Accept: application/json' \
   --header 'Authorization: 123'
 ```

--- a/src/content/docs/en/pages/guides/account-lockout-policy/unlock-user-account-lockout-policy.mdx
+++ b/src/content/docs/en/pages/guides/account-lockout-policy/unlock-user-account-lockout-policy.mdx
@@ -30,7 +30,7 @@ To manually unlock a user, you need to [get the logs](/en/documentation/products
 
 ```bash
 curl --request GET \
-  --url https://api.azion.com/v4/identity/users/?locked=true \
+  --url https://api.azion.com/v4/identity/users?locked=true \
   --header 'Accept: application/json' \
   --header 'Authorization: 123'
 ```

--- a/src/content/docs/en/pages/guides/account-lockout-policy/unlock-user-account-lockout-policy.mdx
+++ b/src/content/docs/en/pages/guides/account-lockout-policy/unlock-user-account-lockout-policy.mdx
@@ -30,7 +30,7 @@ To manually unlock a user, you need to [get the logs](/en/documentation/products
 
 ```bash
 curl --request GET \
-  --url https://api.azion.com/v4/users/?locked=true \
+  --url https://api.azion.com/v4/identity/users/?locked=true \
   --header 'Accept: application/json' \
   --header 'Authorization: 123'
 ```
@@ -66,7 +66,7 @@ Where:
 
 ```bash
 curl --request DELETE \
-  --url https://api.azion.com/v4/users/{id}/lockout \
+  --url https://api.azion.com/v4/identity/users/{id}/lockout \
   --header 'Accept: application/json' \
   --header 'Authorization: 123' \
   --header 'Content-Type: application/json'

--- a/src/content/docs/pt-br/pages/guias/account-lockout-policy/logs-account-lockout-policy.mdx
+++ b/src/content/docs/pt-br/pages/guias/account-lockout-policy/logs-account-lockout-policy.mdx
@@ -28,7 +28,7 @@ Se você não for um *Account Owner* ou se a conta não tiver o recurso ativado,
 
 ```bash
 curl --request GET \
-  --url https://api.azion.com/v4/users/?locked=true \
+  --url https://api.azion.com/v4/identity/users/?locked=true \
   --header 'Accept: application/json' \
   --header 'Authorization: 123'
 ```
@@ -63,7 +63,7 @@ Onde:
 
 ```bash
 curl --request GET \
-  --url https://api.azion.com/v4/users/?locked=false \
+  --url https://api.azion.com/v4/identity/users/?locked=false \
   --header 'Accept: application/json' \
   --header 'Authorization: 123'
 ```

--- a/src/content/docs/pt-br/pages/guias/account-lockout-policy/logs-account-lockout-policy.mdx
+++ b/src/content/docs/pt-br/pages/guias/account-lockout-policy/logs-account-lockout-policy.mdx
@@ -28,7 +28,7 @@ Se você não for um *Account Owner* ou se a conta não tiver o recurso ativado,
 
 ```bash
 curl --request GET \
-  --url https://api.azion.com/v4/identity/users/?locked=true \
+  --url https://api.azion.com/v4/identity/users?locked=true \
   --header 'Accept: application/json' \
   --header 'Authorization: 123'
 ```
@@ -63,7 +63,7 @@ Onde:
 
 ```bash
 curl --request GET \
-  --url https://api.azion.com/v4/identity/users/?locked=false \
+  --url https://api.azion.com/v4/identity/users?locked=false \
   --header 'Accept: application/json' \
   --header 'Authorization: 123'
 ```

--- a/src/content/docs/pt-br/pages/guias/account-lockout-policy/unlock-user-account-lockout-policy.mdx
+++ b/src/content/docs/pt-br/pages/guias/account-lockout-policy/unlock-user-account-lockout-policy.mdx
@@ -30,7 +30,7 @@ Para desbloquear manualmente um usuário, você precisa [obter os logs](/pt-br/d
 
 ```bash
 curl --request GET \
-  --url https://api.azion.com/v4/users/?locked=true \
+  --url https://api.azion.com/v4/identity/users/?locked=true \
   --header 'Accept: application/json' \
   --header 'Authorization: 123'
 ```
@@ -66,7 +66,7 @@ Onde:
 
 ```bash
 curl --request DELETE \
-  --url https://api.azion.com/v4/users/{id}/lockout \
+  --url https://api.azion.com/v4/identity/users/{id}/lockout \
   --header 'Accept: application/json' \
   --header 'Authorization: 123' \
   --header 'Content-Type: application/json'

--- a/src/content/docs/pt-br/pages/guias/account-lockout-policy/unlock-user-account-lockout-policy.mdx
+++ b/src/content/docs/pt-br/pages/guias/account-lockout-policy/unlock-user-account-lockout-policy.mdx
@@ -30,7 +30,7 @@ Para desbloquear manualmente um usuário, você precisa [obter os logs](/pt-br/d
 
 ```bash
 curl --request GET \
-  --url https://api.azion.com/v4/identity/users/?locked=true \
+  --url https://api.azion.com/v4/identity/users?locked=true \
   --header 'Accept: application/json' \
   --header 'Authorization: 123'
 ```


### PR DESCRIPTION
### Related issue:

[EDU-5185]

### Changes

- Update endpoint URL in the Lockout Policy guides: Unlock and Logs.

### Additional links

n/a.

[EDU-5185]: https://aziontech.atlassian.net/browse/EDU-5185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ