### PR TITLE
[EDU-5223] fix: change azion lib link to npm on devtools menu

### DIFF
--- a/src/i18n/en/devtoolsMenu.ts
+++ b/src/i18n/en/devtoolsMenu.ts
@@ -15,7 +15,7 @@
 	/// START HERE :::: DO NOT REMOVE the strings above, it's a work around for header on mobile /// 
 
 	{ text: 'CLI', header: true, anchor: true, type: 'learn', key: 'devtools/cli', slug: '/documentation/products/azion-cli/overview/', hasLabel:'menu.devTools' },
-	{ text: 'Azion Lib', header: true, anchor: true, type: 'learn', key: 'devtools/azionlib', slug: 'https://github.com/aziontech/lib'},
+	{ text: 'Azion Lib', header: true, anchor: true, type: 'learn', key: 'devtools/azionlib', slug: 'https://www.npmjs.com/package/azion'},
 	{ text: 'API', header: true, anchor: true, type: 'learn', key: 'devtools/api', slug: 'https://api.azion.com/' },
 	{ text: 'API GraphQL', header: true, anchor: true, type: 'learn', slug: '/documentation/devtools/graphql-api/', key: 'devtools/graphQL' },
 	{ text: 'SDK',header: true, anchor: true, type: 'learn', slug: '/documentation/devtools/sdk/go/', key: 'devtools/sdk' },

--- a/src/i18n/pt-br/devtoolsMenu.ts
+++ b/src/i18n/pt-br/devtoolsMenu.ts
@@ -15,7 +15,7 @@
 	/// START HERE :::: DO NOT REMOVE the strings above, it's a work around for header on mobile /// 
 
 	{ text: 'CLI', header: true, anchor: true, type: 'learn', key: 'devtools/cli', slug: 'documentacao/produtos/azion-cli/visao-geral', hasLabel:'menu.devTools' },
-	{ text: 'Azion Lib', header: true, anchor: true, type: 'learn', key: 'devtools/azionlib', slug: 'https://github.com/aziontech/lib' },
+	{ text: 'Azion Lib', header: true, anchor: true, type: 'learn', key: 'devtools/azionlib', slug: 'https://www.npmjs.com/package/azion' },
 	{ text: 'API', header: true, anchor: true, type: 'learn', key: 'devtools/api', slug: 'https://api.azion.com/' },
 	{ text: 'API GraphQL', header: true, anchor: true, type: 'learn', slug: '/documentacao/produtos/graphql-api/', key: 'devtools/graphQL' },
 	{ text: 'SDK',header: true, anchor: true, type: 'learn', slug: '/documentacao/devtools/sdk/go/', key: 'devtools/sdk' },


### PR DESCRIPTION
### Changes

Update link on DevTool menu Azion Lib item, redirecting to the NPM page instead of Github. 
