### PR TITLE
[EDU-5220] fix: remove frameworks section from runtime overview

### DIFF
--- a/src/content/docs/en/pages/devtools/azion-edge-runtime/overview/overview.mdx
+++ b/src/content/docs/en/pages/devtools/azion-edge-runtime/overview/overview.mdx
@@ -27,39 +27,6 @@ With Azion Runtime, you can use a set of **Web APIs**, such as:
 - Standards
 - V8 Primitives
 
-## Jamstack
-
-[Jamstack](https://jamstack.org/) is an approach that separates data and business logic from the web experience layer, improving flexibility, scalability, performance, and maintainability.
-
-You can experience the **Jamstack** architectural approach deploying an application on the Azion Edge Platform.
-
-### Supported frameworks
-
-<Tag severity="info" client:only="vue">
-  Static applications
-</Tag>
-
-- [Angular](/en/documentation/products/cli/frameworks/angular/)
-- [Astro](/en/documentation/products/cli/frameworks/astro/)
-- [Hexo](/en/documentation/products/cli/frameworks/hexo/)
-- [Next.js](/en/documentation/products/cli/frameworks/next/)
-- [React](/en/documentation/products/cli/frameworks/react/)
-- [Vite](/en/documentation/products/cli/frameworks/vite/)
-- [Vue](/en/documentation/products/cli/frameworks/vue/)
-
-<Tag severity="info" client:only="vue">
-  Compute
-</Tag>
-
-- Next.js
-
-<br />
-<LinkButton link="/en/documentation/products/devtools/azion-edge-runtime/frameworks-compatibility/" label="go to supported frameworks reference" severity="secondary" target="_blank" />
-<LinkButton link="/en/documentation/products/edge-application/edge-functions/runtime-apis/javascript/" label="go to supported Web APIs reference" severity="secondary" target="_blank" />
-<LinkButton link="/en/documentation/products/azion-edge-runtime/compatibility/node/" label="go to node.js support reference" severity="secondary" target="_blank" />
-
-
-
 ## Strict mode 
 
 Azion makes strict mode the default and required option for type checking JavaScript code. The Azion core team strongly advocates for strict mode as the sensible default choice. This mode empowers developers with essential JavaScript features that ideally should have been available from the beginning. However, as JavaScript evolved over time, incorporating these features would have introduced breaking changes to existing codebases.

--- a/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/visao-geral/visao-geral-runtime.mdx
+++ b/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/visao-geral/visao-geral-runtime.mdx
@@ -27,33 +27,6 @@ Com o Azion Runtime, você pode usar uma lista de **Web APIs**, como por exemplo
 - Standards
 - V8 Primitives
 
-## Jamstack
-
-[Jamstack](https://jamstack.org/) é uma abordagem que separa os dados e regras de negócio da camada de experiência da web, melhorando a flexibilidade, escalabilidade, performance e manutenção.
-
-Você pode experienciar a abordagem arquitetural **Jamstack** fazendo deploy de uma aplicação na plataforma de Edge da Azion utilizando:
-
-- [Next.js](/pt-br/documentacao/runtime-api/frameworks-suportados/nextjs/)
-
-<Tag severity="info" client:only="vue" value="Static" />
-
-- [Angular](/pt-br/documentacao/produtos/cli/frameworks/angular/)
-- [Astro](/pt-br/documentacao/produtos/cli/frameworks/astro/)
-- [Hexo](/pt-br/documentacao/produtos/cli/frameworks/hexo/)
-- [Next.js](/pt-br/documentacao/produtos/cli/frameworks/next/)
-- [React](/pt-br/documentacao/produtos/cli/frameworks/react/)
-- [Vite](/pt-br/documentacao/produtos/cli/frameworks/vite/)
-- [Vue](/pt-br/documentacao/produtos/cli/frameworks/vue/)
-
-<Tag severity="info" client:only="vue" value="Compute" />
-
-- Next.js
-
-<br />
-<LinkButton link="/pt-br/documentacao/produtos/devtools/azion-edge-runtime/compatibilidade-frameworks/" label="saiba mais sobre os frameworks suportados" severity="secondary" target="_blank" />
-<LinkButton link="/pt-br/documentacao/produtos/edge-application/edge-functions/runtime-apis/javascript/" label="saiba mais sobre as Web APIs suportadas" severity="secondary" target="_blank" />
-<LinkButton link="/pt-br/documentacao/produtos/devtools/azion-edge-runtime/compatibilidade/node/" label="saiba mais sobre o suporte ao Node.js" severity="secondary" target="_blank" />
-
 ## Strict mode
 
 A Azion faz do modo estrito (strict mode) a opção padrão e obrigatória para a verificação de tipos de código JavaScript. A equipe principal da Azion defende veementemente o modo estrito como a escolha sensata padrão. Esse modo capacita os desenvolvedores com recursos essenciais do JavaScript que idealmente deveriam ter sido disponibilizados desde o início. No entanto, à medida que o JavaScript evoluiu ao longo do tempo, incorporar esses recursos teria introduzido breaking changes nas bases de códigos existentes.


### PR DESCRIPTION
### Changes

Remove Jamstack and Frameworks paragraphs on Azion Runtime Overview