### PR TITLE
[EDU-5216] fix: remove bundler paragraph from framework specific overview

### DIFF
--- a/src/content/docs/en/pages/build-journey/develop-with-azion/frameworks/framework-overview.mdx
+++ b/src/content/docs/en/pages/build-journey/develop-with-azion/frameworks/framework-overview.mdx
@@ -23,15 +23,9 @@ This shift not only accelerates website loading times but also enhances security
 
 ---
 
-## Azion Bundler
-
-[Azion Bundler](https://github.com/aziontech/bundler) is a powerful, **open-source** tool designed to streamline the development and deployment of JavaScript applications and frameworks. This powerful **framework adapter** automates polyfills for Edge Computing, significantly simplifying the process of creating Workers, particularly for the Azion platform.
-
-One of the key highlights of Azion Bundler is its ability to establish an intuitive and efficient protocol for facilitating the creation of presets. This makes customization and adaptation to specific project needs even more accessible, providing developers with the necessary flexibility to optimize their applications effectively and efficiently.
-
 ## Azion CLI 
 
-At Azion, you can initialize, build, secure, and deploy edge applications making use of a list of frameworks. It's possible through the combination of Azion Bundler and [Azion CLI](/en/documentation/products/azion-cli/overview/), which
+At Azion, you can initialize, build, secure, and deploy edge applications making use of a list of frameworks. It's possible through the combination of [Azion Bundler](https://github.com/aziontech/bundler) and [Azion CLI](/en/documentation/products/azion-cli/overview/), which
 makes the necessary adaptation for the frameworks to run as they should on the Azion Edge Platform.
 
 The following table brings the frameworks that are adapted to the edge: 

--- a/src/content/docs/pt-br/pages/build-jornada/desenvolva-com-azion/guias-frameworks/framework-overview.mdx
+++ b/src/content/docs/pt-br/pages/build-jornada/desenvolva-com-azion/guias-frameworks/framework-overview.mdx
@@ -19,15 +19,9 @@ A arquitetura **Jamstack** no edge emergiu como um paradigma revolucionário, co
 
 ---
 
-## Azion Bundler
-
-[Azion Bundler](https://github.com/aziontech/bundler) é uma ferramenta **open-source** poderosa projetada para simplificar o desenvolvimento e a implantação de aplicações e frameworks em JavaScript. Esta utilidade automatiza polyfills para edge computing, simplificando significativamente o processo de criação de Workers, especialmente para a plataforma da Azion.
-
-Um dos principais destaques do Azion Bundler é sua capacidade de estabelecer um protocolo intuitivo e eficiente para facilitar a criação de predefinições. Isso torna a personalização e adaptação às necessidades específicas do projeto ainda mais acessíveis, proporcionando aos desenvolvedores a flexibilidade necessária para otimizar suas aplicações de maneira eficaz e eficiente.
-
 ## Azion CLI
 
-Na Azion, você pode inicializar, criar, proteger e implantar edge applications usando uma lista de frameworks. Isso é possível por meio da combinação do Azion Bundler e da [Azion CLI](/pt-br/documentacao/produtos/azion-cli/visao-geral/), que fazem a adaptação necessária para que esses frameworks sejam executados na Plataforma de Edge da Azion.
+Na Azion, você pode inicializar, criar, proteger e implantar edge applications usando uma lista de frameworks. Isso é possível por meio da combinação do [Azion Bundler](https://github.com/aziontech/bundler) e da [Azion CLI](/pt-br/documentacao/produtos/azion-cli/visao-geral/), que fazem a adaptação necessária para que esses frameworks sejam executados na Plataforma de Edge da Azion.
 
 A tabela a seguir apresenta os frameworks que estão adaptadas para o edge:
 


### PR DESCRIPTION
### Changes

Remove Vulcan/Bundler dedicated paragraphs from framework specific overview.