### PR TITLE
[EDU-4913] [EDU-4912] feature: add query connected users data guide

### DIFF
--- a/src/content/docs/en/pages/devtools/api-graphql/features/features.mdx
+++ b/src/content/docs/en/pages/devtools/api-graphql/features/features.mdx
@@ -47,7 +47,7 @@ Four datasets are deprecated and were replaced by other datsets:
 | edgeDnsQueriesMetrics | Query events performed on [Edge DNS](/en/documentation/products/secure/edge-dns/) |
 | imagesProcessedMetrics | Image processing events by [Image Processor](/en/documentation/products/build/edge-application/image-processor/) |
 | tieredCacheMetrics | Request events registered by [Tiered Cache](/en/documentation/products/build/edge-application/tiered-cache/) |
-| connectedUsersMetrics | Query the number of users currently connected to your applications, using [Live Ingest](/en/documentation/products/guides/query-connected-users-data-with-graphql/) |
+| connectedUsersMetrics | Query the number of users connected to your applications, using [Live Ingest](/en/documentation/products/guides/query-connected-users-data-with-graphql/) |
 
 <LinkButton link="/en/documentation/devtools/graphql-api/features/gql-real-time-metrics-fields/" label="see Real-Time Metrics GraphQL API fields descriptions" severity="secondary" />
 

--- a/src/content/docs/en/pages/devtools/api-graphql/features/features.mdx
+++ b/src/content/docs/en/pages/devtools/api-graphql/features/features.mdx
@@ -41,12 +41,13 @@ Four datasets are deprecated and were replaced by other datsets:
 
 | Dataset | Description |
 | ------- | ----------- |
-| dataStreamedMetrics | Sent events of data by [Data Stream](/en/documentation/products/observe/data-stream/) to the clients' endpoint. |
-| edgeFunctionsMetrics | Events executed by [Edge Functions](/en/documentation/products/build/edge-application/edge-functions/). |
-| httpMetrics | Request events registered by [Edge Application](/en/documentation/products/build/edge-application/) and [Edge Firewall](/en/documentation/products/secure/edge-firewall/). |
-| edgeDnsQueriesMetrics | Query events performed on [Edge DNS](/en/documentation/products/secure/edge-dns/). |
-| imagesProcessedMetrics | Image processing events by [Image Processor](/en/documentation/products/build/edge-application/image-processor/). |
-| tieredCacheMetrics | Request events registered by [Tiered Cache](/en/documentation/products/build/edge-application/tiered-cache/). |
+| dataStreamedMetrics | Sent events of data by [Data Stream](/en/documentation/products/observe/data-stream/) to the clients' endpoint |
+| edgeFunctionsMetrics | Events executed by [Edge Functions](/en/documentation/products/build/edge-application/edge-functions/) |
+| httpMetrics | Request events registered by [Edge Application](/en/documentation/products/build/edge-application/) and [Edge Firewall](/en/documentation/products/secure/edge-firewall/) |
+| edgeDnsQueriesMetrics | Query events performed on [Edge DNS](/en/documentation/products/secure/edge-dns/) |
+| imagesProcessedMetrics | Image processing events by [Image Processor](/en/documentation/products/build/edge-application/image-processor/) |
+| tieredCacheMetrics | Request events registered by [Tiered Cache](/en/documentation/products/build/edge-application/tiered-cache/) |
+| connectedUsersMetrics | Query the number of users currently connected to your applications, using [Live Ingest](/en/documentation/products/guides/query-connected-users-data-with-graphql/) |
 
 <LinkButton link="/en/documentation/devtools/graphql-api/features/gql-real-time-metrics-fields/" label="see Real-Time Metrics GraphQL API fields descriptions" severity="secondary" />
 

--- a/src/content/docs/en/pages/devtools/api-graphql/features/metrics-fields.mdx
+++ b/src/content/docs/en/pages/devtools/api-graphql/features/metrics-fields.mdx
@@ -215,6 +215,28 @@ When a field is a result of any kind of calculation, such as a sum, they're cons
 
 ---
 
+## connectedUsersMetrics (Live Ingest)
+
+| Field | Description |
+|----------|----------|
+| ts | A field in the result set representing the timestamp of the data point |
+| host | A field in the result set representing the host from which the data was collected |
+
+:::tip
+You can use other parameters to filter and query more specific data. Read more on [GraphQL API filtering](/en/documentation/devtools/graphql-api/features/#filtering).
+:::
+
+### Calculated fields
+
+When a field is a result of any kind of calculation, such as a sum, they’re considered as *calculated fields*.
+
+| Calculated field | Description |
+|----------|----------|
+| uniqueSessions | A field in the result set representing the number of unique sessions recorded by the host |
+| uniqueSessionsTotal | Total unique sessions calculated among all hosts |
+
+---
+
 ## Deprecated datasets
 
 The following datasets were discontinued. It's recommended to use the [new datasets which replaced them](/en/documentation/devtools/graphql-api/features/#datasets).

--- a/src/content/docs/en/pages/devtools/api-graphql/overview/overview.mdx
+++ b/src/content/docs/en/pages/devtools/api-graphql/overview/overview.mdx
@@ -35,6 +35,7 @@ With the Real-Time Metrics GraphQL API, you can, for example:
 - Get IPs with most requests.
 - See domains with least requests.
 - Analyze quantity of requests by HTTP methods.
+- Consult the number of users currently connected to your live streamings.
 - Find hosts with most requests.
 
 With the Real-Time Events GraphQL API, you can, for example:

--- a/src/content/docs/en/pages/devtools/api-graphql/overview/overview.mdx
+++ b/src/content/docs/en/pages/devtools/api-graphql/overview/overview.mdx
@@ -35,7 +35,7 @@ With the Real-Time Metrics GraphQL API, you can, for example:
 - Get IPs with most requests.
 - See domains with least requests.
 - Analyze quantity of requests by HTTP methods.
-- Consult the number of users currently connected to your live streamings.
+- Consult the number of users connected to your live streamings.
 - Find hosts with most requests.
 
 With the Real-Time Events GraphQL API, you can, for example:

--- a/src/content/docs/en/pages/guides/graphql/connected-users-dataset.mdx
+++ b/src/content/docs/en/pages/guides/graphql/connected-users-dataset.mdx
@@ -1,0 +1,175 @@
+---
+title: How to query Connected Users data with GraphQL API
+description: This guide will explain how to query Connected Used data using the GraphiQL playground.
+meta_tags: graphql, api, query, postman, live ingest, live streaming
+namespace: docs_guides_query_connected_users_graphql
+permalink: /documentation/products/guides/query-connected-users-data-with-graphql/
+---
+
+The **connectedUsers** dataset lets you get real-time aggregated data, provided by Azion Live Ingest, related to the number of users currently connected to your applications with live streamings. This dataset is part of the Real-Time Metrics GraphQL API and is generated from the raw HTTP events, which are populated just for clients with live streaming configurations.
+
+This information can be accessed through the GraphQL API, allowing you to transfer this data to a third-party platform, and enabling you to further analysis and review of user activity and engagement. Additionally, the data is available for up to *2 years*.
+
+This guide will explain how to query Connected Used data using the GraphiQL playground.
+
+:::note
+To retrieve this data, you must be subscribed to [Azion Live Ingest](https://www.azion.com/en/solutions/live-streaming-delivery/) and use the [GraphQL API](https://www.azion.com/en/documentation/devtools/graphql-api/overview/).
+:::
+
+---
+
+## Querying data by host
+
+To query your data by host, proceed as follows:
+
+1. Access the [GraphiQL playground](https://manager.azion.com/metrics/graphql)
+    - You must be logged in to your Azion account. Otherwise, you'll receive an error message.
+2. Send a query following this format:
+
+```bash
+query ConnectedUsers {
+    connectedUsersMetrics(
+        limit: 10000,
+        filter: {
+            tsRange:{
+                begin: "2024-04-10T00:00:00",
+                end: "2024-04-11T00:00:00"
+            }
+        },
+      	 groupBy: [ts,host]
+        orderBy: [ts_DESC]
+    ) {
+        ts,
+	 host,
+        uniqueSessions
+    }
+}
+```
+
+Where:
+
+
+| Field | Description |
+|----------|----------|
+| `limit` | Specifies the maximum number of results to return. System maximum: `10000`   |
+| `filter` | Defines the criteria used to filter the data returned by the query |
+| `tsRange` | A subfield of `filter`. Specifies a time range for filtering data. It includes `begin` and `end` fields to define the start and end timestamps. Format: `"YYYY-MM-DDTHH:mm:ss"`; example: `"2024-04-11T00:00:00"` |
+| `groupBy` | Specifies the fields by which the query results should be grouped. Example: `[ts]` |
+| `orderBy` | Specifies the order in which the results should be returned. Accepted values: `[ts_DESC]`, for descending order, and `[ts_ASC]`, for ascending order |
+| `ts` | A field in the result set representing the timestamp of the data point |
+| `host` | A field in the result set representing the host from which the data was collected |
+| `uniqueSessions` | A field in the result set representing the number of unique sessions recorded by the host |
+
+3. You'll receive a JSON response similar to this: 
+
+```bash
+{
+  "data": {
+    "connectedUsersMetrics": [
+      {
+        "ts": "2024-04-10T00:00:00",
+  "host": "example.net",
+        "uniqueSessions": 120
+      },
+      {
+        "ts": "2024-04-10T00:00:00",
+  "host": "example.net",
+        "uniqueSessions": 175
+      },
+      {
+        "ts": "2024-04-10T00:00:00",
+  "host": "example.net",
+        "uniqueSessions": 136
+      },
+      {
+        "ts": "2024-04-10T00:00:00",
+  "host": "example.net",
+        "uniqueSessions": 100
+      }
+    ]
+  }
+}
+```
+
+Where: 
+
+| Field | Description |
+|----------|----------|
+| `ts` | Timestamp of when the event was created   |
+| `host` | Host information sent on the request line. Stores: hostname from the request line, or hostname from the “Host” request header field, or the server name matching a request  |
+| `uniqueSessions` | Unique sessions calculated for a given host |
+
+---
+
+## Querying total data
+
+To retrieve total values, without filtering by host, you must use the field `uniqueSessionsTotal`:
+
+1. Access the [GraphiQL playground](https://manager.azion.com/metrics/graphql)
+    - You must be logged in to your Azion account. Otherwise, you'll receive an error message.
+2. Send a query following this format:
+
+```bash
+query ConnectedUsers {
+    connectedUsersMetrics(
+        limit: 10000,
+        filter: {
+            tsRange:{
+                begin: "2024-04-10T00:00:00",
+                end: "2024-04-11T00:00:00"
+            }
+        },
+      	 groupBy: [ts]
+        orderBy: [ts_DESC]
+    ) {
+        ts,
+        uniqueSessionsTotal
+    }
+}
+```
+
+Where:
+
+| Field | Description |
+|----------|----------|
+| `limit` | Specifies the maximum number of results to return. System maximum: `10000`   |
+| `filter` | Defines the criteria used to filter the data returned by the query |
+| `tsRange` | A subfield of `filter`. Specifies a time range for filtering data. It includes `begin` and `end` fields to define the start and end timestamps. Format: `"YYYY-MM-DDTHH:mm:ss"`; example: `"2024-04-11T00:00:00"` |
+| `groupBy` | Specifies the fields by which the query results should be grouped. Example: `[ts,host]` |
+| `orderBy` | Specifies the order in which the results should be returned. Accepted values: `[ts_DESC]`, for descending order, and `[ts_ASC]`, for ascending order |
+| `ts` | A field in the result set representing the timestamp of the data point |
+| `uniqueSessionsTotal` | A field in the result set representing the number of unique sessions recorded across all hosts for the specified time range |
+
+3. You'll receive a JSON response similar to this: 
+
+```bash
+{
+  "data": {
+    "connectedUsersMetrics": [
+      {
+        "ts": "2024-04-10T00:00:00",
+        "uniqueSessionsTotal": 169
+      },
+      {
+        "ts": "2024-04-10T00:00:00",
+        "uniqueSessionsTotal": 175
+      },
+      {
+        "ts": "2024-04-10T00:00:00",
+        "uniqueSessionsTotal": 120
+      },
+      {
+        "ts": "2024-04-10T00:00:00",
+        "uniqueSessionsTotal": 100
+      }
+    ]
+  }
+}
+```
+
+Where: 
+
+| Field | Description |
+|----------|----------|
+| `ts` | Timestamp of when the event was created   |
+| `uniqueSessionsTotal` | Total unique sessions calculated among all hosts |

--- a/src/content/docs/en/pages/guides/graphql/connected-users-dataset.mdx
+++ b/src/content/docs/en/pages/guides/graphql/connected-users-dataset.mdx
@@ -4,6 +4,7 @@ description: This guide will explain how to query Connected Used data using the 
 meta_tags: graphql, api, query, postman, live ingest, live streaming
 namespace: docs_guides_query_connected_users_graphql
 permalink: /documentation/products/guides/query-connected-users-data-with-graphql/
+menu_namespace: graphqlMenu
 ---
 
 The **connectedUsers** dataset lets you get real-time aggregated data, provided by Azion Live Ingest, related to the number of users currently connected to your applications with live streamings. This dataset is part of the Real-Time Metrics GraphQL API and is generated from the raw HTTP events, which are populated just for clients with live streaming configurations.

--- a/src/content/docs/en/pages/guides/graphql/connected-users-dataset.mdx
+++ b/src/content/docs/en/pages/guides/graphql/connected-users-dataset.mdx
@@ -7,7 +7,7 @@ permalink: /documentation/products/guides/query-connected-users-data-with-graphq
 menu_namespace: graphqlMenu
 ---
 
-The **connectedUsers** dataset lets you get real-time aggregated data, provided by Azion Live Ingest, related to the number of users currently connected to your applications with live streamings. This dataset is part of the Real-Time Metrics GraphQL API and is generated from the raw HTTP events, which are populated just for clients with live streaming configurations.
+The **connectedUsers** dataset lets you get real-time aggregated data, provided by Azion Live Ingest, related to the number of users connected to your applications with live streamings. This dataset is part of the Real-Time Metrics GraphQL API and is generated from the raw HTTP events, which are populated just for clients with live streaming configurations.
 
 This information can be accessed through the GraphQL API, allowing you to transfer this data to a third-party platform, and enabling you to further analysis and review of user activity and engagement. Additionally, the data is available for up to *2 years*.
 
@@ -55,7 +55,7 @@ Where:
 | `filter` | Defines the criteria used to filter the data returned by the query |
 | `tsRange` | A subfield of `filter`. Specifies a time range for filtering data. It includes `begin` and `end` fields to define the start and end timestamps. Format: `"YYYY-MM-DDTHH:mm:ss"`; example: `"2024-04-11T00:00:00"` |
 | `groupBy` | Specifies the fields by which the query results should be grouped. Example: `[ts]` |
-| `orderBy` | Specifies the order in which the results should be returned. Accepted values: `[ts_DESC]`, for descending order, and `[ts_ASC]`, for ascending order |
+| `orderBy` | Specifies the order in which the results should be returned. Examples: `[ts_DESC]`, for descending order, and `[ts_ASC]`, for ascending order |
 | `ts` | A field in the result set representing the timestamp of the data point |
 | `host` | A field in the result set representing the host from which the data was collected |
 | `uniqueSessions` | A field in the result set representing the number of unique sessions recorded by the host |

--- a/src/content/docs/en/pages/guides/graphql/connected-users-dataset.mdx
+++ b/src/content/docs/en/pages/guides/graphql/connected-users-dataset.mdx
@@ -13,7 +13,7 @@ This information can be accessed through the GraphQL API, allowing you to transf
 This guide will explain how to query Connected Used data using the GraphiQL playground.
 
 :::note
-To retrieve this data, you must be subscribed to [Azion Live Ingest](https://www.azion.com/en/solutions/live-streaming-delivery/) and use the [GraphQL API](https://www.azion.com/en/documentation/devtools/graphql-api/overview/).
+To retrieve this data, you must be subscribed to [Azion Live Ingest](https://www.azion.com/en/solutions/live-streaming-delivery/) and use the [GraphQL API](/en/documentation/devtools/graphql-api/overview/).
 :::
 
 ---
@@ -48,10 +48,9 @@ query ConnectedUsers {
 
 Where:
 
-
 | Field | Description |
 |----------|----------|
-| `limit` | Specifies the maximum number of results to return. System maximum: `10000`   |
+| `limit` | Specifies the maximum number of results to return. System maximum: `10000` |
 | `filter` | Defines the criteria used to filter the data returned by the query |
 | `tsRange` | A subfield of `filter`. Specifies a time range for filtering data. It includes `begin` and `end` fields to define the start and end timestamps. Format: `"YYYY-MM-DDTHH:mm:ss"`; example: `"2024-04-11T00:00:00"` |
 | `groupBy` | Specifies the fields by which the query results should be grouped. Example: `[ts]` |
@@ -95,8 +94,8 @@ Where:
 
 | Field | Description |
 |----------|----------|
-| `ts` | Timestamp of when the event was created   |
-| `host` | Host information sent on the request line. Stores: hostname from the request line, or hostname from the “Host” request header field, or the server name matching a request  |
+| `ts` | Timestamp of when the event was created |
+| `host` | Host information sent on the request line. Stores: hostname from the request line, or hostname from the “Host” request header field, or the server name matching a request |
 | `uniqueSessions` | Unique sessions calculated for a given host |
 
 ---
@@ -132,7 +131,7 @@ Where:
 
 | Field | Description |
 |----------|----------|
-| `limit` | Specifies the maximum number of results to return. System maximum: `10000`   |
+| `limit` | Specifies the maximum number of results to return. System maximum: `10000` |
 | `filter` | Defines the criteria used to filter the data returned by the query |
 | `tsRange` | A subfield of `filter`. Specifies a time range for filtering data. It includes `begin` and `end` fields to define the start and end timestamps. Format: `"YYYY-MM-DDTHH:mm:ss"`; example: `"2024-04-11T00:00:00"` |
 | `groupBy` | Specifies the fields by which the query results should be grouped. Example: `[ts,host]` |
@@ -171,5 +170,5 @@ Where:
 
 | Field | Description |
 |----------|----------|
-| `ts` | Timestamp of when the event was created   |
+| `ts` | Timestamp of when the event was created |
 | `uniqueSessionsTotal` | Total unique sessions calculated among all hosts |

--- a/src/content/docs/en/pages/guides/graphql/connected-users-dataset.mdx
+++ b/src/content/docs/en/pages/guides/graphql/connected-users-dataset.mdx
@@ -1,6 +1,6 @@
 ---
 title: How to query Connected Users data with GraphQL API
-description: This guide will explain how to query Connected Used data using the GraphiQL playground.
+description: This guide will explain how to query Connected Users data using the GraphiQL playground.
 meta_tags: graphql, api, query, postman, live ingest, live streaming
 namespace: docs_guides_query_connected_users_graphql
 permalink: /documentation/products/guides/query-connected-users-data-with-graphql/
@@ -11,7 +11,7 @@ The **connectedUsers** dataset lets you get real-time aggregated data, provided 
 
 This information can be accessed through the GraphQL API, allowing you to transfer this data to a third-party platform, and enabling you to further analysis and review of user activity and engagement. Additionally, the data is available for up to *2 years*.
 
-This guide will explain how to query Connected Used data using the GraphiQL playground.
+This guide will explain how to query Connected Users data using the GraphiQL playground.
 
 :::note
 To retrieve this data, you must be subscribed to [Azion Live Ingest](https://www.azion.com/en/solutions/live-streaming-delivery/) and use the [GraphQL API](/en/documentation/devtools/graphql-api/overview/).

--- a/src/content/docs/en/pages/guides/index.mdx
+++ b/src/content/docs/en/pages/guides/index.mdx
@@ -164,6 +164,7 @@ permalink: /documentation/products/guides/
 - [How to query GraphQL requests on Postman](/en/documentation/products/guides/query-graphql-postman/)
 - [How to query metadata with GraphQL API](/en/documentation/products/guides/graphql-metadata/)
 - [Real-Time Metrics GraphQL API dashboard on Grafana JSON example](/en/documentation/products/real-time-metrics/metrics-dash/)
+- [How to query Connected Users data with GraphQL API](/en/documentation/products/guides/query-connected-users-data-with-graphql/)
 
 ---
 

--- a/src/content/docs/pt-br/pages/devtools/api-graphql/recursos/metrics-campos.mdx
+++ b/src/content/docs/pt-br/pages/devtools/api-graphql/recursos/metrics-campos.mdx
@@ -214,6 +214,28 @@ Quando um campo é o resultado de algum tipo de cálculo, como uma soma, ele é 
 
 ---
 
+## connectedUsersMetrics (Live Ingest)
+
+| Campo | Descrição |
+|----------|----------|
+| ts | Um campo no conjunto de resultados representando o timestamp do ponto de dados |
+| host | Um campo no conjunto de resultados representando o host de onde os dados foram coletados |
+
+:::tip
+Você pode usar outros parâmetros para filtrar e consultar dados mais específicos. Leia mais sobre [filtragem da GraphQL API](/pt-br/documentacao/devtools/graphql-api/recursos/#filtrar).
+:::
+
+### Campos calculados
+
+Quando um campo é o resultado de qualquer tipo de cálculo, como uma soma, eles são considerados como *campos calculados*.
+
+| Campo calculado | Descrição |
+|----------|----------|
+| uniqueSessions | Um campo no conjunto de resultados representando o número de sessões únicas registradas pelo host |
+| uniqueSessionsTotal | Total de sessões únicas calculadas entre todos os hosts |
+
+---
+
 ## Conjuntos de dados descontinuados
 
 Os seguintes conjuntos de dados foram descontinuados. Recomenda-se utilizar os [novos conjuntos que substituiram eles](/pt-br/documentacao/devtools/graphql-api/recursos/).

--- a/src/content/docs/pt-br/pages/devtools/api-graphql/recursos/recursos-gql.mdx
+++ b/src/content/docs/pt-br/pages/devtools/api-graphql/recursos/recursos-gql.mdx
@@ -45,7 +45,7 @@ Quatro conjuntos de dados foram descontinuados e substituiídos por outros:
 | edgeDnsQueriesMetrics | Eventos de consultas realizadas no [Edge DNS](/pt-br/documentacao/produtos/secure/edge-dns/) |
 | imagesProcessedMetrics |  Eventos de processamento de imagens do [Image Processor](/pt-br/documentacao/produtos/build/edge-application/image-processor/) |
 | tieredCacheMetrics | Eventos de requisições registradas pelo [Tiered Cache](/pt-br/documentacao/produtos/build/edge-application/tiered-cache/) |
-| connectedUsersMetrics | Query the number of users currently connected to your applications, using [Live Ingest](/pt-br/documentacao/produtos/guias/query-dados-connected-users-com-graphql/) |
+| connectedUsersMetrics | Consulte o número de usuários conectados às suas aplicações, usando [Live Ingest](/pt-br/documentacao/produtos/guias/query-dados-connected-users-com-graphql/) |
 
 <LinkButton link="/pt-br/documentacao/devtools/graphql-api/recursos/campos-gql-real-time-metrics/" label="veja as descrições dos Campos da API GraphQL do Real⁠-⁠Time Metrics" severity="secondary" />
 

--- a/src/content/docs/pt-br/pages/devtools/api-graphql/recursos/recursos-gql.mdx
+++ b/src/content/docs/pt-br/pages/devtools/api-graphql/recursos/recursos-gql.mdx
@@ -39,12 +39,13 @@ Quatro conjuntos de dados foram descontinuados e substituiídos por outros:
 
 | Conjunto de dados | Descrição |
 | ----------------- | --------- |
-| dataStreamedMetrics | Registros de envio de dados do [Data Stream](/pt-br/documentacao/produtos/observe/data-stream/) para o endpoint do cliente. |
-| edgeFunctionsMetrics | Eventos de execução do [Edge Functions](/pt-br/documentacao/produtos/build/edge-application/edge-functions/). |
-| httpMetrics | Eventos de requisições registradas pelo [Edge Application](/pt-br/documentacao/produtos/build/edge-application/) e [Edge Firewall](/pt-br/documentacao/produtos/secure/edge-firewall/). |
-| idnsQueriesMetrics | Eventos de consultas realizadas no [Edge DNS](/pt-br/documentacao/produtos/secure/edge-dns/). |
-| imagesProcessedMetrics |  Eventos de processamento de imagens do [Image Processor](/pt-br/documentacao/produtos/build/edge-application/image-processor/). |
-| l2CacheMetrics | Eventos de requisições registradas pelo [Tiered Cache](/pt-br/documentacao/produtos/build/edge-application/tiered-cache/). |
+| dataStreamedMetrics | Registros de envio de dados do [Data Stream](/pt-br/documentacao/produtos/observe/data-stream/) para o endpoint do cliente |
+| edgeFunctionsMetrics | Eventos de execução do [Edge Functions](/pt-br/documentacao/produtos/build/edge-application/edge-functions/) |
+| httpMetrics | Eventos de requisições registradas pelo [Edge Application](/pt-br/documentacao/produtos/build/edge-application/) e [Edge Firewall](/pt-br/documentacao/produtos/secure/edge-firewall/) |
+| edgeDnsQueriesMetrics | Eventos de consultas realizadas no [Edge DNS](/pt-br/documentacao/produtos/secure/edge-dns/) |
+| imagesProcessedMetrics |  Eventos de processamento de imagens do [Image Processor](/pt-br/documentacao/produtos/build/edge-application/image-processor/) |
+| tieredCacheMetrics | Eventos de requisições registradas pelo [Tiered Cache](/pt-br/documentacao/produtos/build/edge-application/tiered-cache/) |
+| connectedUsersMetrics | Query the number of users currently connected to your applications, using [Live Ingest](/pt-br/documentacao/produtos/guias/query-dados-connected-users-com-graphql/) |
 
 <LinkButton link="/pt-br/documentacao/devtools/graphql-api/recursos/campos-gql-real-time-metrics/" label="veja as descrições dos Campos da API GraphQL do Real⁠-⁠Time Metrics" severity="secondary" />
 

--- a/src/content/docs/pt-br/pages/devtools/api-graphql/visao-geral/visao-geral-gql.mdx
+++ b/src/content/docs/pt-br/pages/devtools/api-graphql/visao-geral/visao-geral-gql.mdx
@@ -35,6 +35,7 @@ Com a API GraphQL do Real-Time Metrics, você pode, por exemplo:
 - Buscar os IPs com mais requisições.
 - Ver os domínios com menos requisições.
 - Analisar a quantidade de requisições por método HTTP.
+- Consulte o número de usuários atualmente conectados às suas transmissões ao vivo.
 - Encontrar os hosts com mais requisições.
 
 Com a API GraphQL do Real-Time Events, você pode, por exemplo:

--- a/src/content/docs/pt-br/pages/devtools/api-graphql/visao-geral/visao-geral-gql.mdx
+++ b/src/content/docs/pt-br/pages/devtools/api-graphql/visao-geral/visao-geral-gql.mdx
@@ -35,7 +35,7 @@ Com a API GraphQL do Real-Time Metrics, você pode, por exemplo:
 - Buscar os IPs com mais requisições.
 - Ver os domínios com menos requisições.
 - Analisar a quantidade de requisições por método HTTP.
-- Consulte o número de usuários atualmente conectados às suas transmissões ao vivo.
+- Consulte o número de usuários conectados às suas transmissões ao vivo.
 - Encontrar os hosts com mais requisições.
 
 Com a API GraphQL do Real-Time Events, você pode, por exemplo:

--- a/src/content/docs/pt-br/pages/guias/graphql/connected-users-dataset.mdx
+++ b/src/content/docs/pt-br/pages/guias/graphql/connected-users-dataset.mdx
@@ -13,7 +13,7 @@ Essas informações podem ser acessadas através da GraphQL API, permitindo que 
 Este guia explicará como consultar dados de usuários conectados usando o playground GraphiQL.
 
 :::note
-Para obter esses dados, você deve ter a subscrição do [Live Ingest da Azion](https://www.azion.com/en/solutions/live-streaming-delivery/) e usar a [GraphQL API](/en/documentation/devtools/graphql-api/overview/).
+Para obter esses dados, você deve ter a subscrição do [Live Ingest da Azion](https://www.azion.com/pt-br/solucoes/live-streaming/) e usar a [GraphQL API](/pt-br/documentacao/devtools/graphql-api/visao-geral/).
 :::
 
 ---

--- a/src/content/docs/pt-br/pages/guias/graphql/connected-users-dataset.mdx
+++ b/src/content/docs/pt-br/pages/guias/graphql/connected-users-dataset.mdx
@@ -136,7 +136,7 @@ Onde:
 | `filter` | Define os critérios usados para filtrar os dados retornados pela consulta |
 | `tsRange` | Um subcampo de `filter`. Especifica um intervalo de tempo para filtrar os dados. Inclui os campos `begin` e `end` para definir os timestamps de início e fim. Formato: `"YYYY-MM-DDTHH:mm:ss"`; exemplo: `"2024-04-11T00:00:00"` |
 | `groupBy` | Especifica os campos pelos quais os resultados da consulta devem ser agrupados. Exemplo: `[ts]` |
-| `orderBy` | Especifica a ordem em que os resultados devem ser retornados. Valores aceitos: `[ts_DESC]`, para ordem decrescente, e `[ts_ASC]`, para ordem crescente |
+| `orderBy` | Especifica a ordem em que os resultados devem ser retornados. Exemplo: `[ts_DESC]`, para ordem decrescente, e `[ts_ASC]`, para ordem crescente |
 | `ts` | Um campo no conjunto de resultados representando o timestamp do ponto de dados |
 | `uniqueSessionsTotal` | Um campo no conjunto de resultados representando o número de sessões únicas registradas entre todos os hosts para o intervalo de tempo especificado |
 

--- a/src/content/docs/pt-br/pages/guias/graphql/connected-users-dataset.mdx
+++ b/src/content/docs/pt-br/pages/guias/graphql/connected-users-dataset.mdx
@@ -4,6 +4,7 @@ description: Este guia explicará como consultar dados do dataset connectedUsers
 meta_tags: graphql, api, query, postman, live ingest, live streaming
 namespace: docs_guides_query_connected_users_graphql
 permalink: /documentacao/produtos/guias/query-dados-connected-users-com-graphql/
+menu_namespace: graphqlMenu
 ---
 
 O conjunto de dados **connectedUsers** permite que você obtenha dados agregados em tempo real, fornecidos pelo Live Ingest da Azion, relacionados ao número de usuários atualmente conectados às suas aplicações com transmissões ao vivo. Este conjunto de dados faz parte da GraphQL API do Real-Time Metrics e é gerado a partir dos eventos HTTP brutos, que são populados apenas para clientes com configurações de transmissão ao vivo.

--- a/src/content/docs/pt-br/pages/guias/graphql/connected-users-dataset.mdx
+++ b/src/content/docs/pt-br/pages/guias/graphql/connected-users-dataset.mdx
@@ -7,7 +7,7 @@ permalink: /documentacao/produtos/guias/query-dados-connected-users-com-graphql/
 menu_namespace: graphqlMenu
 ---
 
-O conjunto de dados **connectedUsers** permite que você obtenha dados agregados em tempo real, fornecidos pelo Live Ingest da Azion, relacionados ao número de usuários atualmente conectados às suas aplicações com transmissões ao vivo. Este conjunto de dados faz parte da GraphQL API do Real-Time Metrics e é gerado a partir dos eventos HTTP brutos, que são populados apenas para clientes com configurações de transmissão ao vivo.
+O conjunto de dados **connectedUsers** permite que você obtenha dados agregados em tempo real, fornecidos pelo Live Ingest da Azion, relacionados ao número de usuários conectados às suas aplicações com transmissões ao vivo. Este conjunto de dados faz parte da GraphQL API do Real-Time Metrics e é gerado a partir dos eventos HTTP brutos, que são populados apenas para clientes com configurações de transmissão ao vivo.
 
 Essas informações podem ser acessadas através da GraphQL API, permitindo que você transfira esses dados para uma plataforma de terceiros, possibilitando uma análise e revisão mais aprofundadas da atividade e engajamento dos usuários. Além disso, os dados estão disponíveis por até *2 anos*.
 

--- a/src/content/docs/pt-br/pages/guias/graphql/connected-users-dataset.mdx
+++ b/src/content/docs/pt-br/pages/guias/graphql/connected-users-dataset.mdx
@@ -1,0 +1,174 @@
+---
+title: Como consultar dados de usuários conectados com a GraphQL API
+description: Este guia explicará como consultar dados do dataset connectedUsers usando o playground GraphiQL.
+meta_tags: graphql, api, query, postman, live ingest, live streaming
+namespace: docs_guides_query_connected_users_graphql
+permalink: /documentacao/produtos/guias/query-dados-connected-users-com-graphql/
+---
+
+O conjunto de dados **connectedUsers** permite que você obtenha dados agregados em tempo real, fornecidos pelo Live Ingest da Azion, relacionados ao número de usuários atualmente conectados às suas aplicações com transmissões ao vivo. Este conjunto de dados faz parte da GraphQL API do Real-Time Metrics e é gerado a partir dos eventos HTTP brutos, que são populados apenas para clientes com configurações de transmissão ao vivo.
+
+Essas informações podem ser acessadas através da GraphQL API, permitindo que você transfira esses dados para uma plataforma de terceiros, possibilitando uma análise e revisão mais aprofundadas da atividade e engajamento dos usuários. Além disso, os dados estão disponíveis por até *2 anos*.
+
+Este guia explicará como consultar dados de usuários conectados usando o playground GraphiQL.
+
+:::note
+Para obter esses dados, você deve ter a subscrição do [Live Ingest da Azion](https://www.azion.com/en/solutions/live-streaming-delivery/) e usar a [GraphQL API](/en/documentation/devtools/graphql-api/overview/).
+:::
+
+---
+
+## Consulte dados por host
+
+Para consultar seus dados por host, siga os seguintes passos:
+
+1. Acesse o [playground GraphiQL](https://manager.azion.com/metrics/graphql)
+    - Você deve estar logado na sua conta Azion. Caso contrário, você receberá uma mensagem de erro.
+2. Envie uma query seguindo este formato:
+
+```bash
+query ConnectedUsers {
+    connectedUsersMetrics(
+        limit: 10000,
+        filter: {
+            tsRange:{
+                begin: "2024-04-10T00:00:00",
+                end: "2024-04-11T00:00:00"
+            }
+        },
+      	 groupBy: [ts,host]
+        orderBy: [ts_DESC]
+    ) {
+        ts,
+	 host,
+        uniqueSessions
+    }
+}
+```
+
+Onde:
+
+| Campo | Descrição |
+|----------|----------|
+| `limit` | Especifica o número máximo de resultados a serem retornados. Máximo do sistema: `10000`   |
+| `filter` | Define os critérios usados para filtrar os dados retornados pela consulta |
+| `tsRange` | Um subcampo de `filter`. Especifica um intervalo de tempo para filtrar os dados. Inclui os campos `begin` e `end` para definir os timestamps de início e fim. Formato: `"YYYY-MM-DDTHH:mm:ss"`; exemplo: `"2024-04-11T00:00:00"` |
+| `groupBy` | Especifica os campos pelos quais os resultados da consulta devem ser agrupados. Exemplo: `[ts]` |
+| `orderBy` | Especifica a ordem em que os resultados devem ser retornados. Valores aceitos: `[ts_DESC]`, para ordem decrescente, e `[ts_ASC]`, para ordem crescente |
+| `ts` | Um campo no conjunto de resultados representando o timestamp do ponto de dados |
+| `host` | Um campo no conjunto de resultados representando o host de onde os dados foram coletados |
+| `uniqueSessions` | Um campo no conjunto de resultados representando o número de sessões únicas registradas pelo host |
+
+3. Você receberá uma resposta JSON semelhante a esta:
+
+```bash
+{
+  "data": {
+    "connectedUsersMetrics": [
+      {
+        "ts": "2024-04-10T00:00:00",
+  "host": "example.net",
+        "uniqueSessions": 120
+      },
+      {
+        "ts": "2024-04-10T00:00:00",
+  "host": "example.net",
+        "uniqueSessions": 175
+      },
+      {
+        "ts": "2024-04-10T00:00:00",
+  "host": "example.net",
+        "uniqueSessions": 136
+      },
+      {
+        "ts": "2024-04-10T00:00:00",
+  "host": "example.net",
+        "uniqueSessions": 100
+      }
+    ]
+  }
+}
+```
+
+Onde: 
+
+| Campo | Descrição |
+|----------|----------|
+| `ts` | Timestamp de quando o evento foi criado |
+| `host` | Informações do host enviadas na linha de requisição. Armazena: nome do host da linha de requisição, ou nome do host do campo de cabeçalho “Host”, ou o nome do servidor que corresponde a uma requisição |
+| `uniqueSessions` | Sessões únicas calculadas para um determinado host |
+
+---
+
+## Consulte dados totais
+
+Para consultar valores totais, sem filtrar por host, você deve usar o campo `uniqueSessionsTotal`:
+
+1. Acesse o [playground GraphiQL](https://manager.azion.com/metrics/graphql)
+    - Você deve estar logado na sua conta Azion. Caso contrário, você receberá uma mensagem de erro.
+2. Envie uma query seguindo este formato:
+
+```bash
+query ConnectedUsers {
+    connectedUsersMetrics(
+        limit: 10000,
+        filter: {
+            tsRange:{
+                begin: "2024-04-10T00:00:00",
+                end: "2024-04-11T00:00:00"
+            }
+        },
+      	 groupBy: [ts]
+        orderBy: [ts_DESC]
+    ) {
+        ts,
+        uniqueSessionsTotal
+    }
+}
+```
+
+Onde:
+
+| Campo | Descrição |
+|----------|----------|
+| `limit` | Especifica o número máximo de resultados a serem retornados. Máximo do sistema: `10000`   |
+| `filter` | Define os critérios usados para filtrar os dados retornados pela consulta |
+| `tsRange` | Um subcampo de `filter`. Especifica um intervalo de tempo para filtrar os dados. Inclui os campos `begin` e `end` para definir os timestamps de início e fim. Formato: `"YYYY-MM-DDTHH:mm:ss"`; exemplo: `"2024-04-11T00:00:00"` |
+| `groupBy` | Especifica os campos pelos quais os resultados da consulta devem ser agrupados. Exemplo: `[ts]` |
+| `orderBy` | Especifica a ordem em que os resultados devem ser retornados. Valores aceitos: `[ts_DESC]`, para ordem decrescente, e `[ts_ASC]`, para ordem crescente |
+| `ts` | Um campo no conjunto de resultados representando o timestamp do ponto de dados |
+| `uniqueSessionsTotal` | Um campo no conjunto de resultados representando o número de sessões únicas registradas entre todos os hosts para o intervalo de tempo especificado |
+
+3. Você receberá uma resposta JSON semelhante a esta:
+
+```bash
+{
+  "data": {
+    "connectedUsersMetrics": [
+      {
+        "ts": "2024-04-10T00:00:00",
+        "uniqueSessionsTotal": 169
+      },
+      {
+        "ts": "2024-04-10T00:00:00",
+        "uniqueSessionsTotal": 175
+      },
+      {
+        "ts": "2024-04-10T00:00:00",
+        "uniqueSessionsTotal": 120
+      },
+      {
+        "ts": "2024-04-10T00:00:00",
+        "uniqueSessionsTotal": 100
+      }
+    ]
+  }
+}
+```
+
+Onde: 
+
+| Campo | Descrição |
+|----------|----------|
+| `ts` | Timestamp de quando o evento foi criado |
+| `uniqueSessionsTotal` | Total de sessões únicas calculadas entre todos os hosts |

--- a/src/content/docs/pt-br/pages/guias/guides.mdx
+++ b/src/content/docs/pt-br/pages/guias/guides.mdx
@@ -163,6 +163,7 @@ permalink: /documentacao/produtos/guias/
 - [Como rodar requisições da GraphQL no Postman](/pt-br/documentacao/produtos/guias/consultar-graphql-postman/)
 - [Exemplo JSON para dashboard de Data Transferred no Grafana](/pt-br/documentacao/produtos/real-time-metrics/data-transferred-dash/)
 - [Exemplo JSON para dashboard da API GraphQL do Real-Time Metrics no Grafana](/pt-br/documentacao/produtos/real-time-metrics/metrics-dash/)
+- [Como consultar dados de usuários conectados com a GraphQL API](/pt-br/documentacao/produtos/guias/query-dados-connected-users-com-graphql/)
 
 ---
 

--- a/src/i18n/en/graphqlMenu.ts
+++ b/src/i18n/en/graphqlMenu.ts
@@ -36,6 +36,7 @@
 		{ text: 'How to query metadata with GraphQL API', slug: '/documentation/products/guides/graphql-metadata', key: 'guides/graphql-metadata' },
 		{ text: 'How to query aggregated data with GraphQL API', slug: '/documentation/products/guides/graphql-aggregated-data', key: 'guides/graphql-aggregated-data' },
 		{ text: 'How to select Top X queries with GraphQL API', slug: '/documentation/products/guides/graphql-top-x-query', key: 'guides/graphql-top-x' },
+		{ text: 'How to query Connected Users data with GraphQL API', slug: '/documentation/products/guides/query-connected-users-data-with-graphql/', key: 'guides/connected-users-graphql' },
 	] },
 
 

--- a/src/i18n/pt-br/graphqlMenu.ts
+++ b/src/i18n/pt-br/graphqlMenu.ts
@@ -37,6 +37,7 @@
 		{ text: 'Como consultar metadados com a GraphQL API', slug: '/documentacao/produtos/guias/graphql-metadados', key: 'guides/graphql-metadata' },
 		{ text: 'Como realizar consultas agregando dados com a GraphQL API', slug: '/documentacao/produtos/guias/graphql-dados-agregados', key: 'guides/graphql-aggregated-data' },
 		{ text: 'Como selecionar Top X queries com a GraphQL API', slug: '/documentacao/produtos/guias/graphql-query-top-x', key: 'guides/graphql-top-x' },
+		{ text: 'Como consultar dados de usuários conectados com a GraphQL API', slug: '/documentacao/produtos/guias/query-dados-connected-users-com-graphql/', key: 'guides/connected-users-graphql' },
 	] },
 
 


### PR DESCRIPTION
### Related issue:

[EDU-4913] [EDU-4912]

### Changes

- Add query connected users data guide, EN/PT.
- Add the link to the Guides page.
- Add information about the new dataset to existing GraphQL documentation.

### Additional links

n/a.

[EDU-4913]: https://aziontech.atlassian.net/browse/EDU-4913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EDU-4912]: https://aziontech.atlassian.net/browse/EDU-4912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ