### PR TITLE
[EDU-5150] feature: add Conditional Access by IP guide

### DIFF
--- a/src/content/docs/en/pages/guides/accounts/conditional-access-by-ip.mdx
+++ b/src/content/docs/en/pages/guides/accounts/conditional-access-by-ip.mdx
@@ -1,0 +1,294 @@
+---
+title: How to manage a conditional access by IP address policy
+description: This policy allows you to create lists that will enable access to your resources based on specific IP addresses.
+meta_tags: account management, conditional access by IP address policy, security policies
+namespace: docs_guides_conditional_access_by_ip_address
+permalink: /documentation/products/guides/conditional-access-by-ip-address/
+---
+
+The Azion **Conditional Access by IP Address** policy allows you to create lists that allow access to your resources based on specific IP addresses. You can define particular IP addresses to enforce the policy, ensuring that only devices accessing from these addresses can reach the platform. This way, access from any IP address not on the organization's allowlist should be blocked when this policy is enabled.
+
+This guide explains configuring and managing conditional access by IP address policy through Azion's platform.
+
+:::note
+When an organization sets up a conditional access by IP address policy, it applies to all account levels.
+
+This policy is available to customers with **Enterprise** and **Mission Critical** [Service Plans](https://www.azion.com/en/professional-services/).
+:::
+
+---
+
+## Configuring a conditional access by IP address policy
+
+:::note
+To configure a conditional access by IP address policy, you must be **Account Owner** or have *managing policies* privileges. If you aren't an **Account Owner** or have these privileges, the system returns an Error 403.
+
+Currently, an account can have only *1 configuration for this policy*, containing up to 200 rules. The IP Addresses can be either IPv4 or IPv6.
+:::
+
+1. Run the following `POST` request in your terminal, replacing `[Token]` with your [personal token](/en/documentation/products/guides/personal-tokens/) to configure your policy.
+
+```bash 
+curl --request POST \
+  --url https://api.azion.com/v4/auth/policies \
+  --header 'Accept: application/json' \
+  --header 'Authorization: [Token] ' \
+  --header 'Content-Type: application/json' \
+  --data '{
+  "name": "My Policy",
+  "active": true,
+  "rules": [
+    {
+      "name": "My policy Rule",
+      "effect": "allow",
+      "resource": "*",
+      "action": "*",
+      "condition": {
+        "ip_address": [
+          "19.34.213.23",
+          "132.33.16.1/24"
+        ]
+      }
+    }
+  ]
+}'
+```
+
+Where:
+
+| Key | Type | Description |
+| --- | ----------- | ----------- |
+| name | String | Refers to the name of the conditional access policy. Up to *255 characters* |
+| active | Boolean | Indicates whether the policy is active. Accepted values: `true` and `false` |
+| rules | Array of objects | Includes an array of rules that define the policy's behavior |
+| name | String | In the rules' array, refers to the name of the individual rule. Up to *255 characters* |
+| effect | String | Refers to the rule's effect. Accepted values: `allow` and `deny` |
+| resource | String | Specifies the resource(s) to which the rule applies. Accepted value: `*`, for all resources |
+| action | String | Specifies the action(s) to which the rule applies. Accepted value: `*`, for all actions  |
+| condition | Text | Defines the conditions under which the rule applies |
+| ip_address | Array of strings | Includes an array of IP addresses that are evaluated by the condition |
+
+2. You'll receive a response similar to the following:
+
+```bash
+{
+  "state": "executed",
+  "data": {
+    "uuid": "095be615-a8ad-4c33-8e9c-c7612fbf6c9f",
+    "name": "My Policy",
+    "active": true,
+    "rules": [
+      {
+        "name": "My policy Rule",
+        "effect": "allow",
+        "resource": "*",
+        "action": "*",
+        "condition": {
+          "ip_address": [
+             "19.34.213.23",
+          "132.33.16.1/24"
+          ]
+        }
+      }
+    ]
+  }
+}
+```
+
+Where `state` refers to the status of the policy's creation and `uuid` is the unique identifier of the policy. 
+
+Done. You've configured conditional access by IP address policy and it's active. Once the policy is enabled, any user attempting to access the platform from an IP address not on the organization's allowlist will receive an HTTP 403 status.
+
+All the access attempts, both successful and unsuccessful for valid users for the account, are logged in the **Activity History** for auditing and monitoring purposes.
+
+:::note
+This policy includes a carefully considered exception for the Account Owner, balanced with additional robust security measures. This approach ensures strong security while preventing potential account lockouts due to IP or policy changes.
+:::
+
+---
+
+## Updating the status of a conditional access by IP address policy
+
+1. Run the following `GET` request in your terminal, replacing `[Token]` with your [personal token](/en/documentation/products/guides/personal-tokens/) to list all your configured account policies.
+
+```bash
+curl --request GET \
+  --url https://api.azion.com/v4/auth/policies \
+  --header 'Accept: application/json' \
+  --header 'Authorization: [Token]'
+```
+
+2. You'll receive a response similar to the following:
+
+```bash
+{
+  "count": 123,
+  "results": [
+    {
+      "uuid": "095be615-a8ad-4c33-8e9c-c7612fbf6c9f",
+      "name": "string",
+      "active": true,
+      "rules": [
+        {
+          "name": "string",
+          "effect": "allow",
+          "resource": "*",
+          "action": "*",
+          "condition": {
+            "ip_address": [
+              "string"
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+3. Copy the `uuid` of the policy you want to update. 
+4. Run the following `PUT` request in your terminal, replacing `[Token]` with your [personal token](/en/documentation/products/guides/personal-tokens/) and `<uuid>` with the identifier you copied in the previous step, to update the status of your policy. 
+
+> This replaces all policy rules with the new data provided.
+
+```bash
+curl --request PUT \
+  --url https://api.azion.com/v4/auth/policies/<uuid> \
+  --header 'Accept: application/json' \
+  --header 'Authorization: 123' \
+  --header 'Content-Type: application/json' \
+  --data '{
+  "name": "string",
+  "active": false,
+  "rules": [
+    {
+      "name": "string",
+      "effect": "allow",
+      "resource": "*",
+      "action": "*",
+      "condition": {
+        "ip_address": [
+          "string"
+        ]
+      }
+    }
+  ]
+}'
+```
+
+In this example, using `"active": false` will disable the active rule. 
+
+::tip
+Alternatively, you can use a `PATCH` request to partially update a policy, adjusting one or more fields of an existing policy without affecting other fields.
+:::
+
+5. You'll receive a response similar to the following:
+
+```bash
+{
+  "state": "executed",
+  "data": {
+    "uuid": "095be615-a8ad-4c33-8e9c-c7612fbf6c9f",
+    "name": "My Policy",
+    "active": true,
+    "rules": [
+      {
+        "name": "My policy Rule",
+        "effect": "allow",
+        "resource": "*",
+        "action": "*",
+        "condition": {
+          "ip_address": [
+            "19.34.213.23",
+            "132.33.16.1/24"
+          ]
+        }
+      }
+    ]
+  }
+}
+```
+
+---
+
+## Deleting a conditional access by IP address policy
+
+1. Run the following `GET` request in your terminal, replacing `[Token]` with your [personal token](/en/documentation/products/guides/personal-tokens/) to list all your configured account policies.
+
+```bash
+curl --request GET \
+  --url https://api.azion.com/v4/auth/policies \
+  --header 'Accept: application/json' \
+  --header 'Authorization: [Token]'
+```
+
+2. You'll receive a response similar to the following:
+
+```bash
+{
+  "count": 123,
+  "results": [
+    {
+      "uuid": "095be615-a8ad-4c33-8e9c-c7612fbf6c9f",
+      "name": "string",
+      "active": true,
+      "rules": [
+        {
+          "name": "string",
+          "effect": "allow",
+          "resource": "*",
+          "action": "*",
+          "condition": {
+            "ip_address": [
+              "string"
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+3. Copy the `uuid` of the policy you want to update. 
+4. Run the following `DELETE` request in your terminal, replacing `[Token]` with your [personal token](/en/documentation/products/guides/personal-tokens/) and `<uuid>` with the identifier you copied in the previous step, to delete the policy. 
+
+```bash
+curl --request DELETE \
+  --url https://api.azion.com/v4/auth/policies/uuid \
+  --header 'Accept: application/json' \
+  --header 'Authorization: [Token]' \
+  --header 'Content-Type: application/json'
+```
+
+5. You'll receive a response similar to the following: 
+
+```bash
+{
+  "state": "exectuted",
+  "data": {
+    "uuid": "095be615-a8ad-4c33-8e9c-c7612fbf6c9f",
+    "name": "string",
+    "active": true,
+    "rules": [
+      {
+        "name": "string",
+        "effect": "allow",
+        "resource": "*",
+        "action": "*",
+        "condition": {
+          "ip_address": [
+            "string"
+          ]
+        }
+      }
+    ]
+  }
+}
+```
+
+Done. Your policy was deleted from your account.
+
+:::tip
+Check the [Azion API documentation](https://api.azion.com/) and the [OpenAPI specification](https://github.com/aziontech/azionapi-openapi/) to know more about all features available via API.
+:::

--- a/src/content/docs/en/pages/guides/index.mdx
+++ b/src/content/docs/en/pages/guides/index.mdx
@@ -46,6 +46,7 @@ permalink: /documentation/products/guides/
 - [Using Google custom SAML app as an IdP for Azion Console](/en/documentation/products/guides/sso-google-saml/)
 - [Using Azure AD custom SAML app as an IdP for Azion Console](/en/documentation/products/guides/sso-azure-saml/)
 - [How to configure User Session Timeout](/en/documentation/products/guides/configure-user-session-timeout/)
+- [How to manage a conditional access by IP address policy](/en/documentation/products/guides/conditional-access-by-ip-address/)
 - [How to configure Account Lockout Policy](/en/documentation/products/guides/configure-account-lockout-policy/)
 - [How to check Account Lockout Policy logs](/en/documentation/products/guides/account-lockout-policy-logs/)
 - [How to manually unlock a user from the Account Lockout Policy](/en/documentation/products/guides/unlock-account-lockout-policy/)

--- a/src/content/docs/pt-br/pages/guias/contas/conditional-access-by-ip.mdx
+++ b/src/content/docs/pt-br/pages/guias/contas/conditional-access-by-ip.mdx
@@ -1,0 +1,294 @@
+---
+title: Como gerenciar uma política de acesso condicional por endereço IP
+description: Esta política permite que você crie listas que habilitarão o acesso aos seus recursos com base em endereços IP específicos.
+meta_tags: gestão de contas, conditional access by IP address policy, política de acesso condicional por endereço IP, políticas de segurança
+namespace: docs_guides_conditional_access_by_ip_address
+permalink: /documentacao/produtos/guias/conditional-access-by-ip-address/
+---
+
+A política **Conditional Access by IP Address** da Azion permite que você crie listas que permitem o acesso aos seus recursos com base em endereços IP específicos. Você pode definir endereços IP particulares para aplicar a política, garantindo que apenas dispositivos acessando a partir desses endereços possam alcançar a plataforma. Dessa forma, o acesso de qualquer endereço IP que não esteja na lista de permissões da organização deve ser bloqueado quando essa política estiver habilitada.
+
+Este guia explica como configurar e gerenciar a política de acesso condicional por endereço IP através da plataforma da Azion.
+
+:::note
+Quando uma organização configura uma política de acesso condicional por endereço IP, ela se aplica a todos os níveis de conta.
+
+Esta política está disponível para clientes com [planos de serviço](https://www.azion.com/pt-br/servicos-profissionais/) **Enterprise** e **Mission Critical**.
+:::
+
+---
+
+## Configure uma política de acesso condicional por endereço IP
+
+:::note
+Para configurar uma política de acesso condicional por endereço IP, você deve ser **Account Owner** ou ter privilégios de *managing policies*. Se você não for um **Account Owner** ou não tiver esses privilégios, o sistema retornará um Erro 403.
+
+Atualmente, uma conta pode ter apenas *1 política configurada*, contendo até 200 regras. Os endereços IP podem ser tanto IPv4 quanto IPv6.
+:::
+
+1. Execute a seguinte requisição `POST` no seu terminal, substituindo `[Token]` pelo seu [personal token](/en/documentation/products/guides/personal-tokens/) para configurar sua política.
+
+```bash 
+curl --request POST \
+  --url https://api.azion.com/v4/auth/policies \
+  --header 'Accept: application/json' \
+  --header 'Authorization: [Token] ' \
+  --header 'Content-Type: application/json' \
+  --data '{
+  "name": "My Policy",
+  "active": true,
+  "rules": [
+    {
+      "name": "My policy Rule",
+      "effect": "allow",
+      "resource": "*",
+      "action": "*",
+      "condition": {
+        "ip_address": [
+          "19.34.213.23",
+          "132.33.16.1/24"
+        ]
+      }
+    }
+  ]
+}'
+```
+
+Onde:
+
+| Chave | Tipo | Descrição |
+| -------- | ---------------- | --------------------------------------------------------------------------- |
+| name | String | Refere-se ao nome da política de acesso condicional. Até *255 caracteres*  |
+| active | Boolean | Indica se a política está ativa. Valores aceitos: `true` e `false` |
+| rules | Array de objetos | Inclui um array de regras que definem o comportamento da política |
+| name | String | No array de regras, refere-se ao nome da regra individual. Até *255 caracteres* |
+| effect | String | Refere-se ao efeito da regra. Valores aceitos: `allow` e `deny` |
+| resource | String | Especifica o(s) recurso(s) ao qual a regra se aplica. Valor aceito: `*`, para todos os recursos |
+| action | String | Especifica a(s) ação(ões) à qual a regra se aplica. Valor aceito: `*`, para todas as ações |
+| condition | Text | Define as condições sob as quais a regra se aplica |
+| ip_address | Array de strings | Inclui um array de endereços IP que são avaliados pela condição |
+
+2. Você receberá uma resposta semelhante à seguinte:
+
+```bash
+{
+  "state": "executed",
+  "data": {
+    "uuid": "095be615-a8ad-4c33-8e9c-c7612fbf6c9f",
+    "name": "My Policy",
+    "active": true,
+    "rules": [
+      {
+        "name": "My policy Rule",
+        "effect": "allow",
+        "resource": "*",
+        "action": "*",
+        "condition": {
+          "ip_address": [
+             "19.34.213.23",
+          "132.33.16.1/24"
+          ]
+        }
+      }
+    ]
+  }
+}
+```
+
+Onde `state` refere-se ao status da criação da política e `uuid` é o identificador único da política.
+
+Pronto. Você configurou a política de acesso condicional por endereço IP e ela está ativa. Uma vez que a política esteja habilitada, qualquer usuário que tentar acessar a plataforma a partir de um endereço IP que não esteja na lista de permissões da organização receberá um status HTTP 403.
+
+Todas as tentativas de acesso, tanto bem-sucedidas quanto malsucedidas para usuários válidos da conta, são registradas no **Activity History** para fins de auditoria e monitoramento.
+
+:::note
+Esta política inclui uma exceção para o **Account Owner**, equilibrada com medidas de segurança adicionais robustas. Essa abordagem garante uma segurança forte, enquanto previne potenciais bloqueios de conta devido a mudanças de IP ou de política.
+:::
+
+---
+
+## Atualize o status de uma política de acesso condicional por endereço IP
+
+1. Execute a seguinte requisição `GET` no seu terminal, substituindo `[Token]` pelo seu [personal token](/en/documentation/products/guides/personal-tokens/) para listar todas as suas políticas de conta configuradas.
+
+```bash
+curl --request GET \
+  --url https://api.azion.com/v4/auth/policies \
+  --header 'Accept: application/json' \
+  --header 'Authorization: [Token]'
+```
+
+2. Você receberá uma resposta semelhante à seguinte:
+
+```bash
+{
+  "count": 123,
+  "results": [
+    {
+      "uuid": "095be615-a8ad-4c33-8e9c-c7612fbf6c9f",
+      "name": "string",
+      "active": true,
+      "rules": [
+        {
+          "name": "string",
+          "effect": "allow",
+          "resource": "*",
+          "action": "*",
+          "condition": {
+            "ip_address": [
+              "string"
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+3. Copie o `uuid` da política que você deseja atualizar. 
+4. Execute a seguinte requisição `PUT` no seu terminal, substituindo `[Token]` pelo seu [personal token](/en/documentation/products/guides/personal-tokens/) e `<uuid>` pelo identificador que você copiou na etapa anterior, para atualizar o status da sua política.
+
+> Isso substitui todas as regras da política pelos novos dados fornecidos.
+
+```bash
+curl --request PUT \
+  --url https://api.azion.com/v4/auth/policies/<uuid> \
+  --header 'Accept: application/json' \
+  --header 'Authorization: 123' \
+  --header 'Content-Type: application/json' \
+  --data '{
+  "name": "string",
+  "active": false,
+  "rules": [
+    {
+      "name": "string",
+      "effect": "allow",
+      "resource": "*",
+      "action": "*",
+      "condition": {
+        "ip_address": [
+          "string"
+        ]
+      }
+    }
+  ]
+}'
+```
+
+Neste exemplo, usar `"active": false` desativará a regra ativa.
+
+::tip
+Alternativamente, você pode usar uma solicitação `PATCH` para atualizar parcialmente uma política, ajustando um ou mais campos de uma política existente sem afetar outros campos.
+:::
+
+5. Você receberá uma resposta semelhante à seguinte:
+
+```bash
+{
+  "state": "executed",
+  "data": {
+    "uuid": "095be615-a8ad-4c33-8e9c-c7612fbf6c9f",
+    "name": "My Policy",
+    "active": true,
+    "rules": [
+      {
+        "name": "My policy Rule",
+        "effect": "allow",
+        "resource": "*",
+        "action": "*",
+        "condition": {
+          "ip_address": [
+            "19.34.213.23",
+            "132.33.16.1/24"
+          ]
+        }
+      }
+    ]
+  }
+}
+```
+
+---
+
+## Exclua uma política de acesso condicional por endereço IP
+
+1. Execute a seguinte requisição `GET` no seu terminal, substituindo `[Token]` pelo seu [personal token](/en/documentation/products/guides/personal-tokens/) para listar todas as suas políticas de conta configuradas.
+
+```bash
+curl --request GET \
+  --url https://api.azion.com/v4/auth/policies \
+  --header 'Accept: application/json' \
+  --header 'Authorization: [Token]'
+```
+
+2. Você receberá uma resposta semelhante à seguinte:
+
+```bash
+{
+  "count": 123,
+  "results": [
+    {
+      "uuid": "095be615-a8ad-4c33-8e9c-c7612fbf6c9f",
+      "name": "string",
+      "active": true,
+      "rules": [
+        {
+          "name": "string",
+          "effect": "allow",
+          "resource": "*",
+          "action": "*",
+          "condition": {
+            "ip_address": [
+              "string"
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+3. Copie o `uuid` da política que você deseja excluir. 
+4. Execute a seguinte requisição `DELETE` no seu terminal, substituindo `[Token]` pelo seu [personal token](/en/documentation/products/guides/personal-tokens/) e `<uuid>` pelo identificador que você copiou na etapa anterior, para excluir a política.
+
+```bash
+curl --request DELETE \
+  --url https://api.azion.com/v4/auth/policies/uuid \
+  --header 'Accept: application/json' \
+  --header 'Authorization: [Token]' \
+  --header 'Content-Type: application/json'
+```
+
+5. Você receberá uma resposta semelhante à seguinte:
+
+```bash
+{
+  "state": "exectuted",
+  "data": {
+    "uuid": "095be615-a8ad-4c33-8e9c-c7612fbf6c9f",
+    "name": "string",
+    "active": true,
+    "rules": [
+      {
+        "name": "string",
+        "effect": "allow",
+        "resource": "*",
+        "action": "*",
+        "condition": {
+          "ip_address": [
+            "string"
+          ]
+        }
+      }
+    ]
+  }
+}
+```
+
+Pronto. A política foi excluída da sua conta.
+
+:::tip
+Consulte a [documentação da API da Azion](https://api.azion.com/) e a [especificação OpenAPI](https://github.com/aziontech/azionapi-openapi/) para saber mais sobre todos os recursos disponíveis via API.
+:::

--- a/src/content/docs/pt-br/pages/guias/guides.mdx
+++ b/src/content/docs/pt-br/pages/guias/guides.mdx
@@ -45,6 +45,7 @@ permalink: /documentacao/produtos/guias/
 - [Como utilizar Google SAML como IdP para o Azion Console](/pt-br/documentacao/produtos/guias/sso-google-saml/)
 - [Como utilizar Azure AD SAML como IdP para o Azion Console](/pt-br/documentacao/produtos/guias/sso-azure-saml/)
 - [Como configurar o User Session Timeout](/pt-br/documentacao/produtos/guias/configurar-user-session-timeout/)
+- [Como gerenciar uma política de acesso condicional por endereço IP](/pt-br/documentacao/produtos/guias/conditional-access-by-ip-address/)
 - [Como configurar a Account Lockout Policy](/pt-br/documentacao/produtos/guias/configurar-account-lockout-policy/)
 - [Como verificar os logs gerados pela Account Lockout Policy](/pt-br/documentacao/produtos/guias/account-lockout-policy-logs/)
 - [Como desbloquear manualmente um usuário da Account Lockout Policy](/pt-br/documentacao/produtos/guias/desbloquear-account-lockout-policy/)

--- a/src/i18n/en/nav.ts
+++ b/src/i18n/en/nav.ts
@@ -32,6 +32,7 @@ export default [
 			{ text: 'Teams permissions', header: true, anchor: true, type: 'learn', slug: '/documentation/products/guides/teams-permissions/', key: 'account/teamsPermissions' },
 			{ text: 'Activity history', header: true, anchor: true, type: 'learn', slug: '/documentation/products/guides/activity-history/', key: 'account/activityHistory' },
 			{ text: 'Account Lockout Policy', header: true, anchor: true, type: 'learn', slug: '/documentation/products/guides/configure-account-lockout-policy/', key: 'account/accountLockoutPolicy' },
+			{ text: 'Conditional Access by IP Address', header: true, anchor: true, type: 'learn', slug: '/documentation/products/guides/conditional-access-by-ip-address/', key: 'account/conditionalAccess' },
 			{ text: 'Credentials', header: true, anchor: true, type: 'learn', slug: '/documentation/products/guides/credentials/', key: 'account/credentials' },
 			{ text: 'SSO', header: true, anchor: true, type: 'learn', slug: 'documentation/products/guides/sso/', key: 'account/sso' },
 			{ text: 'MFA', header: true, anchor: true, type: 'learn', slug: '/documentation/products/guides/multi-factor-authentication/', key: 'account/mfa' },

--- a/src/i18n/pt-br/nav.ts
+++ b/src/i18n/pt-br/nav.ts
@@ -37,6 +37,7 @@ export default NavDictionary([
 	{ text: 'Times', slug: '/documentacao/produtos/guias/teams-permissions/', key: 'account/teamsPermissions' },
 	{ text: 'Activity history', slug: '/documentacao/produtos/guias/activity-history/', key: 'account/activityHistory' },
 	{ text: 'Account Lockout Policy', slug: '/documentacao/produtos/guias/configurar-account-lockout-policy/', key: 'account/accountLockoutPolicy' },
+	{ text: 'Conditional Access by IP Address', header: true, anchor: true, type: 'learn', slug: '/documentacao/produtos/guias/conditional-access-by-ip-address/', key: 'account/conditionalAccess' },
 	{ text: 'Credenciais', slug: '/documentacao/produtos/guias/credentials/', key: 'account/credentials' },
 	{ text: 'SSO', slug: '/documentacao/produtos/guias/sso/', key: 'account/sso' },
 	{ text: 'MFA', slug: '/documentacao/produtos/guias/multi-factor-authentication/', key: 'account/mfa' },


### PR DESCRIPTION
### Related issue:

[EDU-5150]

### Changes

- Add Conditional Access by IP guide EN-PT.
- Add the link to the Guides page EN-PT.
- Add the link and label to the account menu EN-PT.

### Additional links

n/a.

[EDU-5150]: https://aziontech.atlassian.net/browse/EDU-5150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ