### PR TITLE
[EDU-5221] Replace Vulcan with Bundler in docs

### DIFF
--- a/src/content/docs/en/pages/devtools/azion-edge-runtime/compatibility/cells-node.mdx
+++ b/src/content/docs/en/pages/devtools/azion-edge-runtime/compatibility/cells-node.mdx
@@ -51,7 +51,7 @@ import { API } from "import-origin";
 
 ## Node polyfills
 
-A polyfill is a code snippet, often used in JavaScript, that brings new features to environments lacking these capabilities. Polyfills are used during build time at Azion and can be configured through the [vulcan.config.js](/en/documentation/devtools/vulcan/config/) file.
+A polyfill is a code snippet, often used in JavaScript, that brings new features to environments lacking these capabilities. Polyfills are used during build time at Azion and can be configured through the [bundler.config.js](/en/documentation/devtools/vulcan/config/) file.
 
 Here's a list of Node APIs supported through polyfills:
 

--- a/src/content/docs/en/pages/devtools/vulcan/config-js.mdx
+++ b/src/content/docs/en/pages/devtools/vulcan/config-js.mdx
@@ -1,7 +1,7 @@
 ---
 title: Azion Bundler.config.js file
 description: >-
-  The vulcan.config.js file serves as a powerful configuration system for
+  The bundler.config.js file serves as a powerful configuration system for
   Azion Bundler, offering customization options for your application's build process.
 meta_tags: 'edge, javascript, polyfill'
 namespace: documentation_devtools_vulcan_config
@@ -12,7 +12,7 @@ menu_namespace: cliMenuAlpha
 import TableContainer from "~/components/Table/TableContainer.astro";
 import LinkButton from 'azion-webkit/linkbutton'
 
-The `vulcan.config.js` file serves as a powerful configuration system for Azion Bundler, offering customization options for your application's build process. While not mandatory, this file acts as an override mechanism, allowing you to define properties that supersede preset configurations.
+The `bundler.config.js` file serves as a powerful configuration system for Azion Bundler, offering customization options for your application's build process. While not mandatory, this file acts as an override mechanism, allowing you to define properties that supersede preset configurations.
 
 :::note
 Unspecified properties will default to preset values.
@@ -48,7 +48,7 @@ Azion Bundler employs the terminology `compute` and `deliver` to describe the op
 
 For a Next-based project:
 
-```javascript title="vulcan.config.js"
+```javascript title="bundler.config.js"
 module.exports = {
   entry: 'src/index.js',
   builder: 'webpack',
@@ -69,7 +69,7 @@ module.exports = {
 ```
 
 <br />
-<LinkButton link="https://github.com/aziontech/bundler/" label="go to an implementation of the vulcan.config.js file" severity="secondary"  target="_blank" />
+<LinkButton link="https://github.com/aziontech/bundler/" label="go to an implementation of the bundler.config.js file" severity="secondary"  target="_blank" />
 
 ---
 

--- a/src/content/docs/en/pages/guides/cli/cli-vulcan-use-polyfills.mdx
+++ b/src/content/docs/en/pages/guides/cli/cli-vulcan-use-polyfills.mdx
@@ -76,9 +76,9 @@ Getting templates available? Choose a template for your project: (Use arrow keys
 cd polyfills-guide
 ```
 
-10. Create the `vulcan.config.js` file and paste the following properties:
+10. Create the `bundler.config.js` file and paste the following properties:
 
-```js title="polyfills-guide/vulcan.config.js"
+```js title="polyfills-guide/bundler.config.js"
 module.exports = {
   entry: 'main.js',
   builder: 'webpack',

--- a/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/compatibilidade/node.mdx
+++ b/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/compatibilidade/node.mdx
@@ -6,7 +6,7 @@ description: >-
 permalink: /documentacao/produtos/devtools/azion-edge-runtime/compatibilidade/node/
 meta_tags: >-
   Azion Runtime, Node.js compatibilidade, APIs Node Runtime, polyfills Node,
-  suporte API, exemplo de código, APIs vulcan, Azion Edge Functions, Node.js
+  suporte API, exemplo de código, APIs bundler, Azion Edge Functions, Node.js
   Edge Computing
 namespace: documentation_products_azion_runtime_node
 menu_namespace: runtimeMenu
@@ -53,7 +53,7 @@ import { API } from "import-origin";
 
 ## Node polyfills
 
-Um polyfill é um trecho de código, frequentemente usado em JavaScript, que traz novos recursos para ambientes que não possuem essas capacidades. Os polyfills são usados durante o tempo de *build* e podem ser configurados através do arquivo [vulcan.config.js](/pt-br/documentacao/devtools/vulcan/config/).
+Um polyfill é um trecho de código, frequentemente usado em JavaScript, que traz novos recursos para ambientes que não possuem essas capacidades. Os polyfills são usados durante o tempo de *build* e podem ser configurados através do arquivo [bundler.config.js](/pt-br/documentacao/devtools/vulcan/config/).
 
 Aqui está a lista de APIs do Node suportadas através de polyfills:
 

--- a/src/content/docs/pt-br/pages/devtools/vulcan/config-js.mdx
+++ b/src/content/docs/pt-br/pages/devtools/vulcan/config-js.mdx
@@ -1,11 +1,11 @@
 ---
-title: Arquivo vulcan.config.js
+title: Arquivo bundler.config.js
 description: >-
-  Explore como o vulcan.config.js aprimora a configuração e o desempenho de apps
+  Explore como o bundler.config.js aprimora a configuração e o desempenho de apps
   com Edge Computing usando webpack, esbuild e presets em Azion Edge.
 permalink: /documentacao/devtools/vulcan/config
 meta_tags: >-
-  vulcan.config.js, Edge Computing, configuração de aplicativo, customização de
+  bundler.config.js, Edge Computing, configuração de aplicativo, customização de
   build, webpack, esbuild, presets de configuração, Node.js polyfills, Web APIs,
   Azion Edge, performance no edge
 namespace: documentation_devtools_vulcan_config
@@ -15,7 +15,7 @@ menu_namespace: cliMenuAlpha
 import TableContainer from "~/components/Table/TableContainer.astro";
 import LinkButton from 'azion-webkit/linkbutton'
 
-O arquivo `vulcan.config.js` serve como um poderoso sistema de configuração para o Azion Bundler, oferecendo opções de personalização para o processo de build de sua aplicação. Embora não seja obrigatório, este arquivo atua como um mecanismo de substituição, permitindo que você defina propriedades que substituem as configurações predefinidas.
+O arquivo `bundler.config.js` serve como um poderoso sistema de configuração para o Azion Bundler, oferecendo opções de personalização para o processo de build de sua aplicação. Embora não seja obrigatório, este arquivo atua como um mecanismo de substituição, permitindo que você defina propriedades que substituem as configurações predefinidas.
  
 :::note 
 Propriedades não especificadas serão definidas para valores padrões.
@@ -50,7 +50,7 @@ O Azion Bundler utiliza os termos `compute` e `deliver` para descrever os modos 
 
 Para um projeto baseado em Next:
 
-```javascript title="vulcan.config.js"
+```javascript title="bundler.config.js"
 module.exports = {
   entry: 'src/index.js',
   builder: 'webpack',
@@ -71,7 +71,7 @@ module.exports = {
 ```
 
 <br />
-<LinkButton link="https://github.com/aziontech/bundler/" label="implementação do arquivo vulcan.config.js" severity="secondary"  target="_blank" />
+<LinkButton link="https://github.com/aziontech/bundler/" label="implementação do arquivo bundler.config.js" severity="secondary"  target="_blank" />
 
 ---
 

--- a/src/content/docs/pt-br/pages/guias/cli/cli-vulcan-use-polyfills.mdx
+++ b/src/content/docs/pt-br/pages/guias/cli/cli-vulcan-use-polyfills.mdx
@@ -76,9 +76,9 @@ Getting templates available? Choose a template for your project: (Use arrow keys
 cd polyfills-guide
 ```
 
-10. Crie o arquivo `vulcan.config.js` e cole as seguintes propriedades:
+10. Crie o arquivo `bundler.config.js` e cole as seguintes propriedades:
 
-```js title="polyfills-guide/vulcan.config.js"
+```js title="polyfills-guide/bundler.config.js"
 module.exports = {
   entry: 'main.js',
   builder: 'webpack',


### PR DESCRIPTION
### Changes

Replace the word 'Vulcan' with 'Bundler'(except on links)
