### PR TITLE
[EDU-5288] feature: add item to Release Notes - Connected Users dataset

### DIFF
--- a/src/content/docs/en/pages/guides/graphql/connected-users-dataset.mdx
+++ b/src/content/docs/en/pages/guides/graphql/connected-users-dataset.mdx
@@ -7,7 +7,7 @@ permalink: /documentation/products/guides/query-connected-users-data-with-graphq
 menu_namespace: graphqlMenu
 ---
 
-The **connectedUsersMetrics** dataset lets you get real-time aggregated data, provided by Azion Live Ingest, related to the number of users connected to your applications with live streamings. This dataset is part of the Real-Time Metrics GraphQL API and is generated from the raw HTTP events, which are populated just for clients with live streaming configurations.
+The **connectedUsersMetrics** dataset lets you get real-time aggregated data, provided by Azion Live Ingest, related to the number of users connected to your applications with live streamings. This dataset is part of the Real-Time Metrics GraphQL API.
 
 This information can be accessed through the GraphQL API, allowing you to transfer this data to a third-party platform, and enabling you to further analysis and review of user activity and engagement. Additionally, the data is available for up to *2 years*.
 

--- a/src/content/docs/en/pages/main-menu/release-notes/release-notes.mdx
+++ b/src/content/docs/en/pages/main-menu/release-notes/release-notes.mdx
@@ -9,6 +9,16 @@ permalink: /documentation/products/release-notes/
 ---
 import Tag from 'primevue/tag'
 
+## September 2, 2024
+
+### GraphQL API
+
+The new `connectedUsersMetrics` dataset is available in the **Real-Time Metrics GraphQL API**. Through this dataset, you can get real-time aggregated data, provided by Azion Live Ingest, related to the number of users connected to your applications with live streamings. It's generated from the raw HTTP events, which are populated just for clients with live streaming configurations.
+
+Find out more on [Real⁠-⁠Time Metrics GraphQL API Fields](/en/documentation/devtools/graphql-api/features/gql-real-time-metrics-fields/#connectedusersmetrics-live-ingest) and learn [How to query Connected Users data with GraphQL API](/en/documentation/products/guides/query-connected-users-data-with-graphql/).
+
+---
+
 ## August 30, 2024 
 
 ### Account policies

--- a/src/content/docs/en/pages/main-menu/release-notes/release-notes.mdx
+++ b/src/content/docs/en/pages/main-menu/release-notes/release-notes.mdx
@@ -13,7 +13,7 @@ import Tag from 'primevue/tag'
 
 ### GraphQL API
 
-The new `connectedUsersMetrics` dataset is available in the **Real-Time Metrics GraphQL API**. Through this dataset, you can get real-time aggregated data, provided by Azion Live Ingest, related to the number of users connected to your applications with live streamings. It's generated from the raw HTTP events, which are populated just for clients with live streaming configurations.
+The new `connectedUsersMetrics` dataset is available in the **Real-Time Metrics GraphQL API**. Through this dataset, you can get real-time aggregated data, provided by Azion Live Ingest, related to the number of users connected to your applications with live streamings.
 
 Find out more on [Real⁠-⁠Time Metrics GraphQL API Fields](/en/documentation/devtools/graphql-api/features/gql-real-time-metrics-fields/#connectedusersmetrics-live-ingest) and learn [How to query Connected Users data with GraphQL API](/en/documentation/products/guides/query-connected-users-data-with-graphql/).
 

--- a/src/content/docs/pt-br/pages/guias/graphql/connected-users-dataset.mdx
+++ b/src/content/docs/pt-br/pages/guias/graphql/connected-users-dataset.mdx
@@ -7,7 +7,7 @@ permalink: /documentacao/produtos/guias/query-dados-connected-users-com-graphql/
 menu_namespace: graphqlMenu
 ---
 
-O conjunto de dados **connectedUsersMetrics** permite que você obtenha dados agregados em tempo real, fornecidos pelo Live Ingest da Azion, relacionados ao número de usuários conectados às suas aplicações com transmissões ao vivo. Este conjunto de dados faz parte da GraphQL API do Real-Time Metrics e é gerado a partir dos eventos HTTP brutos, que são populados apenas para clientes com configurações de transmissão ao vivo.
+O conjunto de dados **connectedUsersMetrics** permite que você obtenha dados agregados em tempo real, fornecidos pelo Live Ingest da Azion, relacionados ao número de usuários conectados às suas aplicações com transmissões ao vivo. Este conjunto de dados faz parte da GraphQL API do Real-Time Metrics.
 
 Essas informações podem ser acessadas através da GraphQL API, permitindo que você transfira esses dados para uma plataforma de terceiros, possibilitando uma análise e revisão mais aprofundadas da atividade e engajamento dos usuários. Além disso, os dados estão disponíveis por até *2 anos*.
 

--- a/src/content/docs/pt-br/pages/menu-principal/release-notes/release-notes.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/release-notes/release-notes.mdx
@@ -9,6 +9,16 @@ permalink: /documentacao/produtos/release-notes/
 ---
 import Tag from 'primevue/tag'
 
+## 2 de setembro, 2024
+
+### GraphQL API
+
+O novo conjunto de dados `connectedUsersMetrics` está disponível na **Real-Time Metrics GraphQL API**. Através deste conjunto de dados, você pode obter dados agregados em tempo real, fornecidos pelo Live Ingest da Azion, relacionados ao número de usuários conectados às suas aplicações com transmissões ao vivo. Ele é gerado a partir dos eventos HTTP brutos, que são populados apenas para clientes com configurações de transmissão ao vivo.
+
+Saiba mais sobre [Real⁠-⁠Time Metrics GraphQL API Fields](/pt-br/documentacao/devtools/graphql-api/recursos/campos-gql-real-time-metrics/#connectedusersmetrics-live-ingest) e [Como consultar dados de usuários conectados com a GraphQL API](/pt-br/documentacao/produtos/guias/query-dados-connected-users-com-graphql/).
+
+---
+
 ## 30 de agosto, 2024 
 
 ### Políticas de conta

--- a/src/content/docs/pt-br/pages/menu-principal/release-notes/release-notes.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/release-notes/release-notes.mdx
@@ -13,7 +13,7 @@ import Tag from 'primevue/tag'
 
 ### GraphQL API
 
-O novo conjunto de dados `connectedUsersMetrics` está disponível na **Real-Time Metrics GraphQL API**. Através deste conjunto de dados, você pode obter dados agregados em tempo real, fornecidos pelo Live Ingest da Azion, relacionados ao número de usuários conectados às suas aplicações com transmissões ao vivo. Ele é gerado a partir dos eventos HTTP brutos, que são populados apenas para clientes com configurações de transmissão ao vivo.
+O novo conjunto de dados `connectedUsersMetrics` está disponível na **Real-Time Metrics GraphQL API**. Através deste conjunto de dados, você pode obter dados agregados em tempo real, fornecidos pelo Live Ingest da Azion, relacionados ao número de usuários conectados às suas aplicações com transmissões ao vivo.
 
 Saiba mais sobre [Real⁠-⁠Time Metrics GraphQL API Fields](/pt-br/documentacao/devtools/graphql-api/recursos/campos-gql-real-time-metrics/#connectedusersmetrics-live-ingest) e [Como consultar dados de usuários conectados com a GraphQL API](/pt-br/documentacao/produtos/guias/query-dados-connected-users-com-graphql/).
 


### PR DESCRIPTION
### Related issue:

[EDU-5288]

### Changes

- Add an item to the Release Notes page, related to the `Connected Users dataset` launching. 

### Additional links

n/a.

[EDU-5288]: https://aziontech.atlassian.net/browse/EDU-5288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ