### PR TITLE
[EDU-5348] Fix: substitute orch credentials with token

### DIFF
--- a/src/content/docs/en/pages/deploy-journey/configure-node/install-orch-agent/install-orch-agent.mdx
+++ b/src/content/docs/en/pages/deploy-journey/configure-node/install-orch-agent/install-orch-agent.mdx
@@ -18,7 +18,7 @@ Before installing the agent, it's necessary to generate a personal token.
 :::
 
 <LinkButton link="/en/documentation/products/guides/personal-tokens/" label="go to how to generate a personal token" severity="secondary" />
-<LinkButton link="/en/documentation/products/accounts/personal-tokens/" label="go to personal tokens reference documentation" severity="secondary" target="_blank" />
+<LinkButton link="/en/documentation/products/accounts/personal-tokens/" label="go to Personal Token reference documentation" severity="secondary" target="_blank" />
 
 To begin the **Edge Node** installation process, you must download the **Edge Orchestrator** installation binary of your choice.
 

--- a/src/content/docs/en/pages/deploy-journey/configure-node/install-orch-agent/install-orch-agent.mdx
+++ b/src/content/docs/en/pages/deploy-journey/configure-node/install-orch-agent/install-orch-agent.mdx
@@ -14,10 +14,11 @@ menu_namespace: deployMenu
 import LinkButton from 'azion-webkit/linkbutton'
 
 :::note
-Before installing the agent, it's necessary to generate a credential.
+Before installing the agent, it's necessary to generate a personal token.
 :::
-<LinkButton link="/en/documentation/products/guides/deploy/generate-credentials/" label="go to how to generate credentials" severity="secondary" />
-<LinkButton link="/en/documentation/products/deploy/credentials/" label="go to credentials reference documentation" severity="secondary" target="_blank" />
+
+<LinkButton link="/en/documentation/products/guides/personal-tokens/" label="go to how to generate a personal token" severity="secondary" />
+<LinkButton link="/en/documentation/products/accounts/personal-tokens/" label="go to personal tokens reference documentation" severity="secondary" target="_blank" />
 
 To begin the **Edge Node** installation process, you must download the **Edge Orchestrator** installation binary of your choice.
 
@@ -53,7 +54,7 @@ After downloading, follow the steps below to install the Edge Orchestrator agent
    sudo ./edge-orchestrator install
 ```
 
-2. Enter the credential for the Edge Orchestrator agent.
+2. Enter your personal token when prompted.
 3. Start the **Edge Orchestrator** agent after installing it:
 
 ```bash

--- a/src/content/docs/en/pages/deploy-journey/deploy-service/deploy-service.mdx
+++ b/src/content/docs/en/pages/deploy-journey/deploy-service/deploy-service.mdx
@@ -21,7 +21,7 @@ Azion has two user interfaces: Real-Time Manager and Console, which is in *Previ
 
 **Edge Orchestrator** allows you to manage and control edge resources in real time, including the deployment, update, and management of various services and resources.
 
-Azion provides two ways to manage edge nodes, edge services and resources: 
+Azion provides two ways to manage edge nodes, edge services, and resources: 
 
 - Via [Azion API](https://api.azion.com)
 - Via interface [Azion Console](/en/documentation/products/guides/how-to-access-azion-console/) or [Azion Real-Time Manager (RTM)](https://manager.azion.com/)
@@ -30,7 +30,7 @@ Azion provides two ways to manage edge nodes, edge services and resources:
 The creation of an edge node occurs directly on the devices when the [Edge Orchestrator Agent](/en/documentation/products/guides/deploy/install-orchestrator-agent/) is installed on them.
 :::
 
-<LinkButton link="/en/documentation/products/guides/deploy/install-orchestrator-agent/" label="go to Install Edge Orchestrator agent" severity="secondary" />
+<LinkButton link="/en/documentation/products/guides/deploy/install-orchestrator-agent/" label="go to install Edge Orchestrator agent" severity="secondary" />
 
 ---
 
@@ -75,7 +75,7 @@ To do so:
 With the personal token created, download and install the Edge Orchestrator agent:
 
 
-<LinkButton link="/en/documentation/products/guides/deploy/install-orchestrator-agent/" label="go to how to install edge orchestrator agent" severity="secondary" target="_blank" />
+<LinkButton link="/en/documentation/products/guides/deploy/install-orchestrator-agent/" label="go to how to install Edge Orchestrator Agent" severity="secondary" target="_blank" />
 
 ---
 
@@ -87,7 +87,7 @@ With the Edge Orchestrator Agent installed on the device:
 
 <LinkButton link="/en/documentation/products/guides/deploy/authorize-an-edge-node/" label="go to how to authorize an edge node" severity="secondary" target="_blank" />
 <br/>
-<LinkButton link="/en/documentation/products/deploy/edge-orchestrator/edge-node/" label="go to edge node reference documentation" severity="secondary" />
+<LinkButton link="/en/documentation/products/deploy/edge-orchestrator/edge-node/" label="go to Edge Node reference documentation" severity="secondary" />
 
 ---
 

--- a/src/content/docs/en/pages/deploy-journey/deploy-service/deploy-service.mdx
+++ b/src/content/docs/en/pages/deploy-journey/deploy-service/deploy-service.mdx
@@ -21,7 +21,7 @@ Azion has two user interfaces: Real-Time Manager and Console, which is in *Previ
 
 **Edge Orchestrator** allows you to manage and control edge resources in real time, including the deployment, update, and management of various services and resources.
 
-Azion provides two ways to manage edge nodes, edge services, resources, and credentials: 
+Azion provides two ways to manage edge nodes, edge services and resources: 
 
 - Via [Azion API](https://api.azion.com)
 - Via interface [Azion Console](/en/documentation/products/guides/how-to-access-azion-console/) or [Azion Real-Time Manager (RTM)](https://manager.azion.com/)
@@ -56,25 +56,24 @@ To create a resource, you need to:
 
 ---
 
-## Step 3: Generate a credential 
+## Step 3: Generate a personal token 
 
-To be able to manage edge nodes, you must generate the credentials used by the Azion Orchestrator Agent.
+To be able to manage edge nodes, you must generate a personal token.
 
 To do so: 
 
-- Choose a description.
 - Add an easy-to-remember name.
-- Set the credential as active.
+- Add a description.
+- Set the expiration data for the token.
 
-<LinkButton link="/en/documentation/products/guides/deploy/generate-credentials/" label="go to create a credential" severity="secondary" />
+<LinkButton link="/en/documentation/products/guides/personal-tokens/" label="go to generate a personal token" severity="secondary" />
 
 ---
 
 ## Step 4: Install Edge Orchestrator Agent 
 
-With the credentials created:
+With the personal token created, download and install the Edge Orchestrator agent:
 
-- Download and install the Edge Orchestrator agent with the recently created credentials.
 
 <LinkButton link="/en/documentation/products/guides/deploy/install-orchestrator-agent/" label="go to how to install edge orchestrator agent" severity="secondary" target="_blank" />
 

--- a/src/content/docs/en/pages/deploy-journey/overview/overview.mdx
+++ b/src/content/docs/en/pages/deploy-journey/overview/overview.mdx
@@ -41,16 +41,9 @@ It allows configuration of install, uninstall, and reload triggers, and definiti
 
 ### Edge Nodes
 
-An edge node is a device that has Azion Orchestrator Agent installed with the due credentials configured and authorized on the platform.
+An edge node is a device that has Azion Orchestrator Agent installed and enables you to create your own edge infrastructure.
 
 Edge Orchestrator allows customers to manage their own edge nodes, independent of the Azion distributed network. To start provisioning applications, it's essential to configure edge nodes.
 
 <LinkButton link="/en/documentation/products/deploy/edge-orchestrator/edge-node/" label="go to edge node reference documentation" severity="secondary" target="_blank" />
 <LinkButton link="/en/documentation/products/guides/deploy/authorize-an-edge-node/" label="go to how to authorize an edge node" severity="secondary" target="_blank" />
-
-### Credentials 
-
-**Credentials** are keys used to authenticate edge nodes.
-
-<LinkButton link="/en/documentation/products/deploy/credentials/" label="go to credentials reference documentation" severity="secondary" target="_blank" />
-<LinkButton link="/en/documentation/products/guides/deploy/generate-credentials/" label="go to how to generate credentials" severity="secondary" target="_blank" />

--- a/src/content/docs/en/pages/deploy-journey/overview/overview.mdx
+++ b/src/content/docs/en/pages/deploy-journey/overview/overview.mdx
@@ -27,7 +27,7 @@ When the Azion Orchestrator Agent is installed on a device and the device is aut
 :::
 
 <LinkButton link="/en/documentation/products/deploy/edge-orchestrator/" label="go to edge orchestrator reference documentation" severity="secondary" target="_blank" />
-<LinkButton link="/en/documentation/products/guides/deploy/install-orchestrator-agent/" label="go to how to install edge orchestrator agent" severity="secondary" target="_blank" />
+<LinkButton link="/en/documentation/products/guides/deploy/install-orchestrator-agent/" label="go to how to install Edge Orchestrator Agent" severity="secondary" target="_blank" />
 
 
 ### Edge Services

--- a/src/content/docs/pt-br/pages/deploy-jornada/configurar-node/instalar-orch-agent/instalar-orch-agent.mdx
+++ b/src/content/docs/pt-br/pages/deploy-jornada/configurar-node/instalar-orch-agent/instalar-orch-agent.mdx
@@ -19,7 +19,7 @@ Antes de instalar o agente, é necessário gerar um personal token.
 :::
 
 <LinkButton link="/pt-br/documentacao/produtos/guias/personal-tokens/" label="consulte o guia de criação de personal tokens" severity="secondary" />
-<LinkButton link="/pt-br/documentacao/produtos/gestao-de-contas/personal-tokens/" label="ir para a documentação de referência de personal tokens" severity="secondary" target="_blank" />
+<LinkButton link="/pt-br/documentacao/produtos/gestao-de-contas/personal-tokens/" label="saiba mais sobre personal tokens" severity="secondary" target="_blank" />
 
 Para iniciar o processo de instalação do edge node, você deve baixar o binário de instalação do **Edge Orchestrator** de sua escolha.
 

--- a/src/content/docs/pt-br/pages/deploy-jornada/configurar-node/instalar-orch-agent/instalar-orch-agent.mdx
+++ b/src/content/docs/pt-br/pages/deploy-jornada/configurar-node/instalar-orch-agent/instalar-orch-agent.mdx
@@ -15,10 +15,11 @@ menu_namespace: deployMenu
 import LinkButton from 'azion-webkit/linkbutton'
 
 :::note
-Antes de instalar o agente, é necessário gerar uma credencial.
+Antes de instalar o agente, é necessário gerar um personal token.
 :::
 
-<LinkButton link="/pt-br/documentacao/produtos/deploy/credenciais/" label="ir para a documentação de referência de credenciais" severity="secondary" target="_blank" />
+<LinkButton link="/pt-br/documentacao/produtos/guias/personal-tokens/" label="consulte o guia de criação de personal tokens" severity="secondary" />
+<LinkButton link="/pt-br/documentacao/produtos/gestao-de-contas/personal-tokens/" label="ir para a documentação de referência de personal tokens" severity="secondary" target="_blank" />
 
 Para iniciar o processo de instalação do edge node, você deve baixar o binário de instalação do **Edge Orchestrator** de sua escolha.
 
@@ -54,7 +55,7 @@ sudo chmod +x edge-orchestrator
 sudo ./edge-orchestrator install
 ```
 
-2. Insira a credencial para o Edge Orchestrator Agent.
+2. Insira o personal token quando solicitado.
 3. Inicie o Edge Orchestrator Agent após instalá-lo:
 
 ```bash

--- a/src/content/docs/pt-br/pages/deploy-jornada/deploy-service/deploy-service.mdx
+++ b/src/content/docs/pt-br/pages/deploy-jornada/deploy-service/deploy-service.mdx
@@ -20,7 +20,7 @@ A Azion possui duas interfaces de usuário: Real-Time Manager e Console, que est
 
 **Edge Orchestrator** permite que você gerencie e controle recursos de edge em tempo real, incluindo a implantação, atualização e gerenciamento de vários serviços e recursos.
 
-A Azion oferece duas maneiras de gerenciar edge nodes, edge services, recursos e credenciais:
+A Azion oferece duas maneiras de gerenciar edge nodes, edge services, e recursos:
 
 - Via [Azion API](https://api.azion.com/#9a7daab9-63f7-43a9-9959-2bd91088fca8)
 - Via interface: [Azion Console](/pt-br/documentacao/produtos/guias/como-acessar-o-azion-console/) ou [Azion Real-Time Manager (RTM)](https://manager.azion.com/)
@@ -55,15 +55,15 @@ Para criar um recurso, você precisa:
 
 ---
 
-## Passo 3: Gere uma credencial 
+## Passo 3: Gere um personal token
 
-Para poder gerenciar edge nodes, você deve gerar as credenciais usadas pelo Edge Orchestrator Agent.
+Para poder gerenciar edge nodes, você deve gerar um personal token.
 
 Para fazer isso: 
 
-- Escolha uma descrição.
 - Dê um nome fácil de lembrar.
-- Defina a credencial como ativa.
+- Escreva uma descrição.
+- Defina o tempo de expiração do token.
 
 <LinkButton link="/pt-br/documentacao/produtos/guias/deploy/gerar-credentials/" label="consulte o guia para criar uma credencial" severity="secondary" />
 <br/>
@@ -73,7 +73,7 @@ Para fazer isso:
 
 ## Passo 4: Instale o Agente do Edge Orchestrator
 
-Com as credenciais criadas, baixe e instale o Agente do Edge Orchestrator.
+Com o personal token criado, baixe e instale o Agente do Edge Orchestrator.
 
 <LinkButton link="/pt-br/documentacao/produtos/guias/deploy/instalar-orchestrator-agent/" label="consulte o guia de instalação do edge orchestrator agent" severity="secondary" />
 

--- a/src/content/docs/pt-br/pages/deploy-jornada/deploy-service/deploy-service.mdx
+++ b/src/content/docs/pt-br/pages/deploy-jornada/deploy-service/deploy-service.mdx
@@ -20,7 +20,7 @@ A Azion possui duas interfaces de usuário: Real-Time Manager e Console, que est
 
 **Edge Orchestrator** permite que você gerencie e controle recursos de edge em tempo real, incluindo a implantação, atualização e gerenciamento de vários serviços e recursos.
 
-A Azion oferece duas maneiras de gerenciar edge nodes, edge services, e recursos:
+A Azion oferece duas maneiras de gerenciar edge nodes, edge services e recursos:
 
 - Via [Azion API](https://api.azion.com/#9a7daab9-63f7-43a9-9959-2bd91088fca8)
 - Via interface: [Azion Console](/pt-br/documentacao/produtos/guias/como-acessar-o-azion-console/) ou [Azion Real-Time Manager (RTM)](https://manager.azion.com/)
@@ -65,9 +65,7 @@ Para fazer isso:
 - Escreva uma descrição.
 - Defina o tempo de expiração do token.
 
-<LinkButton link="/pt-br/documentacao/produtos/guias/deploy/gerar-credentials/" label="consulte o guia para criar uma credencial" severity="secondary" />
-<br/>
-<LinkButton link="/pt-br/documentacao/produtos/deploy/credenciais/" label="saiba mais sobre as credenciais" severity="secondary" />
+<LinkButton link="/pt-br/documentacao/produtos/guias/personal-tokens/" label="consulte o guia de criação de personal tokens" severity="secondary" />
 
 ---
 
@@ -75,7 +73,7 @@ Para fazer isso:
 
 Com o personal token criado, baixe e instale o Agente do Edge Orchestrator.
 
-<LinkButton link="/pt-br/documentacao/produtos/guias/deploy/instalar-orchestrator-agent/" label="consulte o guia de instalação do edge orchestrator agent" severity="secondary" />
+<LinkButton link="/pt-br/documentacao/produtos/guias/deploy/instalar-orchestrator-agent/" label="consulte o guia de instalação do Edge Orchestrator Agent" severity="secondary" />
 
 ---
 

--- a/src/content/docs/pt-br/pages/deploy-jornada/overview/overview.mdx
+++ b/src/content/docs/pt-br/pages/deploy-jornada/overview/overview.mdx
@@ -42,16 +42,9 @@ Ele permite a configuração de gatilhos de instalação, desinstalação e reca
 
 ### Edge Nodes
 
-Um edge node é um dispositivo que tem o Agente do Azion Orchestrator instalado com as devidas credenciais configuradas e autorizadas na plataforma.
+Um edge node é um dispositivo que tem o Agente do Azion Orchestrator instalado e permite que você crie a sua própria estrutura Edge.
 
 O Edge Orchestrator permite que os clientes gerenciem seus próprios edge nodes, independentemente da rede distribuída da Azion. Para começar a provisionar aplicações, é essencial configurar os edge nodes.
 
 <LinkButton link="/pt-br/documentacao/produtos/deploy/edge-orchestrator/edge-node/" label="saiba mais sobre edge nodes" severity="secondary" target="_blank" />
 <LinkButton link="/pt-br/documentacao/produtos/guias/deploy/autorizar-edge-node/" label="consulte o guia para autorizar um edge node" severity="secondary" target="_blank" />
-
-### Credentials
-
-**Credentials** são chaves usadas para autenticar edge nodes.
-
-<LinkButton link="/pt-br/documentacao/produtos/deploy/credenciais/" label="saiba mais sobre as credenciais" severity="secondary" target="_target=_blank" />
-<LinkButton link="/pt-br/documentacao/produtos/guias/deploy/gerar-credentials/" label="consulte o guia de criação de credenciais" severity="secondary" target="_blank" />

--- a/src/content/docs/pt-br/pages/deploy-jornada/overview/overview.mdx
+++ b/src/content/docs/pt-br/pages/deploy-jornada/overview/overview.mdx
@@ -28,8 +28,8 @@ Um agente do Edge Orchestrator é instalado nos edge nodes e fornece gerenciamen
 Quando o Agente do Azion Edge Orchestrator é instalado em um dispositivo e o dispositivo é autorizado, ele agora representa um edge node. Um serviço pode ser vinculado a vários edge nodes. Quando um serviço é atualizado, ele será automaticamente implantado nos edge nodes aos quais está relacionado.
 :::
 
-<LinkButton link="/pt-br/documentacao/produtos/deploy/edge-orchestrator/" label="saiba mais sobre o edge orchestrator" severity="secondary" target="_blank" />
-<LinkButton link="/pt-br/documentacao/produtos/guias/deploy/instalar-orchestrator-agent/" label="consulte o guia de instalação do edge orchestrator agent" severity="secondary" target="_blank" />
+<LinkButton link="/pt-br/documentacao/produtos/deploy/edge-orchestrator/" label="saiba mais sobre o Edge Orchestrator" severity="secondary" target="_blank" />
+<LinkButton link="/pt-br/documentacao/produtos/guias/deploy/instalar-orchestrator-agent/" label="consulte o guia de instalação do Edge Orchestrator Agent" severity="secondary" target="_blank" />
 
 ### Edge Services
 
@@ -46,5 +46,5 @@ Um edge node é um dispositivo que tem o Agente do Azion Orchestrator instalado 
 
 O Edge Orchestrator permite que os clientes gerenciem seus próprios edge nodes, independentemente da rede distribuída da Azion. Para começar a provisionar aplicações, é essencial configurar os edge nodes.
 
-<LinkButton link="/pt-br/documentacao/produtos/deploy/edge-orchestrator/edge-node/" label="saiba mais sobre edge nodes" severity="secondary" target="_blank" />
+<LinkButton link="/pt-br/documentacao/produtos/deploy/edge-orchestrator/edge-node/" label="saiba mais sobre Edge Node" severity="secondary" target="_blank" />
 <LinkButton link="/pt-br/documentacao/produtos/guias/deploy/autorizar-edge-node/" label="consulte o guia para autorizar um edge node" severity="secondary" target="_blank" />

--- a/src/i18n/en/deployMenu.ts
+++ b/src/i18n/en/deployMenu.ts
@@ -60,14 +60,6 @@ export default [
 		key: 'configEdgeNode',
 		items: [
 			{
-				text: 'Generate a credential',
-				header: true,
-				anchor: true,
-				type: 'learn',
-				slug: '/documentation/products/guides/deploy/generate-credentials/',
-				key: 'generateCredentials',
-			},
-			{
 				text: 'Install agent',
 				header: true,
 				anchor: true,

--- a/src/i18n/pt-br/deployMenu.ts
+++ b/src/i18n/pt-br/deployMenu.ts
@@ -56,14 +56,6 @@ export default [
 		key: 'configEdgeNode',
 		items: [
 			{
-				text: 'Gere credenciais',
-				header: true,
-				anchor: true,
-				type: 'learn',
-				slug: '/documentacao/produtos/guias/deploy/gerar-credentials/',
-				key: 'generateCredentials',
-			},
-			{
 				text: 'Instale o agente',
 				header: true,
 				anchor: true,


### PR DESCRIPTION
### Changes

Removes references to orchestrator credentials and menu entries in deploy journey, replacing it with "personal token" (the new correct way to install the agent and manage edge nodes).