### PR TITLE
[No-issue] fix: typo in A/B Testing guide

### DIFF
--- a/src/content/docs/pt-br/pages/guias/marketplace/integrations/ab-testing-marketplace.mdx
+++ b/src/content/docs/pt-br/pages/guias/marketplace/integrations/ab-testing-marketplace.mdx
@@ -46,7 +46,7 @@ Você pode procurar qualquer integração navegando pelos cards, usando os filtr
 
 ---
 
-## Confirgure a integração
+## Configure a integração
 
 Sendo uma [Edge Application function](/pt-br/documentacao/produtos/marketplace/integracoes/#edge-application-functions), a **Teste A/B** executa tarefas e serviços no edge, empregando uma edge application *existente*.
 


### PR DESCRIPTION
### Related issue:

[No-issue] 

### Changes

- Fix a typo in the A/B Testing guide, PT.

### Additional links

n/a.