### PR TITLE
[EDU-5388] Add E-commerce Astro Templates guide

### DIFF
--- a/src/content/docs/en/pages/guides/index.mdx
+++ b/src/content/docs/en/pages/guides/index.mdx
@@ -72,6 +72,7 @@ permalink: /documentation/products/guides/
 - [How to create a WordPress website from scratch with WordPress InstaCreator](/en/documentation/products/guides/wordpress-instacreator/)
 - [How to deploy a blog based on Gatsby using a template](/en/documentation/products/guides/gatsby-blog-starter-kit/)
 - [How to deploy an Astro blog using a template](/en/documentation/products/guides/astro-blog-starter-kit/)
+- [How to deploy an Astro e-commerce using a template](/en/documentation/products/guides/astro-ecommerce-collection/)
 - [How to deploy and test HTMX on the edge with a template](/en/documentation/products/guides/htmx-boilerplate/)
 - [How to deploy edge applications with the Angular Boilerplate](/en/documentation/products/guides/angular-boilerplate/)
 - [How to deploy edge applications with the Astro Boilerplate](/en/documentation/products/guides/astro-boilerplate/)

--- a/src/content/docs/en/pages/guides/index.mdx
+++ b/src/content/docs/en/pages/guides/index.mdx
@@ -72,7 +72,7 @@ permalink: /documentation/products/guides/
 - [How to create a WordPress website from scratch with WordPress InstaCreator](/en/documentation/products/guides/wordpress-instacreator/)
 - [How to deploy a blog based on Gatsby using a template](/en/documentation/products/guides/gatsby-blog-starter-kit/)
 - [How to deploy an Astro blog using a template](/en/documentation/products/guides/astro-blog-starter-kit/)
-- [How to deploy an Astro e-commerce using a template](/en/documentation/products/guides/astro-ecommerce-collection/)
+- [How to deploy an e-commerce based on Astro using a template](/en/documentation/products/guides/astro-ecommerce-collection/)
 - [How to deploy and test HTMX on the edge with a template](/en/documentation/products/guides/htmx-boilerplate/)
 - [How to deploy edge applications with the Angular Boilerplate](/en/documentation/products/guides/angular-boilerplate/)
 - [How to deploy edge applications with the Astro Boilerplate](/en/documentation/products/guides/astro-boilerplate/)

--- a/src/content/docs/en/pages/guides/marketplace/templates/astro-ecommerce-collection.mdx
+++ b/src/content/docs/en/pages/guides/marketplace/templates/astro-ecommerce-collection.mdx
@@ -1,0 +1,108 @@
+---
+title: How to deploy an e-commerce with Astro using templates
+description: >-
+  This guide contains instructions to create an e-commerce application using templates based on Astro.
+meta_tags: >-
+  Astro, e-commerce, templates, guides, Azion Marketplace, deployment, online store
+namespace: docs_guides_astro_ecommerce
+permalink: /documentation/products/guides/astro-ecommerce-collection/
+---
+
+import LinkButton from 'azion-webkit/linkbutton';
+import Tag from 'primevue/tag';
+
+<Tag severity="info" client:only="vue">
+Preview
+</Tag>
+
+The **Astro E-commerce Templates** collection offers configurations for building e-commerce applications using templates. These templates are all based on the **Astro** framework.
+
+The available templates are:
+
+- **Astro Audiophile**: create a stylish e-commerce based on Astro. Uses version `3.1.2`of Astro.
+- **Astro Ecommerce**: deploy a complete e-commerce. Uses version `2.0.1` of Astro.
+- **Astro Quickstore**: create your online store with Astro and Tailwind CSS. Uses versions `2.0.1` of Astro and `4.0.0-alpha.23` of Tailwind CSS.
+
+The deployment process for each of these templates creates a GitHub repository for your project, along with an edge application and a domain. This setup enables easy access and management of your e-commerce application through the Azion Edge Platform.
+
+---
+
+## Requirements
+
+- A [GitHub account](https://github.com/signup) to connect with Azion and create your new repository.
+    - Every push will be deployed automatically to this repository to keep your project updated.
+- These templates use [Application Accelerator](/en/documentation/products/build/edge-application/application-accelerator/), [Edge Functions](/en/documentation/products/build/edge-application/edge-functions/), and [Edge Cache](https://www.azion.com/en/documentation/products/build/edge-application/edge-cache/), and could generate usage-related costs. Check the [pricing page](https://www.azion.com/en/pricing/) for more information.
+
+---
+
+## Deploying the template
+
+You can obtain and configure your templates through the Azion Console. To easily deploy any of them at the edge, click the respective button below.
+
+<LinkButton
+    label="Astro Audiophile"
+    link="https://console.azion.com/create/azion-community/astro-audiophile"
+    icon="ai ai-azion"
+    icon-pos="left"
+  />
+<LinkButton
+    label="Astro Ecommerce"
+    link="https://console.azion.com/create/azion-community/astro-ecommerce"
+    icon="ai ai-azion"
+    icon-pos="left"
+  />
+<LinkButton
+    label="Astro Quickstore"
+    link="https://console.azion.com/create/azion-community/astro-quickstore"
+    icon="ai ai-azion"
+    icon-pos="left"
+  />
+
+---
+
+## Setting up the template
+
+In the configuration form, you must provide the information to configure your application. Fill in the presented fields. 
+
+Fields identified with an asterisk are mandatory.
+
+1. Connect Azion with your GitHub account.
+    - A pop-up window will open to confirm the installation of the [Azion GitHub App](/en/documentation/products/guides/azion-github-app/), a tool that connects your GitHub account with Azion's platform.
+    - Define your permissions and repository access as desired.
+2. Select the **Git Scope** to work with.
+3. Define a name for your edge application.
+    - The bucket for storage and the edge function will use the same name.
+    - Use a unique and easy-to-remember name. If the name has already been used, the platform returns an error message.
+4. Click the **Deploy** button to start the deployment process.
+
+During the deployment, you'll be able to follow the process through a window showing off the logs. When it's complete, the page shows information about the application and some options to continue your journey.
+
+:::note
+The link to the edge application allows you to see it on the browser. However, it takes a certain time to propagate and configure the application in Azion's edge locations. It may be necessary to wait a few minutes for the URL to be activated and for the application page to be effectively displayed in the browser.
+:::
+
+---
+
+## Managing the template
+
+Considering that this initial setup may not be optimal for your specific edge application, all settings can be customized any time you need by using Azion's platform.
+
+To manage and edit your edge application's settings, follow these steps:
+
+1. [Access Azion Console](https://console.azion.com).
+2. On the upper-left corner, select **Products menu**, the icon with three horizontal lines, > **Edge Application**.
+    - You'll be redirected to the **Edge Application** page. It lists all the edge applications you've created.
+3. Find the edge application related to your template and select it.
+    - The list is organized alphabetically. You can also use the **search bar** located in the upper-left corner of the list; currently, it filters only by **Application Name**.
+
+After selecting the edge application you'll work on, you'll be directed to a page containing all the settings you can configure.
+
+:::tip
+Read the documentation about [managing edge applications](/en/documentation/products/build/edge-application/first-steps/) for more details.
+:::
+
+### Adding a custom domain
+
+The edge application created during the deployment has an assigned Azion domain to make it accessible through the browser. The domain has the following format: `xxxxxxxxxx.map.azionedge.net/`. However, you can add a custom domain for users to access your edge application through it.
+
+<LinkButton link="/en/documentation/products/guides/configure-a-domain/" label="go to configuring a domain guide" severity="secondary" /> 

--- a/src/content/docs/en/pages/guides/marketplace/templates/astro-ecommerce-collection.mdx
+++ b/src/content/docs/en/pages/guides/marketplace/templates/astro-ecommerce-collection.mdx
@@ -1,5 +1,5 @@
 ---
-title: How to deploy an e-commerce with Astro using templates
+title: How to deploy an e-commerce based on Astro using templates
 description: >-
   This guide contains instructions to create an e-commerce application using templates based on Astro.
 meta_tags: >-
@@ -19,9 +19,9 @@ The **Astro E-commerce Templates** collection offers configurations for building
 
 The available templates are:
 
-- **Astro Audiophile**: create a stylish e-commerce based on Astro. Uses version `3.1.2`of Astro.
-- **Astro Ecommerce**: deploy a complete e-commerce. Uses version `2.0.1` of Astro.
-- **Astro Quickstore**: create your online store with Astro and Tailwind CSS. Uses versions `2.0.1` of Astro and `4.0.0-alpha.23` of Tailwind CSS.
+- **Astro Audiophile**: create a stylish e-commerce based on Astro. It uses version `3.1.2`of Astro.
+- **Astro Ecommerce**: deploy a complete e-commerce. It uses version `2.0.1` of Astro.
+- **Astro Quickstore**: create your online store with Astro and Tailwind CSS. It uses versions `2.0.1` of Astro and `4.0.0-alpha.23` of Tailwind CSS.
 
 The deployment process for each of these templates creates a GitHub repository for your project, along with an edge application and a domain. This setup enables easy access and management of your e-commerce application through the Azion Edge Platform.
 
@@ -40,19 +40,19 @@ The deployment process for each of these templates creates a GitHub repository f
 You can obtain and configure your templates through the Azion Console. To easily deploy any of them at the edge, click the respective button below.
 
 <LinkButton
-    label="Astro Audiophile"
+    label="Deploy Astro Audiophile"
     link="https://console.azion.com/create/azion-community/astro-audiophile"
     icon="ai ai-azion"
     icon-pos="left"
   />
 <LinkButton
-    label="Astro Ecommerce"
+    label="Deploy Astro Ecommerce"
     link="https://console.azion.com/create/azion-community/astro-ecommerce"
     icon="ai ai-azion"
     icon-pos="left"
   />
 <LinkButton
-    label="Astro Quickstore"
+    label="Deploy Astro Quickstore"
     link="https://console.azion.com/create/azion-community/astro-quickstore"
     icon="ai ai-azion"
     icon-pos="left"

--- a/src/content/docs/en/pages/guides/marketplace/templates/astro-ecommerce-collection.mdx
+++ b/src/content/docs/en/pages/guides/marketplace/templates/astro-ecommerce-collection.mdx
@@ -4,7 +4,7 @@ description: >-
   This guide contains instructions to create an e-commerce application using templates based on Astro.
 meta_tags: >-
   Astro, e-commerce, templates, guides, Azion Marketplace, deployment, online store
-namespace: docs_guides_astro_ecommerce
+namespace: docs_guides_astro_ecommerce_templates_collection
 permalink: /documentation/products/guides/astro-ecommerce-collection/
 ---
 

--- a/src/content/docs/en/pages/main-menu/additional-resources/templates-and-integrations/understand-azion-templates.mdx
+++ b/src/content/docs/en/pages/main-menu/additional-resources/templates-and-integrations/understand-azion-templates.mdx
@@ -128,6 +128,12 @@ The Azion Astro Boilerplate encapsulates and automates several steps, from repos
     icon="ai ai-azion"
     icon-pos="left"
   />
+  
+#### Astro E-commerce
+
+The Astro E-commerce Templates collection presents a number of templates to deploy an e-commerce application based on Astro. You can choose and deploy the template that best fits your needs and preferences.
+
+<LinkButton link="/en/documentation/products/guides/astro-ecommerce-collection/" label="go to the Astro E-commerce Templates guide" severity="secondary" /> 
 
 #### Azion Starter Kit
 

--- a/src/content/docs/pt-br/pages/guias/guides.mdx
+++ b/src/content/docs/pt-br/pages/guias/guides.mdx
@@ -103,7 +103,7 @@ permalink: /documentacao/produtos/guias/
 - [Como implantar o VitePress TyeScript Boilerplate](/pt-br/documentacao/produtos/guias/vitepress-typescript-boilerplate/)
 - [Como implantar um blog Astro usando um template](/pt-br/documentacao/produtos/guias/astro-blog-starter-kit/)
 - [Como implantar um blog baseado no Gatsby usando um template](/pt-br/documentacao/produtos/guias/gatsby-blog-starter-kit/)
-- [Como implantar um e-commerce com Astro usando um template](/pt-br/documentacao/produtos/guias/astro-ecommerce-collection/)
+- [Como implantar um e-commerce baseado no Astro usando um template](/pt-br/documentacao/produtos/guias/astro-ecommerce-collection/)
 - [Como integrar um banco de dados Turso com Azion usando um template](/pt-br/documentacao/produtos/guias/turso-starter-kit/)
 - [Como testar o Bot Manager usando um template](/pt-br/documentacao/produtos/guias/bot-manager-starter-kit/)
 - [Como migrar um site WordPress para o edge com WordPress EdgeAccelerator](/pt-br/documentacao/produtos/guias/wordpress-edgeaccelerator/)

--- a/src/content/docs/pt-br/pages/guias/guides.mdx
+++ b/src/content/docs/pt-br/pages/guias/guides.mdx
@@ -103,6 +103,7 @@ permalink: /documentacao/produtos/guias/
 - [Como implantar o VitePress TyeScript Boilerplate](/pt-br/documentacao/produtos/guias/vitepress-typescript-boilerplate/)
 - [Como implantar um blog Astro usando um template](/pt-br/documentacao/produtos/guias/astro-blog-starter-kit/)
 - [Como implantar um blog baseado no Gatsby usando um template](/pt-br/documentacao/produtos/guias/gatsby-blog-starter-kit/)
+- [Como implantar um e-commerce com Astro usando um template](/pt-br/documentacao/produtos/guias/astro-ecommerce-collection/)
 - [Como integrar um banco de dados Turso com Azion usando um template](/pt-br/documentacao/produtos/guias/turso-starter-kit/)
 - [Como testar o Bot Manager usando um template](/pt-br/documentacao/produtos/guias/bot-manager-starter-kit/)
 - [Como migrar um site WordPress para o edge com WordPress EdgeAccelerator](/pt-br/documentacao/produtos/guias/wordpress-edgeaccelerator/)

--- a/src/content/docs/pt-br/pages/guias/marketplace/templates/astro-ecommerce-collection.mdx
+++ b/src/content/docs/pt-br/pages/guias/marketplace/templates/astro-ecommerce-collection.mdx
@@ -1,5 +1,5 @@
 ---
-title: Como implantar um e-commerce com Astro usando templates
+title: Como implantar um e-commerce baseado no Astro usando um template
 description: >-
   Este guia contém instruções para criar uma aplicação e-commerce usando templates baseados em Astro.
 meta_tags: >-
@@ -40,19 +40,19 @@ O processo de implantação para cada um desses templates cria um repositório d
 Você pode obter e configurar seus templates através do Console da Azion. Para implantar um deles facilmente no edge, clique no respectivo botão abaixo.
 
 <LinkButton
-    label="Astro Audiophile"
+    label="Implantar Astro Audiophile"
     link="https://console.azion.com/create/azion-community/astro-audiophile"
     icon="ai ai-azion"
     icon-pos="left"
   />
 <LinkButton
-    label="Astro Ecommerce"
+    label="Implantar Astro Ecommerce"
     link="https://console.azion.com/create/azion-community/astro-ecommerce"
     icon="ai ai-azion"
     icon-pos="left"
   />
 <LinkButton
-    label="Astro Quickstore"
+    label="Implantar Astro Quickstore"
     link="https://console.azion.com/create/azion-community/astro-quickstore"
     icon="ai ai-azion"
     icon-pos="left"

--- a/src/content/docs/pt-br/pages/guias/marketplace/templates/astro-ecommerce-collection.mdx
+++ b/src/content/docs/pt-br/pages/guias/marketplace/templates/astro-ecommerce-collection.mdx
@@ -5,7 +5,7 @@ description: >-
 meta_tags: >-
   Astro, e-commerce, templates, guides, Azion Marketplace, deployment, online store
 namespace: docs_guides_astro_ecommerce
-permalink: /documentacao/produtos/guias/astro-ecommerce-colecao/
+permalink: /documentacao/produtos/guias/astro-ecommerce-collection/
 ---
 
 import LinkButton from 'azion-webkit/linkbutton';

--- a/src/content/docs/pt-br/pages/guias/marketplace/templates/astro-ecommerce-collection.mdx
+++ b/src/content/docs/pt-br/pages/guias/marketplace/templates/astro-ecommerce-collection.mdx
@@ -1,0 +1,108 @@
+---
+title: Como implantar um e-commerce com Astro usando templates
+description: >-
+  Esta guia contém instruções para criar uma aplicação e-commerce usando templates baseados em Astro.
+meta_tags: >-
+  Astro, e-commerce, templates, guides, Azion Marketplace, deployment, online store
+namespace: docs_guides_astro_ecommerce
+permalink: /documentacao/produtos/guias/astro-ecommerce-colecao/
+---
+
+import LinkButton from 'azion-webkit/linkbutton';
+import Tag from 'primevue/tag';
+
+<Tag severity="info" client:only="vue">
+Preview
+</Tag>
+
+A coleção de **Templates de E-commerce Astro** oferece configurações para criar aplicações de e-commerce usando templates. Esses templates são todos baseados no framework **Astro**.
+
+Os templates disponíveis são:
+
+- **Astro Audiophile**: crie um e-commerce estiloso baseado em Astro. Usa a versão `3.1.2` do Astro.
+- **Astro Ecommerce**: implante um e-commerce completo. Usa a versão `2.0.1` do Astro.
+- **Astro Quickstore**: crie sua loja online com Astro e Tailwind CSS. Usa as versões `2.0.1` do Astro e `4.0.0-alpha.23` do Tailwind CSS.
+
+O processo de implantação para cada um desses templates cria um repositório do GitHub para seu projeto, junto com uma edge application e um domínio. Essa configuração permite o acesso e gerenciamento fáceis de sua aplicação de e-commerce através da Plataforma de Edge da Azion.
+
+---
+
+## Pré-requisitos
+
+- Uma [conta GitHub](https://github.com/signup) para se conectar com a Azion e criar seu novo repositório.
+    - Cada push será implantado automaticamente nesse repositório para manter seu projeto atualizado.
+- Estes templates usam [Edge Functions](/pt-br/documentacao/produtos/build/edge-application/edge-functions/), [Application Accelerator](/pt-br/documentacao/produtos/build/edge-application/application-accelerator/), e [Edge Cache](/pt-br/documentacao/produtos/build/edge-application/edge-cache/). Isso pode gerar custos relacionados ao uso. Consulte a [página de preços](/pt-br/documentacao/produtos/precos/) para mais informações.
+
+---
+
+## Implante o template
+
+Você pode obter e configurar seus templates através do Console da Azion. Para implantar um deles facilmente no edge, clique no respectivo botão abaixo.
+
+<LinkButton
+    label="Astro Audiophile"
+    link="https://console.azion.com/create/azion-community/astro-audiophile"
+    icon="ai ai-azion"
+    icon-pos="left"
+  />
+<LinkButton
+    label="Astro Ecommerce"
+    link="https://console.azion.com/create/azion-community/astro-ecommerce"
+    icon="ai ai-azion"
+    icon-pos="left"
+  />
+<LinkButton
+    label="Astro Quickstore"
+    link="https://console.azion.com/create/azion-community/astro-quickstore"
+    icon="ai ai-azion"
+    icon-pos="left"
+  />
+
+---
+
+## Configure o template
+
+No formulário de configuração, você deve fornecer as informações para configurar sua aplicação. Preencha os campos apresentados. 
+
+Os campos identificados com um asterisco são obrigatórios.
+
+1. Conecte a Azion com sua conta do GitHub.
+    - Uma janela pop-up será aberta para confirmar a instalação do [Azion GitHub App](/pt-br/documentacao/produtos/guias/azion-github-app/), uma ferramenta que conecta sua conta do GitHub com a plataforma da Azion.
+    - Defina suas permissões e acesso ao repositório como desejado.
+2. Selecione o **Git Scope** com o qual trabalhar.
+3. Defina um nome para sua edge application.
+    - O bucket para armazenamento e a edge function usarão o mesmo nome.
+    - Use um nome único e fácil de lembrar. Se o nome já tiver sido usado, a plataforma retornará uma mensagem de erro.
+4. Clique no botão **Deploy** para iniciar o processo de implantação.
+
+Durante a implantação, você poderá acompanhar o processo através de uma janela que mostra os logs. Quando estiver completo, a página mostra informações sobre a aplicação e algumas opções para continuar sua jornada.
+
+:::note
+O link para a edge application permite que você a veja no navegador. No entanto, leva um certo tempo para propagar e configurar a aplicação nas localizações de borda da Azion. Pode ser necessário esperar alguns minutos para que a URL seja ativada e para que a página da aplicação seja efetivamente exibida no navegador.
+:::
+
+---
+
+## Gerencie o template
+
+Considerando que essa configuração inicial pode não ser ótima para sua edge application específica, todas as configurações podem ser personalizadas a qualquer momento que você precise, usando a plataforma da Azion.
+
+Para gerenciar e editar as configurações da sua aplicação edge, siga esses passos:
+
+1. [Acesse o Azion Console](https://console.azion.com).
+2. No canto superior esquerdo, selecione **Products Menu**, o ícone de três linhas horizontais, > **Edge Application**.
+    - Você será redirecionado para a página **Edge Application**. Ela lista todas as edge application que você criou.
+3. Encontre a edge application relacionada ao seu template e selecione-a.
+    - A lista está organizada alfabeticamente. Você também pode usar a **barra de busca** localizada no canto superior esquerdo da lista; atualmente, ela filtra apenas pelo campo **Application Name**.
+
+Depois de selecionar a aplicação edge que você trabalhará, você será direcionado para uma página contendo todas as configurações que você pode configurar.
+
+:::tip
+Leia a documentação sobre [gerenciamento de edge application](/pt-br/documentacao/produtos/build/edge-application/primeiros-passos/) para mais detalhes.
+:::
+
+### Adicione um domínio personalizado
+
+A edge application criada durante a implantação tem um domínio Azion atribuído para torná-la acessível através do navegador. O domínio tem o seguinte formato: `xxxxxxxxxx.map.azionedge.net/`. No entanto, você pode adicionar um domínio personalizado para que os usuários acessem sua edge application através dele.
+
+<LinkButton link="/pt-br/documentacao/produtos/guias/configurar-dominio/" label="ir para o guia de configuração de domínio" severity="secondary" /> 

--- a/src/content/docs/pt-br/pages/guias/marketplace/templates/astro-ecommerce-collection.mdx
+++ b/src/content/docs/pt-br/pages/guias/marketplace/templates/astro-ecommerce-collection.mdx
@@ -1,10 +1,10 @@
 ---
 title: Como implantar um e-commerce com Astro usando templates
 description: >-
-  Esta guia contém instruções para criar uma aplicação e-commerce usando templates baseados em Astro.
+  Este guia contém instruções para criar uma aplicação e-commerce usando templates baseados em Astro.
 meta_tags: >-
   Astro, e-commerce, templates, guides, Azion Marketplace, deployment, online store
-namespace: docs_guides_astro_ecommerce
+namespace: docs_guides_astro_ecommerce_templates_collection
 permalink: /documentacao/produtos/guias/astro-ecommerce-collection/
 ---
 
@@ -31,7 +31,7 @@ O processo de implantação para cada um desses templates cria um repositório d
 
 - Uma [conta GitHub](https://github.com/signup) para se conectar com a Azion e criar seu novo repositório.
     - Cada push será implantado automaticamente nesse repositório para manter seu projeto atualizado.
-- Estes templates usam [Edge Functions](/pt-br/documentacao/produtos/build/edge-application/edge-functions/), [Application Accelerator](/pt-br/documentacao/produtos/build/edge-application/application-accelerator/), e [Edge Cache](/pt-br/documentacao/produtos/build/edge-application/edge-cache/). Isso pode gerar custos relacionados ao uso. Consulte a [página de preços](/pt-br/documentacao/produtos/precos/) para mais informações.
+- Estes templates usam [Edge Functions](/pt-br/documentacao/produtos/build/edge-application/edge-functions/), [Application Accelerator](/pt-br/documentacao/produtos/build/edge-application/application-accelerator/), e [Edge Cache](/pt-br/documentacao/produtos/build/edge-application/edge-cache/). Isso pode gerar custos relacionados ao uso. Consulte a [página de preços](/pt-br/precos/) para mais informações.
 
 ---
 

--- a/src/content/docs/pt-br/pages/menu-principal/recursos-adicionais/templates-e-integracoes/templates-visao-geral.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/recursos-adicionais/templates-e-integracoes/templates-visao-geral.mdx
@@ -130,6 +130,12 @@ O **Astro Boilerplate** da Azion encapsula e automatiza várias etapas, desde o 
     icon-pos="left"
   />
 
+#### Astro E-commerce
+
+A coleção Astro E-commerce Templates apresenta uma série de templates para implantar uma aplicação de e-commerce baseada em Astro. Você pode escolher e implantar o template que melhor se adequa às suas necessidades e preferências.
+
+<LinkButton link="/pt-br/documentacao/produtos/guias/astro-ecommerce-collection/" label="consulte o guia dos Astro E-commerce Templates" severity="secondary" /> 
+
 #### Azion Starter Kit 
 
 **Azion Starter Kit** é ideal para dar os primeiros passos na Plataforma Edge da Azion. Com este template, você pode acelerar a criação de um stack de edge básico para explorar a plataforma e seus recursos.


### PR DESCRIPTION
### Changes

Adds the Astro E-commerce Templates guide, with general guidance and buttons to deploy the three available templates:
- Astro Audiophile
- Astro Ecommerce
- Astro Quickstore