### PR TITLE
[EDU-5020] fix: adjust time-related metrics in Observe Docs

### DIFF
--- a/src/content/docs/en/pages/devtools/api-graphql/features/events-fields.mdx
+++ b/src/content/docs/en/pages/devtools/api-graphql/features/events-fields.mdx
@@ -80,7 +80,7 @@ See each available field and their descriptions below.
 | edgeFunctionsInitiatorTypeList | List of initiators used in the function separated by `;`. Can be `1` (Edge Application) or `2` (Edge Firewall). |
 | edgeFunctionsList | List of edge functions that were invocated during the request, in order. The order begins from left to right, meaning functions on the left were invocated first. Example: `3324;43` |
 | edgeFunctionsSolutionId | Identifier of your edge function. Example: `1321` |
-| edgeFunctionsTime | Total execution time, in milliseconds, for the function during its processing. This field is the result of a sum. Example: `0.021` |
+| edgeFunctionsTime | Total execution time, in seconds, for the function during its processing. This field is the result of a sum. Example: `0.021` |
 | functionLanguage | Language used in the function. Example: `javascript` |
 | ts | Timestamp of when the event was created. Example: `2022-10-20T10:10:10` |
 | virtualHostId | Unique ID available on Azion Console. Set on virtual host configuration file. Example: `2410001a` |
@@ -104,7 +104,7 @@ See each available field and their descriptions below.
 | requestId | Unique request identifier. Example: `5f222ae5938482c32a822dbf15e19f0f` |
 | requestLength | Request length in bytes, including request line, headers, and body. This field is the result of a sum. Example: `167` |
 | requestMethod | HTTP request method. Example: `GET` or `POST` |
-| requestTime | Request processing time elapsed since the first bytes were read from the client with resolution in milliseconds. This field is the result of a sum. Example: `1.19` |
+| requestTime | Request processing time, in seconds, since the first bytes were read from the client. This field is the result of a sum. Example: `0.234` |
 | requestUri | URI of the request made by the end user, without the host and protocol information and with arguments. Example: `/v1?v=bo%20dim` |
 | remoteAddress | IP address of the origin that generated the request. Example: `127.0.0.1` |
 | remotePort | Port of the origin that generated the request. Example: `8080` |
@@ -123,7 +123,7 @@ See each available field and their descriptions below.
 | stacktrace | Provides the names of the Rules Engine from your edge application or your edge firewall that are run by the request. Example: `{\\\"edge_firewall\\\":[\\\"Global - Set WAF\\\"]}` |
 | status | HTTP status code of the request. Example: `200` |
 | streamName | ID set through virtual host configuration based on location directive. Set on virtual host configuration file. Example: `company_sector.sdp` |
-| tcpinfoRtt |	Round-Trip Time (RTT) in milliseconds measured by the edge for the user. Available on systems that support the TCP_INFO socket option. Example: `72052` |
+| tcpinfoRtt | Round-Trip Time (RTT) in microseconds measured by the edge for the user. Available on systems that support the TCP_INFO socket option. Example: `72052` |
 | ts | Timestamp of when the event was created. Example: `2022-10-20T10:10:10` |
 | upstreamAddr | Client’s IP address and port. Can also store multiple servers or server groups. Example: `192.168.1.1:80`. When the response is `127.0.0.1:1666`, the upstream is [Azion Cells Runtime](/en/documentation/runtime/overview/). |
 | upstreamAddrStr | List with all `upstreamAddr` responses. |
@@ -132,11 +132,11 @@ See each available field and their descriptions below.
 | upstreamBytesSent | Number of bytes sent to the origin. Example: `2733` |
 | upstreamBytesSentStr | List with all `upstreamBytesSent` responses. |
 | upstreamCacheStatus | Status of the local edge cache. Can be: `MISS`, `BYPASS`, `EXPIRED`, `STALE`, `UPDATING`, `REVALIDATED`, `HIT`, or `-` |
-| upstreamConnectTime | Time it takes for the edge to establish a connection with the origin in milliseconds. In the case of TLS, it includes time spent on handshake. Example: `0.123`. **`0` in case of KeepAlive and `-` in case of cache.** |
+| upstreamConnectTime | Time it takes for the edge to establish a connection with the origin, in seconds. In the case of TLS, it includes time spent on handshake. Example: `0.123`. **Returns `0` for KeepAlive and `-` for cache** |
 | upstreamConnectTimeStr | List with all `upstreamConnectTime` responses. |
-| upstreamHeaderTime | Time it takes for the edge to receive the response header from the origin in milliseconds. Example: `0.345`. **In case of cache, the response is `-`**. |
+| upstreamHeaderTime | Time it takes for the edge to receive the response header from the origin, in seconds. Example: `0.345`. **In case of cache, the response is `-`** |
 | upstreamHeaderTimeStr | List with all `upstreamHeaderTime` responses. |
-| upstreamResponseTime | Time it takes for the edge to receive a default response from the origin in milliseconds, including headers and body. Example: `0.876`. **In case of cache, the response is `-`**. |
+| upstreamResponseTime | Time it takes for the edge to receive a default response from the origin, in seconds, including headers and body. Example: `0.876`. **In case of cache, the response is `-`** |
 | upstreamResponseTimeStr | List with all `upstreamResponseTime` responses. |
 | upstreamStatus | HTTP status code of the origin. If a server can't be selected, the variable keeps the 502 (Bad Gateway) status code. Example: `200`. **In case of cache, the response is `-`**. |
 | upstreamStatusStr | List with all `upstreamStatus` responses. |
@@ -179,7 +179,7 @@ See each available field and their descriptions below.
 | remoteAddr | IP address of the origin that generated the request. Example: `127.0.0.1` |
 | remotePort | Port of the origin that generated the request. Example: `8080` |
 | requestMethod | HTTP request method. Example: `GET` or `POST` |
-| requestTime | Request processing time elapsed since the first bytes were read from the client with resolution in milliseconds. This field is the result of a sum. Example: `1.19` |
+| requestTime | Request processing time, in seconds, since the first bytes were read from the client. This field is the result of a sum. Example: `0.234` |
 | requestUri | URI of the request made by the end user, without the host and protocol information and with arguments. Example: `/v1?v=bo%20dim` |
 | scheme | Request scheme. Example: `HTTP` or `HTTPS` |
 | sentHttpContentType | `Content-Type` header sent in the origin’s response. Example: `text/html; charset=UTF-8` |
@@ -192,7 +192,7 @@ See each available field and their descriptions below.
 | tcpInfoRtt | Round-Trip Time (RTT) measured by the edge for the user. Available on systems that support the TCP_INFO socket option. Example: `72052` |
 | ts | Timestamp of when the event was created. Example: `2022-10-20T10:10:10` |
 | upstreamCacheStatus | Status of the local edge cache. Can be: `MISS`, `BYPASS`, `EXPIRED`, `STALE`, `UPDATING`, `REVALIDATED`, `HIT`, or `-` |
-| upstreamResponseTime | Time it takes for the edge to receive a default response from the origin in milliseconds, including headers and body. This field is the result of a sum. Example: `0.876`. **In case of cache, the response is `-`**. |
+| upstreamResponseTime | Time it takes for the edge to receive a default response from the origin, in seconds, including headers and body. This field is the result of a sum. Example: `0.876`. **In case of cache, the response is `-`** |
 | upstreamResponseTimeStr | List with all `upstreamResponseTime` responses. |
 | upstreamStatus | HTTP status code of the origin. If a server can't be selected, the variable keeps the 502 (Bad Gateway) status code. Example: `200`. **In case of cache, the response is `-`.** |
 | upstreamStatusStr | List with all `upstreamStatus` responses. |
@@ -216,7 +216,7 @@ See each available field and their descriptions below.
 | remotePort | Port of the origin that generated the request. Example: `8080` |
 | requestLength | Request length, including request line, headers, and body. This field is the result of a sum. Example: `167` |
 | requestMethod | HTTP request method. Example: `GET` or `POST` |
-| requestTime | Request processing time elapsed since the first bytes were read from the client with resolution in milliseconds. This field is the result of a sum. Example: `1.19` |
+| requestTime | Request processing time, in seconds, since the first bytes were read from the client. This field is the result of a sum. Example: `0.234` |
 | requestUri | URI of the request made by the end user, without the host and protocol information and with arguments. Example: `/v1?v=bo%20dim` |
 | scheme | Request scheme. Example: `HTTP` or `HTTPS` |
 | sentHttpContentType | `Content-Type` header sent in the origin’s response. Example: `text/html; charset=UTF-8` |
@@ -228,9 +228,9 @@ See each available field and their descriptions below.
 | upstreamBytesReceived | Number of bytes received by the origin’s edge if the content isn’t cached. Example: `8304` |
 | upstreamBytesReceivedStr | List with all `upstreamBytesReceived` responses. |
 | upstreamCacheStatus | Status of the local edge cache. Can be: `MISS`, `BYPASS`, `EXPIRED`, `STALE`, `UPDATING`, `REVALIDATED`, `HIT`, or `-` |
-| upstreamConnectTime | Time it takes for the edge to establish a connection with the origin in milliseconds. In the case of TLS, it includes time spent on handshake. Example: `0.123`. **`0` in case of KeepAlive and `-` in case of cache.** |
-| upstreamHeaderTime | Time it takes for the edge to receive the response header from the origin in milliseconds. Example: `0.345`. **In case of cache, the response is `-`**. |
-| upstreamResponseTime | Time it takes for the edge to receive a default response from the origin in milliseconds, including headers and body. Example: `0.876`. **In case of cache, the response is `-`**. |
+| upstreamConnectTime | Time it takes for the edge to establish a connection with the origin, in seconds. In the case of TLS, it includes time spent on handshake. Example: `0.123`. **Returns `0` for KeepAlive and `-` for cache** |
+| upstreamHeaderTime | Time it takes for the edge to receive the response header from the origin, in seconds. Example: `0.345`. **In case of cache, the response is `-`** |
+| upstreamResponseTime | Time it takes for the edge to receive a default response from the origin, in seconds, including headers and body. Example: `0.876`. **In case of cache, the response is `-`** |
 | upstreamStatus | HTTP status code of the origin. If a server can't be selected, the variable keeps the 502 (Bad Gateway) status code. Example: `200`. **In case of cache, the response is `-`**. |
 
 ---
@@ -306,7 +306,7 @@ The following datasets were discontinued. It's recommended to use the [new datas
 | remotePort | Port of the origin that generated the request. Example: `8080` |
 | requestLength | Request length, including request line, headers, and body. This field is the result of a sum. Example: `167` |
 | requestMethod | HTTP request method. Example: `GET` or `POST` |
-| requestTime | Request processing time elapsed since the first bytes were read from the client with resolution in milliseconds. This field is the result of a sum. Example: `1.19` |
+| requestTime | Request processing time, in seconds, since the first bytes were read from the client. This field is the result of a sum. Example: `0.234` |
 | requestUri | URI of the request made by the end user, without the host and protocol information and with arguments. Example: `/v1?v=bo%20dim` |
 | scheme | Request scheme. Example: `HTTP` or `HTTPS` |
 | sentHttpContentType | `Content-Type` header sent in the origin’s response. Example: `text/html; charset=UTF-8` |
@@ -318,9 +318,9 @@ The following datasets were discontinued. It's recommended to use the [new datas
 | upstreamBytesReceived | Number of bytes received by the origin’s edge if the content isn’t cached. Example: `8304` |
 | upstreamBytesReceivedStr | List with all `upstreamBytesReceived` responses. |
 | upstreamCacheStatus | Status of the local edge cache. Can be: `MISS`, `BYPASS`, `EXPIRED`, `STALE`, `UPDATING`, `REVALIDATED`, `HIT`, or `-` |
-| upstreamConnectTime | Time it takes for the edge to establish a connection with the origin in milliseconds. In the case of TLS, it includes time spent on handshake. Example: `0.123`. **`0` in case of KeepAlive and `-` in case of cache.** |
-| upstreamHeaderTime | Time it takes for the edge to receive the response header from the origin in milliseconds. Example: `0.345`. **In case of cache, the response is `-`**. |
-| upstreamResponseTime | Time it takes for the edge to receive a default response from the origin in milliseconds, including headers and body. Example: `0.876`. **In case of cache, the response is `-`**. |
+| upstreamConnectTime | Time it takes for the edge to establish a connection with the origin, in seconds. In the case of TLS, it includes time spent on handshake. Example: `0.123`. **Returns `0` for KeepAlive and `-` for cache** |
+| upstreamHeaderTime | Time it takes for the edge to receive the response header from the origin, in seconds. Example: `0.345`. **In case of cache, the response is `-`** |
+| upstreamResponseTime | Time it takes for the edge to receive a default response from the origin, in seconds, including headers and body. Example: `0.876`. **In case of cache, the response is `-`** |
 | upstreamStatus | HTTP status code of the origin. If a server can't be selected, the variable keeps the 502 (Bad Gateway) status code. Example: `200`. **In case of cache, the response is `-`**. |
 
 ---

--- a/src/content/docs/en/pages/devtools/api-graphql/features/metrics-fields.mdx
+++ b/src/content/docs/en/pages/devtools/api-graphql/features/metrics-fields.mdx
@@ -35,7 +35,7 @@ The Real-Time Metrics interface on Azion Console also has the `domains` field fo
 | remoteAddressClass | Class of the IP address of the origin that generated the request. Example: `44.192.0.0/11` |
 | requestLength | Request length in bytes, including request line, headers, and body. This field is the result of a sum. Example: `167` |
 | requestMethod | HTTP request method. Example: `GET` or `POST`. |
-| requestTime | Request processing time elapsed since the first bytes were read from the client with resolution in milliseconds. This field is the result of a sum. Example: `1.19` |
+| requestTime | Request processing time, in seconds, since the first bytes were read from the client. This field is the result of a sum. Example: `0.234` |
 | requests | Total amount of requests in the aggregation being used. This field is the result of a sum. Example: `11` |
 | scheme | Request scheme. Example: `HTTP` or `HTTPS`. |
 | sentHttpXOriginalImageSize | “X-Original-Image-Size” header sent in the origin’s response. Used by IMS to inform original image size. This field is the result of a sum. Example: `987390` |
@@ -45,7 +45,7 @@ The Real-Time Metrics interface on Azion Console also has the `domains` field fo
 | ts | Timestamp of when the event was created. Example: `2022-10-20T10:10:10` |
 | upstreamBytesReceived | Number of bytes received by the origin’s edge if the content isn’t cached. This field is the result of a sum. Example: `8304` |
 | upstreamCacheStatus | Status of the local edge cache. Can be: `MISS`, `BYPASS`, `EXPIRED`, `STALE`, `UPDATING`, `REVALIDATED`, `HIT`, or `-` |
-| upstreamResponseTime | Time it takes for the edge to receive a default response from the origin in milliseconds, including headers and body. This field is the result of a sum. Example: `0.876`. **In case of cache, the response is -**. |
+| upstreamResponseTime | Time it takes for the edge to receive a default response from the origin, in seconds, including headers and body. This field is the result of a sum. Example: `0.876`. **In case of cache, the response is `-`** |
 | upstreamStatus | HTTP status code of the origin. If a server can't be selected, the variable keeps the 502 (Bad Gateway) status code. Example: `200`. **In case of cache, the response is -**. |
 | wafBlock | Informs whether the WAF blocked the action or not. `0` when action wasn’t blocked and `1` when action was blocked. When in *Learning Mode*, it won’t be blocked regardless of the return. |
 | wafLearning | Informs if WAF is in Learning mode. Returns `0` if it isn’t and `1` if it’s. |
@@ -118,7 +118,7 @@ When a field is a result of any kind of calculation, such as a sum, they're cons
 | remoteAddressClass | Class of the IP address of the origin that generated the request. Example: `44.192.0.0/11` |
 | requestLength | Request length in bytes, including request line, headers, and body. This field is the result of a sum. Example: `167` |
 | requestMethod | HTTP request method. Example: `GET` or `POST`. |
-| requestTime | Request processing time elapsed since the first bytes were read from the client with resolution in milliseconds. This field is the result of a sum. Example: `1.19` |
+| requestTime | Request processing time, in seconds, since the first bytes were read from the client. This field is the result of a sum. Example: `0.234` |
 | requests | Total amount of requests in the aggregation being used. This field is the result of a sum. Example: `11` |
 | scheme | Request scheme. Example: `HTTP` or `HTTPS`. |
 | sourceLocPop | Location and PoP of the server that received the request. Example: `lax-bso` |
@@ -126,7 +126,7 @@ When a field is a result of any kind of calculation, such as a sum, they're cons
 | ts | Timestamp the event was created. Example: `2022-10-20T10:10:10` |
 | upstreamBytesReceived | Number of bytes received by the origin’s edge if the content isn’t cached. This field is the result of a sum. Example: `8304` |
 | upstreamCacheStatus | Status of the local edge cache. Can be: `MISS`, `BYPASS`, `EXPIRED`, `STALE`, `UPDATING`, `REVALIDATED`, `HIT`, or `-` |
-| upstreamResponseTime | Time it takes for the edge to receive a default response from the origin in milliseconds, including headers and body. This field is the result of a sum. Example: `0.876`. **In case of cache, the response is `-`**. |
+| upstreamResponseTime | Time it takes for the edge to receive a default response from the origin, in seconds, including headers and body. This field is the result of a sum. Example: `0.876`. **In case of cache, the response is `-`** |
 | upstreamStatus | HTTP status code of the origin. If a server can't be selected, the variable keeps the 502 (Bad Gateway) status code. Example: `200`. **In case of cache, the response is `-`**. |
 
 ### Calculated fields
@@ -146,7 +146,7 @@ When a field is a result of any kind of calculation, such as a sum, they're cons
 
 | Field | Description |
 | ----- | ----------- |
-| computeTime | Total execution time, in milliseconds, for the function during its processing. This field is the result of a sum. Example: `0` |
+| computeTime | Total execution time, in milliseconds, for the function during its processing. This field is the result of a sum. Example: `120` |
 | configurationId | Unique Azion configuration identifier set on virtual host configuration file. Example: `1595368520` |
 | edgeFunctionId | Identification of your Edge Function. Example: `1321` |
 | edgeFunctionInstanceId | Identification of your Edge Function Instance. Example: `10590` |
@@ -177,14 +177,14 @@ When a field is a result of any kind of calculation, such as a sum, they're cons
 | host | Host information sent on the request line. Stores: host name from the request line, or host name from the “Host” request header field, or the server name matching a request. Example: `hello.myhost.net` |
 | remoteAddressClass | Class of the IP address of the origin that generated the request. Example: `44.192.0.0/11` |
 | requestMethod | HTTP request method. Example: `GET` or `POST`. |
-| requestTime | Request processing time elapsed since the first bytes were read from the client with resolution in milliseconds. This field is the result of a sum. Example: `1.19` |
+| requestTime | Request processing time, in seconds, since the first bytes were read from the client. This field is the result of a sum. Example: `0.234` |
 | requests | Total amount of requests in the aggregation being used. This field is the result of a sum. Example: `11` |
 | scheme | Request scheme. Example: `HTTP` or `HTTPS`. |
 | sourceLocPop | Location and PoP of the server that received the request. Example: `lax-bso` |
 | status | HTTP status code of the request. Example: `200` |
 | ts | Timestamp of when the event was created. Example: `2022-10-20T10:10:10` |
 | upstreamCacheStatus | Status of the local edge cache. Can be: `MISS`, `BYPASS`, `EXPIRED`, `STALE`, `UPDATING`, `REVALIDATED`, `HIT`, or `-` |
-| upstreamResponseTime | Time it takes for the edge to receive a default response from the origin in milliseconds, including headers and body. This field is the result of a sum. Example: `0.876`. **In case of cache, the response is -**. |
+| upstreamResponseTime | Time it takes for the edge to receive a default response from the origin, in seconds, including headers and body. This field is the result of a sum. Example: `0.876`. **In case of cache, the response is `-`** |
 | upstreamStatus | HTTP status code of the origin. If a server can't be selected, the variable keeps the 502 (Bad Gateway) status code. Example: `200`. **In case of cache, the response is `-`**. |
 
 ---
@@ -252,7 +252,7 @@ The following datasets were discontinued. It's recommended to use the [new datas
 | remoteAddressClass | Class of the IP address of the origin that generated the request. Example: `44.192.0.0/11` |
 | requestLength | Request length in bytes, including request line, headers, and body. This field is the result of a sum. Example: `167` |
 | requestMethod | HTTP request method. Example: `GET` or `POST`. |
-| requestTime | Request processing time elapsed since the first bytes were read from the client with resolution in milliseconds. This field is the result of a sum. Example: `1.19` |
+| requestTime | Request processing time, in seconds, since the first bytes were read from the client. This field is the result of a sum. Example: `0.234` |
 | requests | Total amount of requests in the aggregation being used. This field is the result of a sum. Example: `11` |
 | scheme | Request scheme. Example: `HTTP` or `HTTPS`. |
 | sourceLocPop | Location and PoP of the server that received the request. Example: `lax-bso` |
@@ -260,7 +260,7 @@ The following datasets were discontinued. It's recommended to use the [new datas
 | ts | Timestamp the event was created. Example: `2022-10-20T10:10:10` |
 | upstreamBytesReceived | Number of bytes received by the origin’s edge if the content isn’t cached. This field is the result of a sum. Example: `8304` |
 | upstreamCacheStatus | Status of the local edge cache. Can be: `MISS`, `BYPASS`, `EXPIRED`, `STALE`, `UPDATING`, `REVALIDATED`, `HIT`, or `-` |
-| upstreamResponseTime | Time it takes for the edge to receive a default response from the origin in milliseconds, including headers and body. This field is the result of a sum. Example: `0.876`. **In case of cache, the response is `-`**. |
+| upstreamResponseTime | Time it takes for the edge to receive a default response from the origin, in seconds, including headers and body. This field is the result of a sum. Example: `0.876`. **In case of cache, the response is `-`** |
 | upstreamStatus | HTTP status code of the origin. If a server can't be selected, the variable keeps the 502 (Bad Gateway) status code. Example: `200`. **In case of cache, the response is `-`**. |
 
 ### Calculated fields

--- a/src/content/docs/en/pages/main-menu/reference/observe/data-stream/data-stream.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/observe/data-stream/data-stream.mdx
@@ -103,7 +103,7 @@ The **Edge Applications** data source provides the data from requests made to yo
 | $request_id | Unique request identifier. Example: 5f222ae5938482c32a822dbf15e19f0f |
 | $request_length | Request length, including request line, headers, and body. |
 | $request_method | HTTP request method. Example: GET or POST. |
-| $request_time | Request processing time elapsed since the first bytes were read from the client with resolution in milliseconds. Example: 1.19 |
+| $request_time | Request processing time, in seconds, since the first bytes were read from the client. Example: `0.234` |
 | $request_uri | URI of the request made by the end user, without the host and protocol information and with arguments. Example: /v1?v=bo%20dim |
 | $requestPath | Request URI without Query String, Host, and Protocol information. Example: if `request_uri`: /jira/plans/48/scenarios/27?vop=320#plan/backlog, then `requestPath`: /jira/plans/48/scenarios/27 |
 | $requestQuery | URI parameters of the request. Example: `requestQuery: vid=320#plan/backlog` |
@@ -128,9 +128,9 @@ The **Edge Applications** data source provides the data from requests made to yo
 | $upstream_bytes_received | Number of bytes received by the origin's edge if the content isn't cached. Example: 8304 |
 | $upstream_bytes_sent | Number of bytes sent to the origin. Example: 2733 |
 | $upstream_cache_status | Status of the local edge cache. Example: MISS, BYPASS, EXPIRED, STALE, UPDATING, REVALIDATED, or HIT |
-| $upstream_connect_time | Time it takes for the edge to establish a connection with the origin in milliseconds. In the case of TLS, it includes time spent on handshake. Example: 0.123. **`0` in case of KeepAlive and `-` in case of cache.** |
-| $upstream_header_time | Time it takes for the edge to receive the response header from the origin in milliseconds. Example: 0.345. **In case of cache, the response is `-`**. |
-| $upstream_response_time | Time it takes for the edge to receive a default response from the origin in milliseconds, including headers and body. Example: 0.876. **In case of cache, the response is `-`**. |
+| $upstream_connect_time | Time it takes for the edge to establish a connection with the origin, in seconds. In the case of TLS, it includes time spent on handshake. Example: `0.123`. **Returns `0` for KeepAlive and `-` for cache** |
+| $upstream_header_time | Time it takes for the edge to receive the response header from the origin, in seconds. Example: `0.345`. **In case of cache, the response is `-`** |
+| $upstream_response_time | Time it takes for the edge to receive a default response from the origin, in seconds, including headers and body. Example: `0.876`. **In case of cache, the response is `-`** |
 | $upstream_status | HTTP status code of the origin. If a server cannot be selected, the variable keeps the 502 (Bad Gateway) status code. Example: 200. **In case of cache, the response is `-`**. |
 | $waf_attack_action | Reports WAF’s action regarding the action. Can be: $BLOCK, $PASS, $LEARNING_BLOCK, or $LEARNING_PASS. |
 | $waf_attack_family | Informs the classification of the WAF infraction detected in the request. Example: SQL, XSS, TRAVERSAL, among others. |

--- a/src/content/docs/en/pages/main-menu/reference/observe/real-time-events/real-time-events.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/observe/real-time-events/real-time-events.mdx
@@ -86,7 +86,7 @@ Displays the event records from requests made to your [edge applications](/en/do
 | HTTP User Agent | End user’s application, operating system, vendor, and/or version. Value of the `User-Agent` header. Example: `Mozilla/5.0 (Windows NT 10.0; Win64; x64)` |
 | Request Length | Request length in bytes, including request line, headers, and body. This field is the result of a sum. Example: `167` |
 | Request Method | HTTP request method. Example: `GET` or `POST` |
-| Request Time | Request processing time elapsed since the first bytes were read from the client with resolution in milliseconds. This field is the result of a sum. Example: `1.19` |
+| Request Time | Request processing time, in seconds, since the first bytes were read from the client. This field is the result of a sum. Example: `0.234` |
 | Request Uri | URI of the request made by the end user, without the host and protocol information and with arguments. Example: `/v1?v=bo%20dim` |
 | Remote Address | IP address of the origin that generated the request. Example: `127.0.0.1` |
 | Remote Port | Port of the origin that generated the request. Example: `8080` |
@@ -132,7 +132,7 @@ Displays the event records of requests made to your [edge functions](/en/documen
 | Edge Functions Initiator Type List | List of initiators used in the function separated by `;`. Can be `1` (Edge Application) or `2` (Edge Firewall). |
 | Edge Functions List | List of edge functions that were invocated during the request, in order. The order begins from left to right, meaning functions on the left were invocated first. Example: `3324;43` |
 | Edge Functions Solution ID | Identifier of your edge function. Example: `1321` |
-| Edge Functions Time | Total execution time, in milliseconds, for the function during its processing. This field is the result of a sum. Example: `0.021` |
+| Edge Functions Time | Total execution time, in seconds, for the function during its processing. This field is the result of a sum. Example: `0.021` |
 | Function Language | Language used in the function. Example: `javascript` |
 | Virtual Host ID | Unique ID available on Azion Real-Time Manager. Set on virtual host configuration file. Example: `2410001a` |
 
@@ -175,7 +175,7 @@ Displays the event records of requests made to edge applications using [Image Pr
 | Remote Addr | IP address of the origin that generated the request. Example: `127.0.0.1` |
 | Remote Port | Port of the origin that generated the request. Example: `8080` |
 | Request Method | HTTP request method. Example: `GET` or `POST` |
-| Request Time | Request processing time elapsed since the first bytes were read from the client with resolution in milliseconds. This field is the result of a sum. Example: `1.19` |
+| Request Time | Request processing time, in seconds, since the first bytes were read from the client. This field is the result of a sum. Example: `0.234` |
 | Request Uri | URI of the request made by the end user, without the host and protocol information and with arguments. Example: `/v1?v=bo%20dim` |
 | Scheme | Request scheme. Example: `HTTP` or `HTTPS` |
 | Solution | Identifier of your edge application. Example: `1321` |
@@ -211,7 +211,7 @@ Displays the event records of requests made to edge applications using [Tiered C
 | Remote Port | Port of the origin that generated the request. Example: `8080` |
 | Request Length | Request length, including request line, headers, and body. This field is the result of a sum. Example: `167` |
 | Request Method | HTTP request method. Example: `GET` or `POST` |
-| Request Time | Request processing time elapsed since the first bytes were read from the client with resolution in milliseconds. This field is the result of a sum. Example: `1.19` |
+| Request Time | Request processing time, in seconds, since the first bytes were read from the client. This field is the result of a sum. Example: `0.234` |
 | Request Uri | URI of the request made by the end user, without the host and protocol information and with arguments. Example: `/v1?v=bo%20dim` |
 | Scheme | Request scheme. Example: `HTTP` or `HTTPS` |
 | Sent HTTP Content Type | `Content-Type` header sent in the origin’s response. Example: `text/html; charset=UTF-8` |
@@ -221,8 +221,8 @@ Displays the event records of requests made to edge applications using [Tiered C
 | TCP info RTT | Round-Trip Time (RTT) measured by the edge for the user. Available on systems that support the TCP_INFO socket option. Example: `72052` |
 | Upstream Bytes Received | Number of bytes received by the origin’s edge if the content isn’t cached. Example: `8304` |
 | Upstream Cache Status | Status of the local edge cache. Can be: `MISS`, `BYPASS`, `EXPIRED`, `STALE`, `UPDATING`, `REVALIDATED`, `HIT`, or `-` |
-| Upstream Connect Time | Time it takes for the edge to establish a connection with the origin in milliseconds. In the case of TLS, it includes time spent on handshake. Example: `0.123`. **`0` in case of KeepAlive and `-` in case of cache.** |
-| Upstream Header Time | Time it takes for the edge to receive the response header from the origin in milliseconds. Example: `0.345`. **In case of cache, the response is `-`**. |
+| Upstream Connect Time | Time it takes for the edge to establish a connection with the origin, in seconds. In the case of TLS, it includes time spent on handshake. Example: `0.123`. **Returns `0` for KeepAlive and `-` for cache** |
+| Upstream Header Time | Time it takes for the edge to receive the response header from the origin, in seconds. Example: `0.345`. **In case of cache, the response is `-`** |
 | Upstream Response Time | Time it takes for the edge to receive a default response from the origin in seconds, including headers and body. Example: `0.876`. **In case of cache, the response is `-`** |
 | Upstream Status | HTTP status code of the origin. If a server can't be selected, the variable keeps the 502 (Bad Gateway) status code. Example: `200`. **In case of cache, the response is `-`**. |
 

--- a/src/content/docs/pt-br/pages/devtools/api-graphql/recursos/events-campos.mdx
+++ b/src/content/docs/pt-br/pages/devtools/api-graphql/recursos/events-campos.mdx
@@ -106,7 +106,7 @@ Veja cada campo disponível e suas descrições abaixo.
 | requestId | Identificador exclusivo da requisição. Exemplo: `5f222ae5938482c32a822dbf15e19f0f` |
 | requestLength | Tamanho da requisição, incluindo a linha da requisição, cabeçalhos e corpo. Este campo é o resultado de uma soma. Exemplo: `167` |
 | requestMethod | Método HTTP da requisição. Exemplo: `GET` ou `POST` |
-| requestTime | Tempo de processamento da requisição, em segundos, desde que os primeiros bytes foram lidos a partir do cliente. Este campo é resultado de uma soma. Exemplo: Exemplo: `0.234` |
+| requestTime | Tempo de processamento da requisição, em segundos, desde que os primeiros bytes foram lidos a partir do cliente. Este campo é resultado de uma soma. Exemplo: `0.234` |
 | requestUri | URI da requisição realizada pelo usuário, sem a informação do host e de protocolo e com argumentos. Exemplo: `/v1?v=bo%20dim` |
 | remoteAddress | Endereço IP da origem que gerou a requisição. Exemplo: `127.0.0.1` |
 | remotePort | Porta remota da origem que gerou a requisição. Exemplo: `8080` |
@@ -182,7 +182,7 @@ Veja cada campo disponível e suas descrições abaixo.
 | remoteAddr | Endereço IP da origem que gerou a requisição. Exemplo: `127.0.0.1` |
 | remotePort | Porta remota da origem que gerou a requisição. Exemplo: `8080` |
 | requestMethod | Método HTTP da requisição. Exemplo: `GET` ou `POST` |
-| requestTime | Tempo de processamento da requisição, em segundos, desde que os primeiros bytes foram lidos a partir do cliente. Este campo é resultado de uma soma. Exemplo: Exemplo: `0.234` |
+| requestTime | Tempo de processamento da requisição, em segundos, desde que os primeiros bytes foram lidos a partir do cliente. Este campo é resultado de uma soma. Exemplo: `0.234` |
 | requestUri | URI da requisição realizada pelo usuário, sem a informação do host e de protocolo e com argumentos. Exemplo:`/v1?v=bo%20dim` |
 | scheme | Esquema da requisição. Exemplo: `HTTP` ou `HTTPS` |
 | sentHttpContentType | `Cabeçalho “Content-Type` enviado na resposta da origem. Exemplo: `text/html; charset=UTF-8` |
@@ -220,7 +220,7 @@ Veja cada campo disponível e suas descrições abaixo.
 | remotePort | Porta remota da origem que gerou a requisição. Exemplo: `8080` |
 | requestLength | Tamanho da requisição, incluindo a linha da requisição, cabeçalhos e corpo. Este campo é o resultado de uma soma. Exemplo: `167` |
 | requestMethod | Método HTTP da requisição. Exemplo: `GET` ou `POST` |
-| requestTime | Tempo de processamento da requisição, em segundos, desde que os primeiros bytes foram lidos a partir do cliente. Este campo é resultado de uma soma. Exemplo: Exemplo: `0.234` |
+| requestTime | Tempo de processamento da requisição, em segundos, desde que os primeiros bytes foram lidos a partir do cliente. Este campo é resultado de uma soma. Exemplo: `0.234` |
 | requestUri | URI da requisição realizada pelo usuário, sem a informação do host e de protocolo e com argumentos. Exemplo: `/v1?v=bo%20dim` |
 | scheme | Esquema da requisição. Exemplo: `HTTP` ou `HTTPS` |
 | sentHttpContentType | `Cabeçalho “Content-Type` enviado na resposta da origem. Exemplo: `text/html; charset=UTF-8` |
@@ -311,7 +311,7 @@ Os seguintes conjuntos de dados foram descontinuados. Recomenda-se utilizar os [
 | remotePort | Porta remota da origem que gerou a requisição. Exemplo: `8080` |
 | requestLength | Tamanho da requisição, incluindo a linha da requisição, cabeçalhos e corpo. Este campo é o resultado de uma soma. Exemplo: `167` |
 | requestMethod | Método HTTP da requisição. Exemplo: `GET` ou `POST` |
-| requestTime | Tempo de processamento da requisição, em segundos, desde que os primeiros bytes foram lidos a partir do cliente. Este campo é resultado de uma soma. Exemplo: Exemplo: `0.234` |
+| requestTime | Tempo de processamento da requisição, em segundos, desde que os primeiros bytes foram lidos a partir do cliente. Este campo é resultado de uma soma. Exemplo: `0.234` |
 | requestUri | URI da requisição realizada pelo usuário, sem a informação do host e de protocolo e com argumentos. Exemplo: `/v1?v=bo%20dim` |
 | scheme | Esquema da requisição. Exemplo: `HTTP` ou `HTTPS` |
 | sentHttpContentType | `Cabeçalho “Content-Type` enviado na resposta da origem. Exemplo: `text/html; charset=UTF-8` |

--- a/src/content/docs/pt-br/pages/devtools/api-graphql/recursos/events-campos.mdx
+++ b/src/content/docs/pt-br/pages/devtools/api-graphql/recursos/events-campos.mdx
@@ -81,7 +81,7 @@ Veja cada campo disponível e suas descrições abaixo.
 | edgeFunctionsInitiatorTypeList | Lista de initiators utilizados na function, separados por`;`. Pode ser `1` (Edge Application) ou `2` (Edge Firewall). |
 | edgeFunctionsList | Lista de edge functions que foram invocadas durante a requisição, em ordem. A ordem começa da esquerda para a direita, o que significa que as funções à esquerda foram invocadas primeiro. Exemplo: `3324;43` |
 | edgeFunctionsSolutionId | Identificador da edge function. Exemplo: `1321` |
-| edgeFunctionsTime | Tempo total de execução, em milissegundos, da function durante seu processamento. Este campo é o resultado de uma soma. Exemplo: `0.021` |
+| edgeFunctionsTime | Tempo total de execução, em segundos, da function durante seu processamento. Este campo é o resultado de uma soma. Exemplo: `0.021` |
 | functionLanguage | Linguagem utilizada na function. Exemplo: `javascript` |
 | source | Servidor que gerou a linha do log. Exemplo: `edg-fln-ggn001p` |
 | ts | Data e hora de quando o evento foi criado. Exemplo: `2022-10-20T10:10:10` |
@@ -106,7 +106,7 @@ Veja cada campo disponível e suas descrições abaixo.
 | requestId | Identificador exclusivo da requisição. Exemplo: `5f222ae5938482c32a822dbf15e19f0f` |
 | requestLength | Tamanho da requisição, incluindo a linha da requisição, cabeçalhos e corpo. Este campo é o resultado de uma soma. Exemplo: `167` |
 | requestMethod | Método HTTP da requisição. Exemplo: `GET` ou `POST` |
-| requestTime | Tempo de processamento da requisição decorrido desde que os primeiros bytes foram lidos a partir do cliente, com resolução de milissegundos. Este campo é o resultado de uma soma. Exemplo: `1.19` |
+| requestTime | Tempo de processamento da requisição, em segundos, desde que os primeiros bytes foram lidos a partir do cliente. Este campo é resultado de uma soma. Exemplo: Exemplo: `0.234` |
 | requestUri | URI da requisição realizada pelo usuário, sem a informação do host e de protocolo e com argumentos. Exemplo: `/v1?v=bo%20dim` |
 | remoteAddress | Endereço IP da origem que gerou a requisição. Exemplo: `127.0.0.1` |
 | remotePort | Porta remota da origem que gerou a requisição. Exemplo: `8080` |
@@ -126,7 +126,7 @@ Veja cada campo disponível e suas descrições abaixo.
 | stacktrace | Informa os nomes das Rules Engine da edge application ou do edge firewall executadas pela requisição. Exemplo: `{\\\"edge_firewall\\\":[\\\"Global - Definir WAF\\\"]}` |
 | status | Código de status HTTP da requisição. Exemplo: `200` |
 | streamName | Identificador definido através do arquivo de configuração do virtual host com base na diretiva de localização. Definido no arquivo de configuração do virtual host. Exemplo: `company_sector.sdp`  |
-| tcpinfoRtt | Tempo de ida e volta (RTT), em milissegundos, medido pelo edge para o usuário. Disponível em sistemas que suportam a opção de socket TCP_INFO. Exemplo: `72052` |
+| tcpinfoRtt | Tempo de ida e volta (RTT), em microsegundos, medido pelo edge para o usuário. Disponível em sistemas que suportam a opção de socket TCP_INFO. Exemplo: `72052` |
 | ts | Data e hora de quando o evento foi criado. Exemplo: `2022-10-20T10:10:10` |
 | upstreamAddr | Endereço IP e porta do cliente. Também pode armazenar múltiplos servidores ou grupos de servidores. Exemplo: `192.168.1.1:80`. Quando a resposta é `127.0.0.1:1666`, o upstream é o [Azion Cells Runtime](/pt-br/documentacao/runtime/visao-geral/). |
 | upstreamAddrStr | Lista com todas as respostas `upstreamAddr`. |
@@ -135,11 +135,11 @@ Veja cada campo disponível e suas descrições abaixo.
 | upstreamBytesSent | Número de bytes enviados para a origem. Exemplo: `2733` |
 | upstreamBytesSentStr | Lista com todas as respostas `upstreamBytesSent`. |
 | upstreamCacheStatus | Status do cache local do edge. Pode ser: `MISS`, `BYPASS`, `EXPIRED`, `STALE`, `UPDATING`, `REVALIDATED`, `HIT` ou `-` |
-| upstreamConnectTime | Tempo que o edge leva para estabelecer uma conexão com a origem em milissegundos. No caso de TLS, inclui o tempo gasto no handshake. Exemplo: `0.123`. **`0` no caso do KeepAlive e `-` no caso de cache.** |
+| upstreamConnectTime | Time it takes for the edge to establish a connection with the origin, in seconds. In the case of TLS, it includes time spent on handshake. Example: `0.123`. **Returns `0` for KeepAlive and `-` for cache** |
 | upstreamConnectTimeStr | Lista com todas as respostas `upstreamConnectTime`. |
-| upstreamHeaderTime | Tempo que leva para o edge receber o cabeçalho de resposta da origem em milissegundos. Exemplo: `0.345`. **Em caso de cache, a resposta é `-`**. |
+| upstreamHeaderTime | Tempo para que o edge receba os cabeçalhos de resposta da origem, em segundos. Exemplo: `0.345`. **No caso de cache, a resposta é `-`** |
 | upstreamHeaderTimeStr | Lista com todas as respostas `upstreamHeaderTime`. |
-| upstreamResponseTime | Tempo, em milissegundos, para o edge receber uma resposta padrão da origem, incluindo cabeçalhos e corpo. Exemplo: `0.876`. **Em caso de cache, a resposta é `-`**. |
+| upstreamResponseTime | Tempo para o edge receber uma resposta padrão da origem, em segundos, incluindo cabeçalhos e corpo. Exemplo: `0.876`. **No caso de cache, a resposta é `-`**  |
 | upstreamResponseTimeStr | Lista com todas as respostas `upstreamResponseTime`. |
 | upstreamStatus | Código de status HTTP da origem. Se um servidor não puder ser selecionado, a variável mantém o código de status 502 (Bad Gateway). Exemplo: `200`. **Em caso de cache, a resposta é `-`**. |
 | upstreamStatusStr | Lista com todas as respostas `upstreamStatus`. |
@@ -182,7 +182,7 @@ Veja cada campo disponível e suas descrições abaixo.
 | remoteAddr | Endereço IP da origem que gerou a requisição. Exemplo: `127.0.0.1` |
 | remotePort | Porta remota da origem que gerou a requisição. Exemplo: `8080` |
 | requestMethod | Método HTTP da requisição. Exemplo: `GET` ou `POST` |
-| requestTime | Tempo de processamento da requisição decorrido desde que os primeiros bytes foram lidos a partir do cliente, com resolução de milissegundos. Este campo é o resultado de uma soma. Exemplo: `1.19` |
+| requestTime | Tempo de processamento da requisição, em segundos, desde que os primeiros bytes foram lidos a partir do cliente. Este campo é resultado de uma soma. Exemplo: Exemplo: `0.234` |
 | requestUri | URI da requisição realizada pelo usuário, sem a informação do host e de protocolo e com argumentos. Exemplo:`/v1?v=bo%20dim` |
 | scheme | Esquema da requisição. Exemplo: `HTTP` ou `HTTPS` |
 | sentHttpContentType | `Cabeçalho “Content-Type` enviado na resposta da origem. Exemplo: `text/html; charset=UTF-8` |
@@ -196,7 +196,7 @@ Veja cada campo disponível e suas descrições abaixo.
 | tcpinfoRtt | Round-Trip Time (RTT), em milissegundos, medido pelo edge para o usuário. Disponível em sistemas que suportam a opção de socket TCP_INFO. Exemplo: `72052` |
 | ts | Data e hora de quando o evento foi criado. Exemplo: `2022-10-20T10:10:10` |
 | upstreamCacheStatus | Status do cache local do edge. Pode ser: `MISS`, `BYPASS`, `EXPIRED`, `STALE`, `UPDATING`, `REVALIDATED`, `HIT` ou `-` |
-| upstreamResponseTime | Tempo, em milissegundos, para o edge receber uma resposta padrão da origem, incluindo cabeçalhos e corpo. Este campo é o resultado de uma soma. Exemplo: `0.876`. **Em caso de cache, a resposta é `-`**. |
+| upstreamResponseTime | Tempo para o edge receber uma resposta padrão da origem, em segundos, incluindo cabeçalhos e corpo. Exemplo: `0.876`. **No caso de cache, a resposta é `-`** |
 | upstreamResponseTimeStr | Lista com todas as respostas `upstreamResponseTime`. |
 | upstreamStatus | Código de status HTTP da origem. Se um servidor não puder ser selecionado, a variável mantém o código de status 502 (Bad Gateway). Exemplo: `200` **Em caso de cache, a resposta é `-`.** |
 | upstreamStatusStr | Lista com todas as respostas `upstreamStatus`. |
@@ -220,7 +220,7 @@ Veja cada campo disponível e suas descrições abaixo.
 | remotePort | Porta remota da origem que gerou a requisição. Exemplo: `8080` |
 | requestLength | Tamanho da requisição, incluindo a linha da requisição, cabeçalhos e corpo. Este campo é o resultado de uma soma. Exemplo: `167` |
 | requestMethod | Método HTTP da requisição. Exemplo: `GET` ou `POST` |
-| requestTime | Tempo de processamento da requisição decorrido desde que os primeiros bytes foram lidos a partir do cliente, com resolução de milissegundos. Este campo é o resultado de uma soma. Exemplo: `1.19` |
+| requestTime | Tempo de processamento da requisição, em segundos, desde que os primeiros bytes foram lidos a partir do cliente. Este campo é resultado de uma soma. Exemplo: Exemplo: `0.234` |
 | requestUri | URI da requisição realizada pelo usuário, sem a informação do host e de protocolo e com argumentos. Exemplo: `/v1?v=bo%20dim` |
 | scheme | Esquema da requisição. Exemplo: `HTTP` ou `HTTPS` |
 | sentHttpContentType | `Cabeçalho “Content-Type` enviado na resposta da origem. Exemplo: `text/html; charset=UTF-8` |
@@ -233,9 +233,9 @@ Veja cada campo disponível e suas descrições abaixo.
 | upstreamBytesReceived | Número de bytes recebidos pelo edge da origem, se o conteúdo não estiver em cache. Exemplo: `8304` |
 | upstreamBytesReceivedStr | Lista com todas as respostas `upstreamBytesReceived`. |
 | upstreamCacheStatus | Status do cache local do edge. Pode ser: `MISS`, `BYPASS`, `EXPIRED`, `STALE`, `UPDATING`, `REVALIDATED`, `HIT` ou `-` |
-| upstreamConnectTime | Tempo que o edge leva para estabelecer uma conexão com a origem em milissegundos. No caso de TLS, inclui o tempo gasto no handshake. Exemplo: `0.123`. **`0` no caso do KeepAlive e `-` no caso de cache.** |
-| upstreamHeaderTime | Tempo que leva para o edge receber o cabeçalho de resposta da origem em milissegundos. Exemplo: `0.345`. **Em caso de cache, a resposta é `-`**. |
-| upstreamResponseTime | Tempo, em milissegundos, para o edge receber uma resposta padrão da origem, incluindo cabeçalhos e corpo. Exemplo: `0.876`. **Em caso de cache, a resposta é `-`**. |
+| upstreamConnectTime | Tempo que leva para o edge estabelecer uma conexão com a origem, em segundos. No caso de TLS, inclui o tempo gasto no handshake. Exemplo: `0.123`. **Retorna `0` para KeepAlive e `-` para cache** |
+| upstreamHeaderTime | Tempo para que o edge receba os cabeçalhos de resposta da origem, em segundos. Exemplo: `0.345`. **No caso de cache, a resposta é `-`** |
+| upstreamResponseTime | Tempo para o edge receber uma resposta padrão da origem, em segundos, incluindo cabeçalhos e corpo. Exemplo: `0.876`. **No caso de cache, a resposta é `-`.** |
 | upstreamStatus | Código de status HTTP da origem. Se um servidor não puder ser selecionado, a variável mantém o código de status 502 (Bad Gateway). Exemplo: `200`. **Em caso de cache, a resposta é `-`**. |
 
 ---
@@ -311,7 +311,7 @@ Os seguintes conjuntos de dados foram descontinuados. Recomenda-se utilizar os [
 | remotePort | Porta remota da origem que gerou a requisição. Exemplo: `8080` |
 | requestLength | Tamanho da requisição, incluindo a linha da requisição, cabeçalhos e corpo. Este campo é o resultado de uma soma. Exemplo: `167` |
 | requestMethod | Método HTTP da requisição. Exemplo: `GET` ou `POST` |
-| requestTime | Tempo de processamento da requisição decorrido desde que os primeiros bytes foram lidos a partir do cliente, com resolução de milissegundos. Este campo é o resultado de uma soma. Exemplo: `1.19` |
+| requestTime | Tempo de processamento da requisição, em segundos, desde que os primeiros bytes foram lidos a partir do cliente. Este campo é resultado de uma soma. Exemplo: Exemplo: `0.234` |
 | requestUri | URI da requisição realizada pelo usuário, sem a informação do host e de protocolo e com argumentos. Exemplo: `/v1?v=bo%20dim` |
 | scheme | Esquema da requisição. Exemplo: `HTTP` ou `HTTPS` |
 | sentHttpContentType | `Cabeçalho “Content-Type` enviado na resposta da origem. Exemplo: `text/html; charset=UTF-8` |
@@ -324,9 +324,9 @@ Os seguintes conjuntos de dados foram descontinuados. Recomenda-se utilizar os [
 | upstreamBytesReceived | Número de bytes recebidos pelo edge da origem, se o conteúdo não estiver em cache. Exemplo: `8304` |
 | upstreamBytesReceivedStr | Lista com todas as respostas `upstreamBytesReceived`. |
 | upstreamCacheStatus | Status do cache local do edge. Pode ser: `MISS`, `BYPASS`, `EXPIRED`, `STALE`, `UPDATING`, `REVALIDATED`, `HIT` ou `-` |
-| upstreamConnectTime | Tempo que o edge leva para estabelecer uma conexão com a origem em milissegundos. No caso de TLS, inclui o tempo gasto no handshake. Exemplo: `0.123`. **`0` no caso do KeepAlive e `-` no caso de cache.** |
-| upstreamHeaderTime | Tempo que leva para o edge receber o cabeçalho de resposta da origem em milissegundos. Exemplo: `0.345`. **Em caso de cache, a resposta é `-`**. |
-| upstreamResponseTime | Tempo, em milissegundos, para o edge receber uma resposta padrão da origem, incluindo cabeçalhos e corpo. Exemplo: `0.876`. **Em caso de cache, a resposta é `-`**. |
+| upstreamConnectTime | Tempo que leva para o edge estabelecer uma conexão com a origem, em segundos. No caso de TLS, inclui o tempo gasto no handshake. Exemplo: `0.123`. **Retorna `0` para KeepAlive e `-` para cache** |
+| upstreamHeaderTime | Tempo para que o edge receba os cabeçalhos de resposta da origem, em segundos. Exemplo: `0.345`. **No caso de cache, a resposta é `-`** |
+| upstreamResponseTime | Tempo para o edge receber uma resposta padrão da origem, em segundos, incluindo cabeçalhos e corpo. Exemplo: `0.876`. **No caso de cache, a resposta é `-`.** |
 | upstreamStatus | Código de status HTTP da origem. Se um servidor não puder ser selecionado, a variável mantém o código de status 502 (Bad Gateway). Exemplo: `200`. **Em caso de cache, a resposta é `-`**. |
 
 ---

--- a/src/content/docs/pt-br/pages/devtools/api-graphql/recursos/events-campos.mdx
+++ b/src/content/docs/pt-br/pages/devtools/api-graphql/recursos/events-campos.mdx
@@ -135,7 +135,7 @@ Veja cada campo disponível e suas descrições abaixo.
 | upstreamBytesSent | Número de bytes enviados para a origem. Exemplo: `2733` |
 | upstreamBytesSentStr | Lista com todas as respostas `upstreamBytesSent`. |
 | upstreamCacheStatus | Status do cache local do edge. Pode ser: `MISS`, `BYPASS`, `EXPIRED`, `STALE`, `UPDATING`, `REVALIDATED`, `HIT` ou `-` |
-| upstreamConnectTime | Time it takes for the edge to establish a connection with the origin, in seconds. In the case of TLS, it includes time spent on handshake. Example: `0.123`. **Returns `0` for KeepAlive and `-` for cache** |
+| upstreamConnectTime | Tempo que leva para o edge estabelecer uma conexão com a origem, em segundos. No caso de TLS, inclui o tempo gasto no handshake. Exemplo: `0.123`. **Retorna `0` para KeepAlive e `-` para cache** |
 | upstreamConnectTimeStr | Lista com todas as respostas `upstreamConnectTime`. |
 | upstreamHeaderTime | Tempo para que o edge receba os cabeçalhos de resposta da origem, em segundos. Exemplo: `0.345`. **No caso de cache, a resposta é `-`** |
 | upstreamHeaderTimeStr | Lista com todas as respostas `upstreamHeaderTime`. |

--- a/src/content/docs/pt-br/pages/devtools/api-graphql/recursos/metrics-campos.mdx
+++ b/src/content/docs/pt-br/pages/devtools/api-graphql/recursos/metrics-campos.mdx
@@ -34,7 +34,7 @@ A interface do Real-Time Metrics no Azion Console também possui o campo `domain
 | remoteAddressClass | Classe do endereço de IP da origem que gerou a requisição. Exemplo: `44.192.0.0/11` |
 | requestLength | Tamanho da requisição em bytes, incluindo a linha da requisição, cabeçalhos e corpo. Este campo é resultado de uma soma. Exemplo: `167` |
 | requestMethod | Método da requisição. Exemplo: `GET` ou `POST`. |
-| requestTime | Tempo de processamento da requisição decorrido desde que os primeiros bytes foram lidos a partir do cliente com resolução de milissegundos. Este campo é resultado de uma soma. Exemplo: `1.19` |
+| requestTime | Tempo de processamento da requisição, em segundos, desde que os primeiros bytes foram lidos a partir do cliente. Este campo é resultado de uma soma. Exemplo: Exemplo: `0.234` |
 | requests | Quantidade total de requisições na agregação sendo usada. Este campo é resultado de uma soma. Exemplo: `11` |
 | scheme | Esquema da requisição. Exemplo: `HTTP` ou `HTTPS`. |
 | serverProtocol | Versão do protocolo da requisição. Exemplo: `HTTP/1.1`, `HTTP/2.0`, `HTTP/3.0` |
@@ -44,7 +44,7 @@ A interface do Real-Time Metrics no Azion Console também possui o campo `domain
 | ts | Data e hora de quando o evento foi criado. Exemplo: `2022-10-20T10:10:10` |
 | upstreamBytesReceived | Número de bytes recebidos pelo edge da origem, se o conteúdo não estiver em cache. Este campo é resultado de uma soma. Exemplo: `8304` |
 | upstreamCacheStatus | Status do cache local do edge. Pode ser: `MISS`, `BYPASS`, `EXPIRED`, `STALE`, `UPDATING`, `REVALIDATED`, `HIT` ou `-` |
-| upstreamResponseTime | Tempo, em milissegundos, para o edge receber uma resposta padrão da origem, incluindo cabeçalhos e corpo. Este campo é resultado de uma soma. Exemplo: `0.876`. **No caso de cache, a resposta é -**. |
+| upstreamResponseTime | Tempo para o edge receber uma resposta padrão da origem, em segundos, incluindo cabeçalhos e corpo. Este campo é resultado de uma soma. Exemplo: `0.876`. **No caso de cache, a resposta é -** |
 | upstreamStatus | Código de status HTTP da origem. Se um servidor não pode ser selecionado, a variável mantém o código de status 502 (Bad Gateway). Exemplo: `200`. **No caso de cache, a resposta é -**. |
 | wafBlock | Informa se o WAF bloqueou ou não a ação. `0` quando não bloqueado e `1` quando bloqueado. Quando em *Learning Mode*, ele não será bloqueado, independentemente do retorno. |
 | wafLearning | Informa se o WAF está em Learning Mode. Retorna `0` se está e `1` se não está. |
@@ -117,7 +117,7 @@ Quando um campo é o resultado de algum tipo de cálculo, como uma soma, ele é 
 | remoteAddressClass | Classe do endereço de IP da origem que gerou a requisição. Exemplo: `44.192.0.0/11` |
 | requestLength | Tamanho da requisição em bytes, incluindo a linha da requisição, cabeçalhos e corpo. Este campo é resultado de uma soma. Exemplo: `167` |
 | requestMethod | Método da requisição. Exemplo: `GET` ou `POST`. |
-| requestTime | Tempo de processamento da requisição decorrido desde que os primeiros bytes foram lidos a partir do cliente com resolução de milissegundos. Este campo é resultado de uma soma. Exemplo: `1.19` |
+| requestTime | Tempo de processamento da requisição, em segundos, desde que os primeiros bytes foram lidos a partir do cliente. Este campo é resultado de uma soma. Exemplo: Exemplo: `0.234` |
 | requests | Quantidade total de requisições na agregação sendo usada. Este campo é resultado de uma soma. Exemplo: `11` |
 | scheme | Esquema da requisição. Exemplo: `HTTP` ou `HTTPS`. |
 | sourceLocPop | Localização e PoP do edge que recebeu a requisição. Exemplo: `lax-bso` |
@@ -125,7 +125,7 @@ Quando um campo é o resultado de algum tipo de cálculo, como uma soma, ele é 
 | ts | Data e hora de quando o evento foi criado. Exemplo: `2022-10-20T10:10:10` |
 | upstreamBytesReceived | Número de bytes recebidos pelo edge da origem, se o conteúdo não estiver em cache. Este campo é resultado de uma soma. Exemplo: `8304` |
 | upstreamCacheStatus | Status do cache local do edge. Pode ser: `MISS`, `BYPASS`, `EXPIRED`, `STALE`, `UPDATING`, `REVALIDATED`, `HIT` ou `-` |
-| upstreamResponseTime | Tempo, em milissegundos, para o edge receber uma resposta padrão da origem, incluindo cabeçalhos e corpo. Este campo é resultado de uma soma. Exemplo: `0.876`. **No caso de cache, a resposta é `-`**. |
+| upstreamResponseTime | Tempo para o edge receber uma resposta padrão da origem, em segundos, incluindo cabeçalhos e corpo. Este campo é resultado de uma soma. Exemplo: `0.876`. **No caso de cache, a resposta é -** |
 | upstreamStatus | Código de status HTTP da origem. Se um servidor não pode ser selecionado, a variável mantém o código de status 502 (Bad Gateway). Exemplo: `200`. **No caso de cache, a resposta é `-`**. |
 
 ### Campos calculados
@@ -145,7 +145,7 @@ Quando um campo é o resultado de algum tipo de cálculo, como uma soma, ele é 
 
 | Campo | Descrição |
 | ----- | --------- |
-| computeTime | Tempo total de exeção, em milissegundos, para a function durante seu processamento. Este campo é resultado de uma soma. Exemplo: `0` |
+| computeTime | Tempo total de exeção, em milissegundos, para a function durante seu processamento. Este campo é resultado de uma soma. Exemplo: `120` |
 | configurationId | Identificador único de configuração Azion definido no arquivo de configuração do virtual host. Exemplo: `1595368520` |
 | edgeFunctionId | Identificador da edge function. Exemplo: `1321` |
 | edgeFunctionInstanceId | Identificador único da edge function instance. Exemplo: `10590` |
@@ -176,14 +176,14 @@ Quando um campo é o resultado de algum tipo de cálculo, como uma soma, ele é 
 | host | Informação de host enviada na linha da requisição. Armazena: nome do host da linha da requisição, ou o nome do host do campo Host do campo host do cabeçalho, ou o nome do servidor correspondente à requisição. Exemplo: `g1sdetynmxe0ao.map.azionedge.net` |
 | remoteAddressClass | Classe do endereço de IP da origem que gerou a requisição. Exemplo: `44.192.0.0/11` |
 | requestMethod | Método da requisição. Exemplo: `GET` ou `POST`. |
-| requestTime | Tempo de processamento da requisição decorrido desde que os primeiros bytes foram lidos a partir do cliente com resolução de milissegundos. Este campo é resultado de uma soma. Exemplo: `1.19` |
+| requestTime | Tempo de processamento da requisição, em segundos, desde que os primeiros bytes foram lidos a partir do cliente. Este campo é resultado de uma soma. Exemplo: Exemplo: `0.234` |
 | requests | Quantidade total de requisições na agregação sendo usada. Este campo é resultado de uma soma. Exemplo: `11` |
 | scheme | Esquema da requisição. Exemplo: `HTTP` ou `HTTPS` |
 | sourceLocPop | Localização e PoP do edge que recebeu a requisição. Exemplo: `lax-bso` |
 | status | Código de status HTTP da requisição. Exemplo: `200` |
 | ts | Data e hora de quando o evento foi criado. Exemplo: `2022-10-20T10:10:10` |
 | upstreamCacheStatus | Status do cache local do edge. Pode ser: `MISS`, `BYPASS`, `EXPIRED`, `STALE`, `UPDATING`, `REVALIDATED`, `HIT` ou `-` |
-| upstreamResponseTime | Tempo, em milissegundos, para o edge receber uma resposta padrão da origem, incluindo cabeçalhos e corpo. Este campo é resultado de uma soma. Exemplo: `0.876`. **No caso de cache, a resposta é -**. |
+| upstreamResponseTime | Tempo para o edge receber uma resposta padrão da origem, em segundos, incluindo cabeçalhos e corpo. Este campo é resultado de uma soma. Exemplo: `0.876`. **No caso de cache, a resposta é -**. |
 | upstreamStatus | Código de status HTTP da origem. Se um servidor não pode ser selecionado, a variável mantém o código de status 502 (Bad Gateway). Exemplo: `200`. **No caso de cache, a resposta é `-`**. |
 
 ---
@@ -251,7 +251,7 @@ Os seguintes conjuntos de dados foram descontinuados. Recomenda-se utilizar os [
 | remoteAddressClass | Classe do endereço de IP da origem que gerou a requisição. Exemplo: `44.192.0.0/11` |
 | requestLength | Tamanho da requisição em bytes, incluindo a linha da requisição, cabeçalhos e corpo. Este campo é resultado de uma soma. Exemplo: `167` |
 | requestMethod | Método da requisição. Exemplo: `GET` ou `POST`. |
-| requestTime | Tempo de processamento da requisição decorrido desde que os primeiros bytes foram lidos a partir do cliente com resolução de milissegundos. Este campo é resultado de uma soma. Exemplo: `1.19` |
+| requestTime | Tempo de processamento da requisição, em segundos, desde que os primeiros bytes foram lidos a partir do cliente. Este campo é resultado de uma soma. Exemplo: Exemplo: `0.234` |
 | requests | Quantidade total de requisições na agregação sendo usada. Este campo é resultado de uma soma. Exemplo: `11` |
 | scheme | Esquema da requisição. Exemplo: `HTTP` ou `HTTPS`. |
 | sourceLocPop | Localização e PoP do edge que recebeu a requisição. Exemplo: `lax-bso` |
@@ -259,7 +259,7 @@ Os seguintes conjuntos de dados foram descontinuados. Recomenda-se utilizar os [
 | ts | Data e hora de quando o evento foi criado. Exemplo: `2022-10-20T10:10:10` |
 | upstreamBytesReceived | Número de bytes recebidos pelo edge da origem, se o conteúdo não estiver em cache. Este campo é resultado de uma soma. Exemplo: `8304` |
 | upstreamCacheStatus | Status do cache local do edge. Pode ser: `MISS`, `BYPASS`, `EXPIRED`, `STALE`, `UPDATING`, `REVALIDATED`, `HIT` ou `-` |
-| upstreamResponseTime | Tempo, em milissegundos, para o edge receber uma resposta padrão da origem, incluindo cabeçalhos e corpo. Este campo é resultado de uma soma. Exemplo: `0.876`. **No caso de cache, a resposta é `-`**. |
+| upstreamResponseTime | Tempo para o edge receber uma resposta padrão da origem, em segundos, incluindo cabeçalhos e corpo. Este campo é resultado de uma soma. Exemplo: `0.876`. **No caso de cache, a resposta é `-`**. |
 | upstreamStatus | Código de status HTTP da origem. Se um servidor não pode ser selecionado, a variável mantém o código de status 502 (Bad Gateway). Exemplo: `200`. **No caso de cache, a resposta é `-`**. |
 
 ### Campos calculados

--- a/src/content/docs/pt-br/pages/devtools/api-graphql/recursos/metrics-campos.mdx
+++ b/src/content/docs/pt-br/pages/devtools/api-graphql/recursos/metrics-campos.mdx
@@ -117,7 +117,7 @@ Quando um campo é o resultado de algum tipo de cálculo, como uma soma, ele é 
 | remoteAddressClass | Classe do endereço de IP da origem que gerou a requisição. Exemplo: `44.192.0.0/11` |
 | requestLength | Tamanho da requisição em bytes, incluindo a linha da requisição, cabeçalhos e corpo. Este campo é resultado de uma soma. Exemplo: `167` |
 | requestMethod | Método da requisição. Exemplo: `GET` ou `POST`. |
-| requestTime | Tempo de processamento da requisição, em segundos, desde que os primeiros bytes foram lidos a partir do cliente. Este campo é resultado de uma soma. Exemplo: Exemplo: `0.234` |
+| requestTime | Tempo de processamento da requisição, em segundos, desde que os primeiros bytes foram lidos a partir do cliente. Este campo é resultado de uma soma. Exemplo: `0.234` |
 | requests | Quantidade total de requisições na agregação sendo usada. Este campo é resultado de uma soma. Exemplo: `11` |
 | scheme | Esquema da requisição. Exemplo: `HTTP` ou `HTTPS`. |
 | sourceLocPop | Localização e PoP do edge que recebeu a requisição. Exemplo: `lax-bso` |
@@ -176,7 +176,7 @@ Quando um campo é o resultado de algum tipo de cálculo, como uma soma, ele é 
 | host | Informação de host enviada na linha da requisição. Armazena: nome do host da linha da requisição, ou o nome do host do campo Host do campo host do cabeçalho, ou o nome do servidor correspondente à requisição. Exemplo: `g1sdetynmxe0ao.map.azionedge.net` |
 | remoteAddressClass | Classe do endereço de IP da origem que gerou a requisição. Exemplo: `44.192.0.0/11` |
 | requestMethod | Método da requisição. Exemplo: `GET` ou `POST`. |
-| requestTime | Tempo de processamento da requisição, em segundos, desde que os primeiros bytes foram lidos a partir do cliente. Este campo é resultado de uma soma. Exemplo: Exemplo: `0.234` |
+| requestTime | Tempo de processamento da requisição, em segundos, desde que os primeiros bytes foram lidos a partir do cliente. Este campo é resultado de uma soma. Exemplo: `0.234` |
 | requests | Quantidade total de requisições na agregação sendo usada. Este campo é resultado de uma soma. Exemplo: `11` |
 | scheme | Esquema da requisição. Exemplo: `HTTP` ou `HTTPS` |
 | sourceLocPop | Localização e PoP do edge que recebeu a requisição. Exemplo: `lax-bso` |
@@ -251,7 +251,7 @@ Os seguintes conjuntos de dados foram descontinuados. Recomenda-se utilizar os [
 | remoteAddressClass | Classe do endereço de IP da origem que gerou a requisição. Exemplo: `44.192.0.0/11` |
 | requestLength | Tamanho da requisição em bytes, incluindo a linha da requisição, cabeçalhos e corpo. Este campo é resultado de uma soma. Exemplo: `167` |
 | requestMethod | Método da requisição. Exemplo: `GET` ou `POST`. |
-| requestTime | Tempo de processamento da requisição, em segundos, desde que os primeiros bytes foram lidos a partir do cliente. Este campo é resultado de uma soma. Exemplo: Exemplo: `0.234` |
+| requestTime | Tempo de processamento da requisição, em segundos, desde que os primeiros bytes foram lidos a partir do cliente. Este campo é resultado de uma soma. Exemplo: `0.234` |
 | requests | Quantidade total de requisições na agregação sendo usada. Este campo é resultado de uma soma. Exemplo: `11` |
 | scheme | Esquema da requisição. Exemplo: `HTTP` ou `HTTPS`. |
 | sourceLocPop | Localização e PoP do edge que recebeu a requisição. Exemplo: `lax-bso` |

--- a/src/content/docs/pt-br/pages/menu-principal/referencia/observe/data-streaming/data-streaming.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/referencia/observe/data-streaming/data-streaming.mdx
@@ -104,7 +104,7 @@ O data source **Edge Applications** exibe os dados das requisições feitas para
 | $request_id | Identificador único da requisição. Exemplo: 5f222ae5938482c32a822dbf15e19f0f |
 | $request_length | Tamanho da requisição, incluindo a linha da requisição, cabeçalhos e corpo. |
 | $request_method | Método da requisição. Exemplo: GET ou POST |
-| $request_time | Tempo de processamento da requisição decorrido desde que os primeiros bytes foram lidos a partir do cliente com resolução de milisegundos. Exemplo: 1.19 |
+| $request_time | Tempo de processamento da requisição, em segundos, desde que os primeiros bytes foram lidos a partir do cliente. Exemplo: `0.234`|
 | $request_uri | URI da requisição realizada pelo usuário, sem a informação do host e de protocolo e com argumentos. Exemplo: /v1?v=bo%20dim |
 | $requestPath | URI da requisição sem a informação de Query String, Host e Protocol. Exemplo:  se `request_uri`: /jira/plans/48/scenarios/27?vop=320#plan/backlog, então `requestPath`: /jira/plans/48/scenarios/27 |
 | $requestQuery | Parâmetros da URI da requisição. Exemplo: requestQuery: vid=320#plan/backlog |
@@ -129,10 +129,10 @@ O data source **Edge Applications** exibe os dados das requisições feitas para
 | $upstream_bytes_received | Número de bytes recebidos pelo edge da origem, se o conteúdo não estiver em cache. Exemplo: 8304 |
 | $upstream_bytes_sent | Número de bytes enviados para a origem. Exemplo: 2733 |
 | $upstream_cache_status | Status do cache local do edge. Exemplo: MISS, BYPASS, EXPIRED, STALE, UPDATING, REVALIDATED ou HIT. |
-| $upstream_connect_time | Tempo, em milisegundos, para o edge estabelecer uma conexão com a origem. No caso de TLS, inclui tempo gasto em handshake. **`0` no caso de KeepAlive e `-` no caso de cache.** |
-| $upstream_header_time | Tempo, em milissegundos, para que o edge receba os cabeçalhos de resposta da origem. Exemplo: 0.345. **No caso de cache, a resposta é `-`.** |
-| $upstream_response_time | Tempo, em milisegundos, para o edge receber uma resposta padrão da origem, incluindo cabeçalhos e corpo. Exemplo: 0.876. **No caso de cache, a resposta é `-`.** |
-| $upstream_status | Código de status HTTP da origem. Se um servidor não pode ser selecionado, a variável mantém o código de status 502 (Bad Gateway). **No caso de cache, a resposta é `-`.** |
+| $upstream_connect_time | Tempo que leva para o edge estabelecer uma conexão com a origem, em segundos. No caso de TLS, inclui o tempo gasto no handshake. Exemplo: `0.123`. **Retorna `0` para KeepAlive e `-` para cache** |
+| $upstream_header_time | Tempo para que o edge receba os cabeçalhos de resposta da origem, em segundos. Exemplo: `0.345`. **No caso de cache, a resposta é `-`** |
+| $upstream_response_time | Tempo para o edge receber uma resposta padrão da origem, em segundos, incluindo cabeçalhos e corpo. Exemplo: `0.876`. **No caso de cache, a resposta é `-`.** |
+| $upstream_status | Código de status HTTP da origem. Se um servidor não pode ser selecionado, a variável mantém o código de status 502 (Bad Gateway). **No caso de cache, a resposta é `-`** |
 | $waf_attack_action | Informa a ação do WAF em relação à ação. Pode ser: $BLOCK, $PASS, $LEARNING_BLOCK ou $LEARNING_PASS. |
 | $waf_attack_family | Informa a classificação da infração de WAF detectada na requisição. Exemplo: SQL, XSS, TRAVERSAL, entre outras. |
 | $waf_block | Informa se o WAF bloqueou ou não a ação. `0` quando não bloqueado e `1` quando bloqueado. Quando em `Learning Mode`, ele não será bloqueado, independentemente do retorno. |

--- a/src/content/docs/pt-br/pages/menu-principal/referencia/observe/real-time-events/real-time-events.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/referencia/observe/real-time-events/real-time-events.mdx
@@ -87,7 +87,7 @@ Exibe os registros de eventos de requisições feitas para suas [edge applicatio
 | Proxy Status | Código de status de erro HTTP ou da origem quando nenhuma resposta é obtida da origem. Exemplo: `520`. **Em caso de cache, a resposta é `-`.** |
 | Request Length | Tamanho da requisição, incluindo a linha da requisição, cabeçalhos e corpo. Este campo é o resultado de uma soma. Exemplo: `167` |
 | Request Method | Método HTTP da requisição. Exemplo: `GET` ou `POST` |
-| Request Time | Tempo de processamento da requisição, em segundos, desde que os primeiros bytes foram lidos a partir do cliente. Este campo é resultado de uma soma. Exemplo: Exemplo: `0.234` |
+| Request Time | Tempo de processamento da requisição, em segundos, desde que os primeiros bytes foram lidos a partir do cliente. Este campo é resultado de uma soma. Exemplo: `0.234` |
 | Request URI | URI da requisição realizada pelo usuário, sem a informação do host e de protocolo e com argumentos. Exemplo: `/v1?v=bo%20dim` |
 | Remote Address | Endereço IP da origem que gerou a requisição. Exemplo: `127.0.0.1` |
 | Remote Port | Porta remota da origem que gerou a requisição. Exemplo: `8080` |
@@ -176,7 +176,7 @@ Exibe os registros de eventos de requisições feitas às edge applications que 
 | Remote Addr | Endereço IP da origem que gerou a requisição. Exemplo: `127.0.0.1` |
 | Remote Port | Porta remota da origem que gerou a requisição. Exemplo: `8080` |
 | Request Method | Método HTTP da requisição. Exemplo: `GET` ou `POST` |
-| Request Time | Tempo de processamento da requisição, em segundos, desde que os primeiros bytes foram lidos a partir do cliente. Este campo é resultado de uma soma. Exemplo: Exemplo: `0.234` |
+| Request Time | Tempo de processamento da requisição, em segundos, desde que os primeiros bytes foram lidos a partir do cliente. Este campo é resultado de uma soma. Exemplo: `0.234` |
 | Request URI | URI da requisição realizada pelo usuário, sem a informação do host e de protocolo e com argumentos. Exemplo:`/v1?v=bo%20dim` |
 | Scheme | Esquema da requisição. Exemplo: `HTTP` ou `HTTPS` |
 | Solution | Identificação da edge application. Exemplo: `1321` |
@@ -213,7 +213,7 @@ Exibe os registros de eventos de requisições feitas às edge applications que 
 | Remote Port | Porta remota da origem que gerou a requisição. Exemplo: `8080` |
 | Request Length | Tamanho da requisição, incluindo a linha da requisição, cabeçalhos e corpo. Este campo é o resultado de uma soma. Exemplo: `167` |
 | Request Method | Método HTTP da requisição. Exemplo: `GET` ou `POST` |
-| Request Time | Tempo de processamento da requisição, em segundos, desde que os primeiros bytes foram lidos a partir do cliente. Este campo é resultado de uma soma. Exemplo: Exemplo: `0.234` |
+| Request Time | Tempo de processamento da requisição, em segundos, desde que os primeiros bytes foram lidos a partir do cliente. Este campo é resultado de uma soma. Exemplo: `0.234` |
 | Request URI | URI da requisição realizada pelo usuário, sem a informação do host e de protocolo e com argumentos. Exemplo: `/v1?v=bo%20dim` |
 | Scheme | Esquema da requisição. Exemplo: `HTTP` ou `HTTPS` |
 | Server Protocol | Protocolo da requisição. Exemplo: `HTTP/1.1`, `HTTP/2.0`, `HTTP/3.0` |

--- a/src/content/docs/pt-br/pages/menu-principal/referencia/observe/real-time-events/real-time-events.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/referencia/observe/real-time-events/real-time-events.mdx
@@ -87,7 +87,7 @@ Exibe os registros de eventos de requisições feitas para suas [edge applicatio
 | Proxy Status | Código de status de erro HTTP ou da origem quando nenhuma resposta é obtida da origem. Exemplo: `520`. **Em caso de cache, a resposta é `-`.** |
 | Request Length | Tamanho da requisição, incluindo a linha da requisição, cabeçalhos e corpo. Este campo é o resultado de uma soma. Exemplo: `167` |
 | Request Method | Método HTTP da requisição. Exemplo: `GET` ou `POST` |
-| Request Time | Tempo de processamento da requisição decorrido desde que os primeiros bytes foram lidos a partir do cliente, com resolução de milissegundos. Este campo é o resultado de uma soma. Exemplo: `1.19` |
+| Request Time | Tempo de processamento da requisição, em segundos, desde que os primeiros bytes foram lidos a partir do cliente. Este campo é resultado de uma soma. Exemplo: Exemplo: `0.234` |
 | Request URI | URI da requisição realizada pelo usuário, sem a informação do host e de protocolo e com argumentos. Exemplo: `/v1?v=bo%20dim` |
 | Remote Address | Endereço IP da origem que gerou a requisição. Exemplo: `127.0.0.1` |
 | Remote Port | Porta remota da origem que gerou a requisição. Exemplo: `8080` |
@@ -133,7 +133,7 @@ Exibe os registros de eventos de requisições feitas às suas [edge functions](
 | Edge Functions Initiator Type List | Lista de initiators utilizados na function, separados por`;`. Pode ser `1` (Edge Application) ou `2` (Edge Firewall) |
 | Edge Functions List | Lista de edge functions que foram invocadas durante a requisição, em ordem. A ordem começa da esquerda para a direita, o que significa que as funções à esquerda foram invocadas primeiro. Exemplo: `3324;43` |
 | Edge Functions Solution ID | Identificador da edge function. Exemplo: `1321` |
-| Edge Functions Time | Tempo total de execução, em milissegundos, da function durante seu processamento. Este campo é o resultado de uma soma. Exemplo: `0.021` |
+| Edge Functions Time | Tempo total de execução, em segundos, da function durante seu processamento. Este campo é o resultado de uma soma. Exemplo: `0.021` |
 | Function Language | Linguagem utilizada na function. Exemplo: `javascript` |
 | Virtual Host ID | Identificador disponível no Azion Console. Definido no arquivo de configuração do virtual host. Exemplo: `2410001a` |
 
@@ -176,7 +176,7 @@ Exibe os registros de eventos de requisições feitas às edge applications que 
 | Remote Addr | Endereço IP da origem que gerou a requisição. Exemplo: `127.0.0.1` |
 | Remote Port | Porta remota da origem que gerou a requisição. Exemplo: `8080` |
 | Request Method | Método HTTP da requisição. Exemplo: `GET` ou `POST` |
-| Request Time | Tempo de processamento da requisição decorrido desde que os primeiros bytes foram lidos a partir do cliente, com resolução de milissegundos. Este campo é o resultado de uma soma. Exemplo: `1.19` |
+| Request Time | Tempo de processamento da requisição, em segundos, desde que os primeiros bytes foram lidos a partir do cliente. Este campo é resultado de uma soma. Exemplo: Exemplo: `0.234` |
 | Request URI | URI da requisição realizada pelo usuário, sem a informação do host e de protocolo e com argumentos. Exemplo:`/v1?v=bo%20dim` |
 | Scheme | Esquema da requisição. Exemplo: `HTTP` ou `HTTPS` |
 | Solution | Identificação da edge application. Exemplo: `1321` |
@@ -213,7 +213,7 @@ Exibe os registros de eventos de requisições feitas às edge applications que 
 | Remote Port | Porta remota da origem que gerou a requisição. Exemplo: `8080` |
 | Request Length | Tamanho da requisição, incluindo a linha da requisição, cabeçalhos e corpo. Este campo é o resultado de uma soma. Exemplo: `167` |
 | Request Method | Método HTTP da requisição. Exemplo: `GET` ou `POST` |
-| Request Time | Tempo de processamento da requisição decorrido desde que os primeiros bytes foram lidos a partir do cliente, com resolução de milissegundos. Este campo é o resultado de uma soma. Exemplo: `1.19` |
+| Request Time | Tempo de processamento da requisição, em segundos, desde que os primeiros bytes foram lidos a partir do cliente. Este campo é resultado de uma soma. Exemplo: Exemplo: `0.234` |
 | Request URI | URI da requisição realizada pelo usuário, sem a informação do host e de protocolo e com argumentos. Exemplo: `/v1?v=bo%20dim` |
 | Scheme | Esquema da requisição. Exemplo: `HTTP` ou `HTTPS` |
 | Server Protocol | Protocolo da requisição. Exemplo: `HTTP/1.1`, `HTTP/2.0`, `HTTP/3.0` |
@@ -223,8 +223,8 @@ Exibe os registros de eventos de requisições feitas às edge applications que 
 | Upstream Addr | Endereço IP e porta do cliente. Também pode armazenar múltiplos servidores ou grupos de servidores. Exemplo: `192.168.1.1:80`. Quando a resposta é `127.0.0.1:1666`, o upstream é o [Azion Cells Runtime](/pt-br/documentacao/runtime/visao-geral/) |
 | Upstream Bytes Received | Número de bytes recebidos pelo edge da origem, se o conteúdo não estiver em cache. Exemplo: `8304` |
 | Upstream Cache Status | Status do cache local do edge. Pode ser: `MISS`, `BYPASS`, `EXPIRED`, `STALE`, `UPDATING`, `REVALIDATED`, `HIT` ou `-` |
-| Upstream Connect Time | Tempo que o edge leva para estabelecer uma conexão com a origem em milissegundos. No caso de TLS, inclui o tempo gasto no handshake. Exemplo: `0.123`. **`0` no caso do KeepAlive e `-` no caso de cache** |
-| Upstream Header Time | Tempo que leva para o edge receber o cabeçalho de resposta da origem em milissegundos. Exemplo: `0.345`. **Em caso de cache, a resposta é `-`**. |
+| Upstream Connect Time | Tempo que leva para o edge estabelecer uma conexão com a origem, em segundos. No caso de TLS, inclui o tempo gasto no handshake. Exemplo: `0.123`. **Retorna `0` para KeepAlive e `-` para cache** |
+| Upstream Header Time | Tempo para que o edge receba os cabeçalhos de resposta da origem, em segundos. Exemplo: `0.345`. **No caso de cache, a resposta é `-`** |
 | Upstream Response Time | Tempo, em segundos, para o edge receber uma resposta padrão da origem, incluindo cabeçalhos e corpo. Exemplo: `0.876`. **Em caso de cache, a resposta é `-`** |
 | Upstream Status | Código de status HTTP da origem. Se um servidor não puder ser selecionado, a variável mantém o código de status 502 (Bad Gateway). Exemplo: `200`. **Em caso de cache, a resposta é `-`** |
 


### PR DESCRIPTION
### Related issue:

[EDU-5020] 

### Changes

Adjust time-related metrics in Observe Docs:

- Real-Time Events GraphQL API Fields
- Real-Time Events Reference.
- Real-Time Metrics GraphQL API Fields
- Data Stream Reference

### Additional links

n/a.

[EDU-5020]: https://aziontech.atlassian.net/browse/EDU-5020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ