### PR TITLE
[EDU-5503] feature: add guide - How to query the top URLs impacted by bots

### DIFF
--- a/src/content/docs/en/pages/guides/graphql/bot-manager-breakdown-data.mdx
+++ b/src/content/docs/en/pages/guides/graphql/bot-manager-breakdown-data.mdx
@@ -1,0 +1,107 @@
+---
+title: How to query Bot Manager Breakdown data with GraphQL API
+description: This guide explains how to query the top 5 URLs impacted by bot activity using the GraphiQL playground.
+meta_tags: graphql, api, query, bot management, Azion Bot Manager, Breakdown
+namespace: docs_guides_query_bot_manager_breakdown_data_graphql
+permalink: /documentation/products/guides/query-bot-manager-breakdown-data-with-graphql/
+menu_namespace: graphqlMenu
+---
+
+The **botManagerBreakdownMetrics** dataset provides access to real-time aggregated data from Azion Bot Manager activity, related to requests classified as bots and bad bots across your applications, as well as the URLs most impacted by bots access. This dataset is part of the Real-Time Metrics GraphQL API and is generated from the requests analyzed and identified as bots and bad bots.
+
+This information can be accessed through the GraphQL API. Additionally, this data is retained and available for up to *60 days*.
+
+This guide explains how to query the top 5 URLs impacted by bot activity.
+
+:::note
+To retrieve this data, you must be subscribed to Azion Bot Manager and use the [GraphQL API](/en/documentation/devtools/graphql-api/overview/). Contact the [Sales team](https://www.azion.com/en/contact-sales/) for more details on the subscription.
+:::
+
+---
+
+## Querying data
+
+To query the top 5 URLs impacted by bot activity, proceed as follows:
+
+1. Access the GraphiQL playground in this link: `https://manager.azion.com/metrics/graphql`.
+    - You must be logged in to your Azion account. Otherwise, you'll receive an error message.
+2. Send a query following this format:
+
+```graphql
+query {
+  botManagerBreakdownMetrics (
+    filter: {
+      tsRange: {
+        begin: "2024-10-01T00:00:00"
+        end: "2024-10-03T00:00:00"
+      }
+    }
+    aggregate: {
+      sum: botRequests
+    }
+    groupBy: [requestUrl]
+    orderBy: [sum_DESC]
+    limit: 5
+  ) {
+    requestUrl
+    sum
+  }
+}
+```
+
+Where:
+
+| Field | Description |
+|----------|----------|
+| `filter` | Defines the criteria used to filter the data returned by the query |
+| `tsRange` | A subfield of `filter`. Specifies a time range for filtering data. It includes `begin` and `end` fields to define the start and end timestamps. Format: `"YYYY-MM-DDTHH:mm:ss"`; example: `"2024-04-11T00:00:00"` |
+| `sum: botRequests` | Returns the total number of requests classified as bots within the specified time range, after applying any filters |
+| `orderBy` | Specifies the order in which the results should be returned. Examples: `[sum_DESC]`, for descending order, and `[sum_ASC]`, for ascending order |
+| `groupBy` | Specifies the fields by which the query results should be grouped. Example: `[requestUrl]` to group by URL |
+| `limit` | Specifies the maximum number of results to return. In this case, `5` |
+
+:::note
+This example retrieves data for `requestUrl`, the impacted URLs, and the total (sum) of requests identified as bots during the specified time range, grouped by the selected fields. To know more about the available fields, check the [Real-Time Metrics GraphQL API Fields documentation](/en/documentation/devtools/graphql-api/features/gql-real-time-metrics-fields/).
+:::
+
+3. You'll receive a JSON response similar to this: 
+
+```graphql
+{
+  "data": {
+    "botManagerBreakdownMetrics": [
+      {
+        "requestUrl": "example-host1.com/api/v1/resource",
+        "sum": 333543
+      },
+      {
+        "requestUrl": "example-host2.net/api/v2/data",
+        "sum": 107281
+      },
+      {
+        "requestUrl": "example-host3.org/api/v3/info",
+        "sum": 103363
+      },
+      {
+        "requestUrl": "example-host4.io/api/v4/details",
+        "sum": 89668
+      },
+      {
+        "requestUrl": "example-host5.co/api/v5/summary",
+        "sum": 64060
+      }
+    ]
+  }
+}
+```
+
+Where: 
+
+| Field | Description |
+|----------|----------|
+| `requestUrl` | URL impacted by bot activity. Example: `example-host5.co/api/v5/summary` |
+| `sum` | Total bot activity requests received by the URL. This field is the result of a sum. Example: `333543` |
+
+:::tip
+To know more about the available fields, check the [Real-Time Metrics GraphQL API Fields documentation](/en/documentation/devtools/graphql-api/features/gql-real-time-metrics-fields/).
+:::

--- a/src/content/docs/en/pages/guides/graphql/bot-manager-breakdown-data.mdx
+++ b/src/content/docs/en/pages/guides/graphql/bot-manager-breakdown-data.mdx
@@ -1,6 +1,6 @@
 ---
-title: How to query Bot Manager Breakdown data with GraphQL API
-description: This guide explains how to query the top 5 URLs impacted by bot activity using the GraphiQL playground.
+title: How to query the top URLs impacted by bots with GraphQL API
+description: This guide explains how to query the top 5 URLs impacted by bot activity using the GraphiQL playground and the botManagerBreakdownMetrics dataset.
 meta_tags: graphql, api, query, bot management, Azion Bot Manager, Breakdown
 namespace: docs_guides_query_bot_manager_breakdown_data_graphql
 permalink: /documentation/products/guides/query-bot-manager-breakdown-data-with-graphql/

--- a/src/content/docs/en/pages/guides/graphql/bot-manager-breakdown-data.mdx
+++ b/src/content/docs/en/pages/guides/graphql/bot-manager-breakdown-data.mdx
@@ -64,7 +64,7 @@ Where:
 This example retrieves data for `requestUrl`, the impacted URLs, and the total (sum) of requests identified as bots during the specified time range, grouped by the selected fields. To know more about the available fields, check the [Real-Time Metrics GraphQL API Fields documentation](/en/documentation/devtools/graphql-api/features/gql-real-time-metrics-fields/).
 :::
 
-3. You'll receive a JSON response similar to this: 
+3. You'll receive a response similar to this: 
 
 ```graphql
 {
@@ -100,7 +100,7 @@ Where:
 | Field | Description |
 |----------|----------|
 | `requestUrl` | URL impacted by bot activity. Example: `example-host5.co/api/v5/summary` |
-| `sum` | Total bot activity requests received by the URL. This field is the result of a sum. Example: `333543` |
+| `sum` | Total requests involving bot activity received by the URL. This field is the result of a sum. Example: `333543` |
 
 :::tip
 To know more about the available fields, check the [Real-Time Metrics GraphQL API Fields documentation](/en/documentation/devtools/graphql-api/features/gql-real-time-metrics-fields/).

--- a/src/content/docs/en/pages/guides/index.mdx
+++ b/src/content/docs/en/pages/guides/index.mdx
@@ -175,6 +175,7 @@ permalink: /documentation/products/guides/
 - [Real-Time Metrics GraphQL API dashboard on Grafana JSON example](/en/documentation/products/real-time-metrics/metrics-dash/)
 - [How to query Connected Users data with GraphQL API](/en/documentation/products/guides/query-connected-users-data-with-graphql/)
 - [How to query Bot Manager data with GraphQL API](/en/documentation/products/guides/query-bot-manager-data-with-graphql/)
+- [How to query the top URLs impacted by bots with GraphQL API](/en/documentation/products/guides/query-bot-manager-breakdown-data-with-graphql/)
 
 ---
 

--- a/src/content/docs/pt-br/pages/guias/graphql/bot-manager-breakdown-data.mdx
+++ b/src/content/docs/pt-br/pages/guias/graphql/bot-manager-breakdown-data.mdx
@@ -1,6 +1,6 @@
 ---
-title: Como consultar dados do Bot Manager Breakdown com a GraphQL API
-description: Este guia explica como consultar as 5 principais URLs impactadas pela atividade de bots usando o GraphiQL playground.
+title: Como consultar as principais URLs impactadas por bots com a GraphQL API
+description: Este guia explica como consultar as 5 principais URLs impactadas pela atividade de bots usando o GraphiQL playground e o dataset botManagerBreakdownMetrics.
 meta_tags: graphql, api, query, bot management, gerenciamento de bots, Azion Bot Manager, breakdown
 namespace: docs_guides_query_bot_manager_breakdown_data_graphql
 permalink: /documentacao/produtos/guias/consultar-dados-bot-manager-breakdown-com-graphql/

--- a/src/content/docs/pt-br/pages/guias/graphql/bot-manager-breakdown-data.mdx
+++ b/src/content/docs/pt-br/pages/guias/graphql/bot-manager-breakdown-data.mdx
@@ -19,13 +19,13 @@ Para recuperar esses dados, você deve estar inscrito no Azion Bot Manager e usa
 
 ---
 
-## Querying data
+## Consulte os dados
 
-To query the top 5 URLs impacted by bot activity, proceed as follows:
+Para consultar as 5 principais URLs impactadas pela atividade de bots, proceda da seguinte forma:
 
-1. Access the GraphiQL playground in this link: `https://manager.azion.com/metrics/graphql`.
-    - You must be logged in to your Azion account. Otherwise, you'll receive an error message.
-2. Send a query following this format:
+1. Acesse o GraphiQL playground nesse link: `https://manager.azion.com/metrics/graphql`.
+    - Você deve estar logado na sua conta Azion. Caso contrário, você receberá uma mensagem de erro.
+2. Envie uma query seguindo este formato:
 
 ```graphql
 query {

--- a/src/content/docs/pt-br/pages/guias/graphql/bot-manager-breakdown-data.mdx
+++ b/src/content/docs/pt-br/pages/guias/graphql/bot-manager-breakdown-data.mdx
@@ -1,0 +1,107 @@
+---
+title: Como consultar dados do Bot Manager Breakdown com a GraphQL API
+description: Este guia explica como consultar as 5 principais URLs impactadas pela atividade de bots usando o GraphiQL playground.
+meta_tags: graphql, api, query, bot management, gerenciamento de bots, Azion Bot Manager, breakdown
+namespace: docs_guides_query_bot_manager_breakdown_data_graphql
+permalink: /documentacao/produtos/guias/consultar-dados-bot-manager-breakdown-com-graphql/
+menu_namespace: graphqlMenu
+---
+
+O conjunto de dados **botManagerBreakdownMetrics** fornece acesso a dados agregados em tempo real da atividade do Azion Bot Manager, relacionado a requisições classificadas como bots e bots maliciosos em suas aplicações, bem como as URLs mais impactadas pelo acesso de bots. Este conjunto de dados faz parte da API GraphQL de Real-Time Metrics e é gerado a partir das requisições analisadas e identificadas como bots e bots maliciosos.
+
+Essas informações podem ser acessadas através da API GraphQL. Além disso, esses dados são retidos e disponíveis por até *60 dias*.
+
+Este guia explica como consultar dados do Bot Manager usando o playground GraphiQL.
+
+:::note
+Para recuperar esses dados, você deve estar inscrito no Azion Bot Manager e usar a [API GraphQL](/pt-br/documentacao/devtools/graphql-api/visao-geral/). Entre em contato com a [equipe de vendas](https://www.azion.com/pt-br/contate-vendas/) para mais detalhes sobre a assinatura.
+:::
+
+---
+
+## Querying data
+
+To query the top 5 URLs impacted by bot activity, proceed as follows:
+
+1. Access the GraphiQL playground in this link: `https://manager.azion.com/metrics/graphql`.
+    - You must be logged in to your Azion account. Otherwise, you'll receive an error message.
+2. Send a query following this format:
+
+```graphql
+query {
+  botManagerBreakdownMetrics (
+    filter: {
+      tsRange: {
+        begin: "2024-10-01T00:00:00"
+        end: "2024-10-03T00:00:00"
+      }
+    }
+    aggregate: {
+      sum: botRequests
+    }
+    groupBy: [requestUrl]
+    orderBy: [sum_DESC]
+    limit: 5
+  ) {
+    requestUrl
+    sum
+  }
+}
+```
+
+Onde:
+
+| Campo | Descrição |
+|----------|----------|
+| `filter` | Define os critérios usados para filtrar os dados retornados pela consulta |
+| `tsRange` | Um subcampo de `filter`. Especifica um intervalo de tempo para filtrar dados. Inclui os campos `begin` e `end` para definir os timestamps de início e fim. Formato: `"YYYY-MM-DDTHH:mm:ss"`; exemplo: `"2024-04-11T00:00:00"` |
+| `sum: botRequests` | Retorna o número total de requisições classificadas como bots dentro do intervalo de tempo especificado, após a aplicação de quaisquer filtros |
+| `orderBy` | Especifica a ordem em que os resultados devem ser retornados. Exemplos: `[sum_DESC]`, para ordem decrescente, e `[sum_ASC]`, para ordem crescente |
+| `groupBy` | Especifica os campos pelos quais os resultados da consulta devem ser agrupados. Exemplo: `[requestUrl]` para agrupar por URL |
+| `limit` | Especifica o número máximo de resultados a serem retornados. Neste caso, `5` |
+
+:::note
+Este exemplo recupera dados para `requestUrl`, as URLs impactadas, e o total (`sum`) de requisições identificadas como bots durante o intervalo de tempo especificado, agrupados pelos campos selecionados. Para saber mais sobre os campos disponíveis, consulte a [documentação dos Campos da GraphQL API do Real-Time Metrics](/pt-br/documentacao/devtools/graphql-api/recursos/campos-gql-real-time-metrics/)
+:::
+
+3. Você receberá uma resposta semelhante a esta:
+
+```graphql
+{
+  "data": {
+    "botManagerBreakdownMetrics": [
+      {
+        "requestUrl": "example-host1.com/api/v1/resource",
+        "sum": 333543
+      },
+      {
+        "requestUrl": "example-host2.net/api/v2/data",
+        "sum": 107281
+      },
+      {
+        "requestUrl": "example-host3.org/api/v3/info",
+        "sum": 103363
+      },
+      {
+        "requestUrl": "example-host4.io/api/v4/details",
+        "sum": 89668
+      },
+      {
+        "requestUrl": "example-host5.co/api/v5/summary",
+        "sum": 64060
+      }
+    ]
+  }
+}
+```
+
+Onde: 
+
+| Campo | Descrição |
+|----------|----------|
+| `requestUrl` | URL impactada pela atividade de bots. Exemplo: `example-host5.co/api/v5/summary` |
+| `sum` | Total de requisições envolvendo atividade de bots recebidas pela URL. Este campo é o resultado de uma soma. Exemplo: `333543` |
+
+:::tip
+Para saber mais sobre os campos disponíveis, consulte a [documentação dos Campos da API GraphQL do Real-Time Metrics](/pt-br/documentacao/devtools/graphql-api/recursos/campos-gql-real-time-metrics/).
+:::

--- a/src/content/docs/pt-br/pages/guias/graphql/query-bot-manager-data.mdx
+++ b/src/content/docs/pt-br/pages/guias/graphql/query-bot-manager-data.mdx
@@ -23,7 +23,7 @@ Para recuperar esses dados, você deve estar inscrito no Azion Bot Manager e usa
 
 Para consultar seus dados, siga os passos:
 
-1. Acesse o [playground GraphiQL](https://manager.azion.com/metrics/graphql).
+1. Acesse o playground GraphiQL visitando o link `https://manager.azion.com/metrics/graphql`.
     - Você deve estar logado na sua conta Azion. Caso contrário, você receberá uma mensagem de erro.
 2. Envie uma query seguindo este formato:
 

--- a/src/content/docs/pt-br/pages/guias/guides.mdx
+++ b/src/content/docs/pt-br/pages/guias/guides.mdx
@@ -175,6 +175,7 @@ permalink: /documentacao/produtos/guias/
 - [Exemplo JSON para dashboard da API GraphQL do Real-Time Metrics no Grafana](/pt-br/documentacao/produtos/real-time-metrics/metrics-dash/)
 - [Como consultar dados de usuários conectados com a GraphQL API](/pt-br/documentacao/produtos/guias/query-dados-connected-users-com-graphql/)
 - [Como consultar dados do Bot Manager com a GraphQL API](/pt-br/documentacao/produtos/guias/consultar-dados-bot-manager-com-graphql/)
+- [Como consultar as principais URLs impactadas por bots com a GraphQL API](/pt-br/documentacao/produtos/guias/consultar-dados-bot-manager-breakdown-com-graphql/)
 
 ---
 

--- a/src/content/docs/pt-br/pages/observe-jornada/real-time-events/analise-logs/investigue-requisicoes.mdx
+++ b/src/content/docs/pt-br/pages/observe-jornada/real-time-events/analise-logs/investigue-requisicoes.mdx
@@ -34,7 +34,7 @@ Veja os passos descritos neste guia para investigar requisições e os próximos
 
 Inicie sua investigação com uma query focada nos países que estão fazendo requisições.
 
-1. No [playground](https://manager.azion.com/events/graphql) da API GraphQL Real-Time Events, adicione a seguinte query:
+1. Entre no playground no link `https://manager.azion.com/events/graphql` da API GraphQL Real-Time Events, adicione a seguinte query:
 
 ```graphql
 query requestsInvestigationCountries {

--- a/src/content/docs/pt-br/pages/secure-jornada/firewall-configuracoes-avancadas/gerenciar-bots.mdx
+++ b/src/content/docs/pt-br/pages/secure-jornada/firewall-configuracoes-avancadas/gerenciar-bots.mdx
@@ -69,7 +69,7 @@ Você pode consultar o conjunto de dados do [Bot Manager](/pt-br/documentacao/pr
 
 ### Use o Data Stream como ferramenta de observabilidade
 
-Para configurar uma edge function, siga as etapas em [Configure a função](/pt-br/documentacao/produtos/guias/bot-manager/#configure-a-funcao).
+Para configurar uma edge function, siga as etapas em [Configure a função](/pt-br/documentacao/produtos/guias/bot-manager-lite/#configure-a-funcao).
 
 Depois, você pode utilizar [Data Stream](/pt-br/documentacao/produtos/observe/data-stream/) para integrar com plataformas de stream, SIEM e big data usando o source **Edge Functions** e o template **Edge Functions Event Collector**. Assim, você pode enviar seus registros para o conector que você usa e monitorar os eventos do Bot Manager.
 <br /><br />

--- a/src/i18n/en/graphqlMenu.ts
+++ b/src/i18n/en/graphqlMenu.ts
@@ -37,7 +37,8 @@
 		{ text: 'How to query aggregated data', slug: '/documentation/products/guides/graphql-aggregated-data', key: 'guides/graphql-aggregated-data' },
 		{ text: 'How to select Top X queries', slug: '/documentation/products/guides/graphql-top-x-query', key: 'guides/graphql-top-x' },
 		{ text: 'How to query Connected Users data', slug: '/documentation/products/guides/query-connected-users-data-with-graphql/', key: 'guides/connected-users-graphql' },
-		{ text: 'How to query Bot Manager data', slug: '/documentation/products/guides/query-bot-manager-data-with-graphql/', key: 'guides/bot-data-graphql' }
+		{ text: 'How to query Bot Manager data', slug: '/documentation/products/guides/query-bot-manager-data-with-graphql/', key: 'guides/bot-data-graphql' },
+		{ text: 'How to query the top URLs impacted by bots', slug: '/documentation/products/guides/query-bot-manager-breakdown-data-with-graphql/', key: 'guides/bot-breakdown-data-graphql' }
 	] },
 
 

--- a/src/i18n/pt-br/devtoolsMenu.ts
+++ b/src/i18n/pt-br/devtoolsMenu.ts
@@ -17,7 +17,7 @@
 	{ text: 'CLI', header: true, anchor: true, type: 'learn', key: 'devtools/cli', slug: 'documentacao/produtos/azion-cli/visao-geral', hasLabel:'menu.devTools' },
 	{ text: 'Azion Lib', header: true, anchor: true, type: 'learn', key: 'devtools/azionlib', slug: 'https://www.npmjs.com/package/azion' },
 	{ text: 'API', header: true, anchor: true, type: 'learn', key: 'devtools/api', slug: 'https://api.azion.com/' },
-	{ text: 'API GraphQL', header: true, anchor: true, type: 'learn', slug: '/documentacao/produtos/graphql-api/', key: 'devtools/graphQL' },
+	{ text: 'API GraphQL', header: true, anchor: true, type: 'learn', slug: '/documentacao/devtools/graphql-api/', key: 'devtools/graphQL' },
 	{ text: 'SDK',header: true, anchor: true, type: 'learn', slug: '/documentacao/devtools/sdk/go/', key: 'devtools/sdk' },
 	{ text: 'Terraform', header: true, anchor: true, type: 'learn', slug: '/documentacao/produtos/terraform-provider/', key: 'devtools/terraform' },
 	{ text: 'Console Kit', header: true, anchor: true, type: 'learn', slug: '/documentacao/devtools/console-kit/', key: 'devtools/consoleKit' },

--- a/src/i18n/pt-br/graphqlMenu.ts
+++ b/src/i18n/pt-br/graphqlMenu.ts
@@ -39,6 +39,7 @@
 		{ text: 'Como selecionar Top X queries', slug: '/documentacao/produtos/guias/graphql-query-top-x', key: 'guides/graphql-top-x' },
 		{ text: 'Como consultar dados de usuários conectados', slug: '/documentacao/produtos/guias/query-dados-connected-users-com-graphql/', key: 'guides/connected-users-graphql' },
 		{ text: 'Como consultar dados do Bot Manager', slug: '/documentacao/produtos/guias/consultar-dados-bot-manager-com-graphql/', key: 'guides/bot-data-graphql' },
+		{ text: 'Como consultar as principais URLs impactadas por bots', slug: '/documentacao/produtos/guias/consultar-dados-bot-manager-breakdown-com-graphql/', key: 'guides/bot-breakdown-data-graphql' }
 	] },
 
 


### PR DESCRIPTION
### Related issue: 

[EDU-5503] 

### Changes

- Add  How to query the top URLs impacted by bots guide EN/PT.
- Add the link to the Guides page.
- Add the label and link to the GraphQL menu.

### Additional links

n/a.

[EDU-5503]: https://aziontech.atlassian.net/browse/EDU-5503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ