### PR TITLE
[EDU-4725] Add architectures on header menu

### DIFF
--- a/src/content/docs/en/homes/home-docs.mdx
+++ b/src/content/docs/en/homes/home-docs.mdx
@@ -74,7 +74,7 @@ product_cards:
       - icon: /assets/docs/images/uploads/icon-guides.svg
         title: Find more
         description: >-
-          View all use cases.
+          View all architectures for use cases.
         link: >-
           /en/documentation/architectures/
   - title: Pick your development interface

--- a/src/content/docs/pt-br/homes/doc-home.mdx
+++ b/src/content/docs/pt-br/homes/doc-home.mdx
@@ -74,7 +74,7 @@ product_cards:
       - icon: /assets/docs/images/uploads/icon-guides.svg
         title: Saiba mais
         description: >-
-          Veja todos os casos de uso.
+          Veja todas as arquiteturas para casos de uso.
         link: >-
           /pt-br/documentacao/arquiteturas/
   - title: Escolha sua interface de desenvolvimento

--- a/src/i18n/en/header.ts
+++ b/src/i18n/en/header.ts
@@ -14,7 +14,12 @@ const menuData = {
       label: 'DevTools',
       href: '/en/documentation/devtools/',
       items: []
-    }
+    },
+		{
+			label: 'Architectures',
+			href: '/en/documentation/architectures/',
+			items: []
+		}
   ]
 };
 

--- a/src/i18n/pt-br/header.ts
+++ b/src/i18n/pt-br/header.ts
@@ -14,7 +14,12 @@ const menuData = {
       label: 'DevTools',
       href: '/pt-br/documentacao/produtos/devtools/',
       items: []
-    }
+    },
+		{
+			label: 'Arquiteturas',
+			href: '/pt-br/documentacao/arquiteturas/',
+			items: []
+		}
   ]
 };
 


### PR DESCRIPTION

### Changes

Adds a label on the header menu for architectures and updates the description of the "Find more" card directing to the architectures home.