### PR TITLE
[EDU-5523] Update azion.config.js reference

### DIFF
--- a/src/content/docs/en/pages/devtools/azion-edge-runtime/compatibility/cells-node.mdx
+++ b/src/content/docs/en/pages/devtools/azion-edge-runtime/compatibility/cells-node.mdx
@@ -51,7 +51,7 @@ import { API } from "import-origin";
 
 ## Node polyfills
 
-A polyfill is a code snippet, often used in JavaScript, that brings new features to environments lacking these capabilities. Polyfills are used during build time at Azion and can be configured through the [bundler.config.js](/en/documentation/devtools/vulcan/config/) file.
+A polyfill is a code snippet, often used in JavaScript, that brings new features to environments lacking these capabilities. Polyfills are used during build time at Azion and can be configured through the [azion.config.js](/en/documentation/devtools/cli/configs/azion-config-js/) file.
 
 Here's a list of Node APIs supported through polyfills:
 

--- a/src/content/docs/en/pages/devtools/cli/azion-cli/config/azion-config-js.mdx
+++ b/src/content/docs/en/pages/devtools/cli/azion-cli/config/azion-config-js.mdx
@@ -192,7 +192,7 @@ The property cache in rules can be a reference to a cache created in the config 
 | layer | string | `edge_caching`, `l2_caching` | |
 
 
-For further information, access [azion.config.js schema in the Azion Lib repository](https://github.com/aziontech/lib/blob/346e944ac6bfb3a8e8b3eb658166b87957eb5fec/packages/config/src/processConfig/helpers/schema.ts).
+For further information, access [azion.config.js schema](https://github.com/aziontech/lib/blob/346e944ac6bfb3a8e8b3eb658166b87957eb5fec/packages/config/src/processConfig/helpers/schema.ts) in the **Azion Lib** repository.
 
 ---
 

--- a/src/content/docs/en/pages/devtools/cli/azion-cli/config/azion-config-js.mdx
+++ b/src/content/docs/en/pages/devtools/cli/azion-cli/config/azion-config-js.mdx
@@ -16,16 +16,32 @@ The azion.config.js file is an IaC configuration file created during the applica
 
 The configurations set by this file include: 
 
+- Build Configurations
 - Origins
 - Cache Settings
 - Rules Engine
 - Network List
+- Purge Settings
 
 :::note
 The default properties and values generated in the project's initial build are tested and work properly. In case this file is altered, we no longer guarantee it works properly, so use it wisely.
 :::
 
 The following tables explain the properties of this configuration file.
+
+---
+
+## build
+
+| Property | Type | Description | Expected values |
+| --- | --- | --- | --- |
+| **builder** | String | The build tool to use | `esbuild` or `webpack` |
+| **preset** | Object | The preset to use | Property:<br />**name** (String) |
+| **entry** | String | Entry point for your application | |
+| **polyfills** | Boolean | Whether to include Node.js polyfills | |
+| **worker** | Boolean | Whether to build an owner worker | |
+| **custom** | Object | Custom build configuration | |
+| **memoryFS** | Object | Memory file system configuration | Properties:<br /> **InjectionDirs** (Array)<br />**RemovePathPrefix** (String) |
 
 ---
 
@@ -68,11 +84,6 @@ The following tables explain the properties of this configuration file.
 | bucket | string, null | | The 'bucket' field must be a string or null |
 | prefix | string, null | | The 'prefix' field must be a string or null |
 | additionalProperties | boolean | | No additional properties are allowed in origin item objects |
-
-:::note
-| required | array | The 'name and type' field is required in each origin item |
-| errorMessage | object | The 'origin' field must be an array of objects |
-:::
 
 ---
 
@@ -168,7 +179,6 @@ The property cache in rules can be a reference to a cache created in the config 
 | listType | string | The 'listType' field must be a string |
 | listContent | array | The 'listContent' field must be an array of strings |
 
-[For further information, access azion.config.js schema in Azion Bundler repository](https://github.com/aziontech/bundler/blob/stage/lib/utils/generateManifest/helpers/schema.js).
 
 ---
 
@@ -177,15 +187,80 @@ The property cache in rules can be a reference to a cache created in the config 
 | Property | Type | Expected values | Error message |
 |---|---|---|---|
 | type | string | `url`, `cachekey`, `wildcard` | |
-| urls | array | |  |
-| method | string | |  |
+| urls | array | | |
+| method | string `delete` | | |
+| layer | string | `edge_caching`, `l2_caching` | |
 
-:::note
-| required | array | The 'type and urls' field is required in each purge item |
-| errorMessage | object | The 'purge' field must be an array of objects |
-:::
+
+For further information, access [azion.config.js schema in the Azion Lib repository](https://github.com/aziontech/lib/blob/346e944ac6bfb3a8e8b3eb658166b87957eb5fec/packages/config/src/processConfig/helpers/schema.ts).
+
+---
 
 ## Example
 
-<LinkButton link="https://github.com/aziontech/bundler/blob/stage/lib/utils/generateManifest/helpers/azion.config.example.js" label="Go to IaC sample file" severity="secondary" target="_blank" />
+Here's an example of an implementation of the `azion.config.js` file:
 
+```JavaScript
+import { defineConfig } from 'azion';
+
+const config = defineConfig({
+  domain: {
+    name: 'example.com',
+    cnameAccessOnly: false,
+    cnames: ['www.example.com', 'cdn.example.com'],
+    Id: 12345,
+    edgeFirewallId: 67890,
+    digitalCertificateId: null,
+    mtls: {
+      verification: 'enforce',
+      trustedCaCertificateId: 98765,
+    },
+  },
+  origin: [
+    {
+      name: 'My Origin',
+      type: 'single_origin',
+      addresses: [
+        {
+          address: 'origin.example.com',
+          weight: 100,
+        },
+      ],
+      protocolPolicy: 'https',
+    },
+  ],
+  cache: [
+    {
+      name: 'Default Cache',
+      browser: {
+        maxAgeSeconds: 3600,
+      },
+      edge: {
+        maxAgeSeconds: 7200,
+      },
+    },
+  ],
+  rules: {
+    request: [
+      {
+        name: 'Example Rule',
+        match: 'path',
+        behavior: {
+          setOrigin: {
+            name: 'My Origin',
+            type: 'single_origin',
+          },
+        },
+      },
+    ],
+  },
+  purge: [
+    {
+      type: 'url',
+      urls: ['https://example.com/path/to/purge'],
+      method: 'delete',
+      layer: 'edge_caching',
+    },
+  ],
+});
+```

--- a/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/compatibilidade/node.mdx
+++ b/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/compatibilidade/node.mdx
@@ -53,7 +53,7 @@ import { API } from "import-origin";
 
 ## Node polyfills
 
-Um polyfill é um trecho de código, frequentemente usado em JavaScript, que traz novos recursos para ambientes que não possuem essas capacidades. Os polyfills são usados durante o tempo de *build* e podem ser configurados através do arquivo [bundler.config.js](/pt-br/documentacao/devtools/vulcan/config/).
+Um polyfill é um trecho de código, frequentemente usado em JavaScript, que traz novos recursos para ambientes que não possuem essas capacidades. Os polyfills são usados durante o tempo de *build* e podem ser configurados através do arquivo [azion.config.js](/pt-br/documentacao/devtools/cli/configs/azion-config-js/).
 
 Aqui está a lista de APIs do Node suportadas através de polyfills:
 

--- a/src/content/docs/pt-br/pages/devtools/cli/azion-cli/configs/azion-config-js.mdx
+++ b/src/content/docs/pt-br/pages/devtools/cli/azion-cli/configs/azion-config-js.mdx
@@ -17,16 +17,32 @@ O arquivo `azion.config.js` é um arquivo de configuração de IaC criado durant
 
 As configurações definidas por este arquivo incluem: 
 
+- Build Configurations
 - Origins
 - Cache Settings
 - Rules Engine
 - Network List
+- Purge Settings
 
 :::note
 As propriedades e valores padrão gerados no build inicial do projeto são testados e funcionam corretamente. Caso este arquivo seja alterado, não garantimos mais que funcione corretamente, portanto, use-o com cuidado.
 :::
 
 As tabelas a seguir explicam as propriedades deste arquivo de configuração.
+
+---
+
+## build
+
+| Propriedade | Tipo | Descrição | Valores esperados |
+| --- | --- | --- | --- |
+| **builder** | String | A ferramenta de build a ser usada | `esbuild` ou `webpack` |
+| **preset** | Object | O preset a ser usado | Propriedade:<br />**name** (String) |
+| **entry** | String | Ponto de entrada para sua aplicação | |
+| **polyfills** | Boolean | Se deve incluir polyfills do Node.js | |
+| **worker** | Boolean | Se deve construir um worker proprietário | |
+| **custom** | Object | Configuração de build personalizada | |
+| **memoryFS** | Object | Configuração do sistema de arquivos em memória | Propriedades:<br /> **InjectionDirs** (Array)<br />**RemovePathPrefix** (String) |
 
 ---
 
@@ -97,7 +113,7 @@ As tabelas a seguir explicam as propriedades deste arquivo de configuração.
 
 ### Request rules
 
-| Propriedade | Tipo | Valores esperados | Mensagem de erro |
+| Propriedade | Tipo | Mensagem de erro |
 |----------------|----------------|---------------------------------------------------------------------------------------------------------------|
 | name | string | The 'name' field must be a string |
 | match | string | The 'match' field must be a string |
@@ -165,7 +181,6 @@ A propriedade cache nas regras pode ser uma referência a um cache criado no arq
 | listType | string | O campo 'listType' deve ser uma string |
 | listContent | array | O campo 'listContent' deve ser uma array de strings |
 
-Para mais informações, acesse o [esquema do azion.config.js no repositório Azion Bundler](https://github.com/aziontech/bundler/blob/stage/lib/utils/generateManifest/helpers/schema.js).
 
 ---
 
@@ -174,13 +189,77 @@ Para mais informações, acesse o [esquema do azion.config.js no repositório Az
 | Propriedade | tipo | Valores esperados | Mensagem de erro |
 |---|---|---|---|
 | type | string | `url`, `cachekey`, `wildcard` | |
-| urls | array | |  |
-| method | string | |  |
+| urls | array | | |
+| method | string | `delete` | |
+| layer | string | `edge_caching`, `l2_caching` | |
+
+Para mais informações, acesse o [esquema do azion.config.js no repositório Azion Lib](https://github.com/aziontech/lib/blob/346e944ac6bfb3a8e8b3eb658166b87957eb5fec/packages/config/src/processConfig/helpers/schema.ts).
 
 ---
 
 ## Exemplo
+Aqui está um exemplo de implementação do arquivo `azion.config.js`:
 
+```JavaScript
+import { defineConfig } from 'azion';
 
-
-<LinkButton link="https://github.com/aziontech/bundler/blob/stage/lib/utils/generateManifest/helpers/azion.config.example.js" label="Acesse o arquivo de exemplo do IaC" severity="secondary" target="_blank" />
+const config = defineConfig({
+  domain: {
+    name: 'example.com',
+    cnameAccessOnly: false,
+    cnames: ['www.example.com', 'cdn.example.com'],
+    Id: 12345,
+    edgeFirewallId: 67890,
+    digitalCertificateId: null,
+    mtls: {
+      verification: 'enforce',
+      trustedCaCertificateId: 98765,
+    },
+  },
+  origin: [
+    {
+      name: 'My Origin',
+      type: 'single_origin',
+      addresses: [
+        {
+          address: 'origin.example.com',
+          weight: 100,
+        },
+      ],
+      protocolPolicy: 'https',
+    },
+  ],
+  cache: [
+    {
+      name: 'Default Cache',
+      browser: {
+        maxAgeSeconds: 3600,
+      },
+      edge: {
+        maxAgeSeconds: 7200,
+      },
+    },
+  ],
+  rules: {
+    request: [
+      {
+        name: 'Example Rule',
+        match: 'path',
+        behavior: {
+          setOrigin: {
+            name: 'My Origin',
+            type: 'single_origin',
+          },
+        },
+      },
+    ],
+  },
+  purge: [
+    {
+      type: 'url',
+      urls: ['https://example.com/path/to/purge'],
+      method: 'delete',
+      layer: 'edge_caching',
+    },
+  ],
+});

--- a/src/content/docs/pt-br/pages/devtools/cli/azion-cli/configs/azion-config-js.mdx
+++ b/src/content/docs/pt-br/pages/devtools/cli/azion-cli/configs/azion-config-js.mdx
@@ -193,7 +193,7 @@ A propriedade cache nas regras pode ser uma referência a um cache criado no arq
 | method | string | `delete` | |
 | layer | string | `edge_caching`, `l2_caching` | |
 
-Para mais informações, acesse o [esquema do azion.config.js no repositório Azion Lib](https://github.com/aziontech/lib/blob/346e944ac6bfb3a8e8b3eb658166b87957eb5fec/packages/config/src/processConfig/helpers/schema.ts).
+Para mais informações, acesse o [esquema do azion.config.js](https://github.com/aziontech/lib/blob/346e944ac6bfb3a8e8b3eb658166b87957eb5fec/packages/config/src/processConfig/helpers/schema.ts) no repositório **Azion Lib**.
 
 ---
 

--- a/src/i18n/en/cliMenuAlpha.ts
+++ b/src/i18n/en/cliMenuAlpha.ts
@@ -55,7 +55,6 @@ export default [
 	{
         text: 'Project configuration', header: true, type: 'learn', key: 'cli/configs', items: [
             { text: 'azion.config.js file', header: true, anchor: true, type: 'learn', slug: '/documentation/devtools/cli/configs/azion-config-js/', key: 'cli/config/azion' },
-            { text: 'vulcan.config.js file', header: true, anchor: true, type: 'learn', slug: '/documentation/devtools/vulcan/config/', key: 'cli/config/vulcan' },
         ]
     },
 

--- a/src/i18n/pt-br/cliMenuAlpha.ts
+++ b/src/i18n/pt-br/cliMenuAlpha.ts
@@ -50,7 +50,6 @@ export default [
 	{
         text: 'Configurações de projeto', header: true, type: 'learn', key: 'cli/configs', items: [
             { text: 'azion.config.js', header: true, anchor: true, type: 'learn', slug: '/documentacao/devtools/cli/configs/azion-config-js/', key: 'cli/config/azion' },
-            { text: 'vulcan.config.js', header: true, anchor: true, type: 'learn', slug: '/documentacao/devtools/vulcan/config/', key: 'cli/config/vulcan' },
         ]
     },
 


### PR DESCRIPTION

### Changes

As the azion.config.js file has taken up the build configurations previously  set in the bundler.config.js file (formerly vulcan.config.js), these changes update the azion.config reference and replace/remove links to bundler.config page.