### PR TITLE
[EDU-5527] improve link command guide

### DIFF
--- a/src/content/docs/en/pages/devtools/cli/azion-cli/commands/link-project/link.mdx
+++ b/src/content/docs/en/pages/devtools/cli/azion-cli/commands/link-project/link.mdx
@@ -85,7 +85,7 @@ If you want to start a local development server later, run 'azion dev'
 ```
 
 :::note 
-If you want to deploy your application later, run 'azion deploy'. Your application will not be available on the edge until it's deployed.
+If you want to deploy your application later, run 'azion deploy'. Your application won't be available on the edge until it's deployed.
 :::
 
 :::tip

--- a/src/content/docs/en/pages/devtools/cli/azion-cli/commands/link-project/link.mdx
+++ b/src/content/docs/en/pages/devtools/cli/azion-cli/commands/link-project/link.mdx
@@ -18,7 +18,7 @@ In case one or more required fields aren't informed through the specific flags, 
 
 ## Link
 
-The linking process adapts the project so it's linked to Azion and can be deployed as an edge application. It creates the necessary configurations for future build and deploy of the application on the edge.
+The linking process adapts the project so it's linked to Azion and can be deployed as an edge application. It creates the necessary configurations for future build and deployment of the application on the edge.
 
 :::note 
 It's necessary to run the command in the project's root folder.
@@ -86,6 +86,10 @@ If you want to start a local development server later, run 'azion dev'
 
 :::note 
 If you want to deploy your application later, run 'azion deploy'. Your application will not be available on the edge until it's deployed.
+:::
+
+:::tip
+Optionally, you can run `npm i azion` to install [Azion Lib](https://www.npmjs.com/package/azion). These libraries provide tools to interact with Azion services and enable custom configurations for your edge application. Check the [azion.config.js file reference](/en/documentation/devtools/cli/configs/azion-config-js/) for more information. 
 :::
 
 ### Optional flags

--- a/src/content/docs/en/pages/devtools/cli/azion-cli/commands/link-project/link.mdx
+++ b/src/content/docs/en/pages/devtools/cli/azion-cli/commands/link-project/link.mdx
@@ -18,7 +18,7 @@ In case one or more required fields aren't informed through the specific flags, 
 
 ## Link
 
-The linking process adapts the project being linked to an Azion edge application.
+The linking process adapts the project so it's linked to Azion and can be deployed as an edge application. It creates the necessary configurations for future build and deploy of the application on the edge.
 
 :::note 
 It's necessary to run the command in the project's root folder.
@@ -32,26 +32,43 @@ azion link
 
 ### Output 
 
-Confirm the linking of the project to an Azion edge application:
+Confirm the linking of the project to Azion:
 
 ```sh 
 ? Do you want to link /cli-examples/effervescent_moon to Azion? (y/N) 
 ```
 
-Choose a *preset* and *mode*:
+Enter the desired name for your edge application:
 
-```sh 
-? Choose a preset and mode:  [Use arrows to move, type to filter]
-> Html (Deliver)
-  Javascript (Compute)
-  Typescript (Compute)
-  Angular (Deliver)
-  Astro (Deliver)
-  Hexo (Deliver)
-  Next (Compute)
+```sh
+? (Hit enter to accept the suggested name in parenthesis) Your application's name:  (nimble-tyrion) 
 ```
 
-Now, the application will be linked to an edge application. Different processes occur based on the selected template, so you need to answer the interactions that are presented.
+Choose a *preset*:
+
+```sh 
+? Choose a preset:  [Use arrows to move, type to filter]
+> Angular
+  Astro
+  Docusaurus
+  Eleventy
+  Emscripten
+  Gatsby
+  Hexo
+  Html
+  Hugo
+  Javascript
+  Jekyll
+  Next
+  React
+  Rustwasm
+  Svelte
+  Typescript
+  Vitepress
+  Vue
+```
+
+Now, the application will be linked to Azion. Different processes occur based on the selected template, so you need to answer the interactions that are presented.
 
 Choose if you want to run the application locally or not:
 
@@ -68,7 +85,7 @@ If you want to start a local development server later, run 'azion dev'
 ```
 
 :::note 
-If you want to deploy your application later, run 'azion deploy'
+If you want to deploy your application later, run 'azion deploy'. Your application will not be available on the edge until it's deployed.
 :::
 
 ### Optional flags
@@ -90,16 +107,24 @@ The `--mode` option can be specified, but it isn't mandatory. The expected value
 
 The `--preset` option can be specified, but it isn't mandatory. The expected values are:
 
-- Html
-- Javascript
-- Typescript
 - Angular
 - Astro
+- Docusaurus
+- Eleventy
+- Emscripten
+- Gatsby
 - Hexo
-- Next 
+- Html
+- Hugo
+- Javascript
+- Jekyll
+- Next
 - React
+- Rustwasm
+- Svelte
+- Typescript
+- Vitepress
 - Vue
-- static
 
 #### remote 
 

--- a/src/content/docs/en/pages/devtools/cli/azion-cli/commands/link-project/link.mdx
+++ b/src/content/docs/en/pages/devtools/cli/azion-cli/commands/link-project/link.mdx
@@ -68,7 +68,7 @@ Choose a *preset*:
   Vue
 ```
 
-Now, the application will be linked to Azion. Different processes occur based on the selected template, so you need to answer the interactions that are presented.
+Now, the application will be linked to Azion. Different processes occur based on the selected preset, so you need to answer the interactions that are presented.
 
 Choose if you want to run the application locally or not:
 

--- a/src/content/docs/pt-br/pages/devtools/cli/azion-cli/comandos/link-project/link.mdx
+++ b/src/content/docs/pt-br/pages/devtools/cli/azion-cli/comandos/link-project/link.mdx
@@ -17,10 +17,10 @@ No caso de um ou mais campos obrigatórios não serem informados através das fl
 
 ## link
 
-O processo de vinculação adapta o projeto para sua vinculação a uma edge application.
+O processo de vinculação adapta o projeto para que seja vinculado à Azion e possa ser implantado como uma edge application. Ele cria as configurações necessárias para posterior construção e implantação da aplicação no edge.
 
 :::note 
-É necessário executar o comando dentro da pasta raíz do seu projeto.
+É necessário executar o comando dentro da pasta raiz do seu projeto.
 :::
 
 ### Uso
@@ -31,26 +31,43 @@ azion link
 
 ### Saída 
 
-Confirme se deseja vincular o projeto a uma edge application:
+Confirme se deseja vincular o projeto à Azion:
 
 ```sh 
 ? Do you want to link /cli-examples/effervescent_moon to Azion? (y/N) 
 ```
 
-Escolha o *preset* e o *mode*:
+Insira o nome desejado para sua edge application:
 
-```sh 
-? Choose a preset and mode:  [Use arrows to move, type to filter]
-> Html (Deliver)
-  Javascript (Compute)
-  Typescript (Compute)
-  Angular (Deliver)
-  Astro (Deliver)
-  Hexo (Deliver)
-  Next (Compute)
+```sh
+? (Hit enter to accept the suggested name in parenthesis) Your application's name:  (nimble-tyrion) 
 ```
 
-Diferentes processos serão executados dependendo do template escolhido. É necessário responder as interações do processo.
+Escolha o *preset*:
+
+```sh 
+? Choose a preset:  [Use arrows to move, type to filter]
+> Angular
+  Astro
+  Docusaurus
+  Eleventy
+  Emscripten
+  Gatsby
+  Hexo
+  Html
+  Hugo
+  Javascript
+  Jekyll
+  Next
+  React
+  Rustwasm
+  Svelte
+  Typescript
+  Vitepress
+  Vue
+```
+
+Agora a aplicação estará vinculada à Azion. Diferentes processos serão executados dependendo do preset escolhido. É necessário responder as interações do processo.
 
 Escolha se você deseja rodar o projeto localmente:
 
@@ -67,7 +84,11 @@ Se você desejar rodar o projeto localmente em outro momento, execute 'azion dev
 ```
 
 :::note 
-Se você desejar implantar o projeto localmente em outro momento, execute 'azion deploy'.
+Se você desejar implantar o projeto localmente em outro momento, execute 'azion deploy'. Sua aplicação não estará disponível no edge até que seja implantada.
+:::
+
+:::tip
+Opcionalmente, você pode executar `npm i azion` para instalar [Azion Lib](https://www.npmjs.com/package/azion). Essas bibliotecas fornecem ferramentas para interagir com os serviços Azion e habilitam configurações personalizadas para sua edge application. Verifique a [referência do arquivo azion.config.js](/pt-br/documentacao/devtools/cli/configs/azion-config-js/) para mais informações. 
 :::
 
 ### Flags opcionais
@@ -88,16 +109,24 @@ A opção `--mode` pode ser especificada, mas não é obrigatória. Os valores e
 
 A opção `--preset` pode ser especificada, mas não é obrigatória. Os valores esperados são:
 
-- Html
-- Javascript
-- Typescript
 - Angular
 - Astro
+- Docusaurus
+- Eleventy
+- Emscripten
+- Gatsby
 - Hexo
-- Next 
+- Html
+- Hugo
+- Javascript
+- Jekyll
+- Next
 - React
+- Rustwasm
+- Svelte
+- Typescript
+- Vitepress
 - Vue
-- static
 
 #### remote 
 

--- a/src/content/docs/pt-br/pages/devtools/cli/azion-cli/comandos/link-project/link.mdx
+++ b/src/content/docs/pt-br/pages/devtools/cli/azion-cli/comandos/link-project/link.mdx
@@ -136,12 +136,6 @@ A opção `--remote`, seguida por um link para um repositório git, especifica o
 
 A opção `--package-manager` permite que você especifique o gerenciador de pacotes a ser usado. Exemplo: `npm`, `yarn`, `pnpm`. Se não for informado, o gerenciador de pacotes será definido automaticamente com base em `package-lock.json` ou `yarn.lock`. Se nenhum dos arquivos for encontrado, então `npm` será o padrão.
 
-
 #### help
 
 A opção `--help` exibe mais informações sobre o comando `link`.
-
-
-
----
-


### PR DESCRIPTION

### Changes

Updates `link` command reference to better explain the purpose of the command, match the actual interactions with the CLI and improve user understanding and experience.