### PR TITLE
[no-issue] fix: adjust tcpInfoRtt metric description in Observe docs

### DIFF
--- a/src/content/docs/en/pages/devtools/api-graphql/features/events-fields.mdx
+++ b/src/content/docs/en/pages/devtools/api-graphql/features/events-fields.mdx
@@ -189,7 +189,7 @@ See each available field and their descriptions below.
 | sslProtocol | Protocol for an established TLS connection. Example: `TLS v1.2` |
 | sslSessionReused | Returns `r` if an SSL session was reused or `.` if it wasn't. |
 | status | HTTP status code of the request. Example: `200` |
-| tcpInfoRtt | Round-Trip Time (RTT) measured by the edge for the user. Available on systems that support the TCP_INFO socket option. Example: `72052` |
+| tcpInfoRtt | Round-Trip Time (RTT) in microseconds measured by the edge for the user. Available on systems that support the TCP_INFO socket option. Example: `72052` |
 | ts | Timestamp of when the event was created. Example: `2022-10-20T10:10:10` |
 | upstreamCacheStatus | Status of the local edge cache. Can be: `MISS`, `BYPASS`, `EXPIRED`, `STALE`, `UPDATING`, `REVALIDATED`, `HIT`, or `-` |
 | upstreamResponseTime | Time it takes for the edge to receive a default response from the origin, in seconds, including headers and body. This field is the result of a sum. Example: `0.876`. **In case of cache, the response is `-`** |
@@ -223,7 +223,7 @@ See each available field and their descriptions below.
 | serverProtocol | Version of the request protocol. Example: `HTTP/1.1`, `HTTP/2.0`, `HTTP/3.0` |
 | solution | Identifier of your edge application. Example: `1321` |
 | status | HTTP status code of the request. Example: `200` |
-| tcpinfoRtt | Round-Trip Time (RTT) measured by the edge for the user. Available on systems that support the TCP_INFO socket option. Example: `72052` |
+| tcpinfoRtt | Round-Trip Time (RTT) in microseconds measured by the edge for the user. Available on systems that support the TCP_INFO socket option. Example: `72052` |
 | ts | Timestamp of when the event was created. Example: `2022-10-20T10:10:10` |
 | upstreamBytesReceived | Number of bytes received by the origin’s edge if the content isn’t cached. Example: `8304` |
 | upstreamBytesReceivedStr | List with all `upstreamBytesReceived` responses. |

--- a/src/content/docs/en/pages/main-menu/reference/observe/data-stream/data-stream.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/observe/data-stream/data-stream.mdx
@@ -121,7 +121,7 @@ The **Edge Applications** data source provides the data from requests made to yo
 | $state | Client's state detected via IP address geolocation. Example: CA |
 | $status | HTTP status code of the request. Example: 200 |
 | $stream | ID set through virtual host configuration based on location directive. Set on virtual host configuration file. |
-| $tcpinfo_rtt | Round-Trip Time (RTT) measured by the edge for the user. Available on systems that support the TCP_INFO socket option. |
+| $tcpinfo_rtt | Round-Trip Time (RTT) in microseconds measured by the edge for the user. Available on systems that support the TCP_INFO socket option. Example: `72052` |
 | $time | Request date and time. Example: Oct. 31st, 2022 - 19:30:41 |
 | $traceback | Provides the names of the Rules Engine from your Edge Application and your Edge Firewall that are run by the request. |
 | $upstream_addr | Client IP address and port. Can also store multiple servers or server groups. Example: 192.168.1.1:80. When the response is `127.0.0.1:1666`, the upstream is Azion [Cells Runtime](/en/documentation/runtime/overview/). |

--- a/src/content/docs/en/pages/main-menu/reference/observe/real-time-events/real-time-events.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/observe/real-time-events/real-time-events.mdx
@@ -183,7 +183,7 @@ Displays the event records of requests made to edge applications using [Image Pr
 | SSL Protocol | Protocol for an established TLS connection. Example: `TLS v1.2` |
 | SSL Session Reused | Returns `r` if an SSL session was reused or `.` if it wasn't. |
 | Status | HTTP status code of the request. Example: `200` |
-| TCP Info RTT | Round-Trip Time (RTT) measured by the edge for the user. Available on systems that support the TCP_INFO socket option. Example: `72052` |
+| TCP Info RTT | Round-Trip Time (RTT) in microseconds measured by the edge for the user. Available on systems that support the TCP_INFO socket option. Example: `72052` |
 | Upstream Cache Status | Status of the local edge cache. Can be: `MISS`, `BYPASS`, `EXPIRED`, `STALE`, `UPDATING`, `REVALIDATED`, `HIT`, or `-` |
 | Upstream Response Time | Time it takes for the edge to receive a default response from the origin in seconds, including headers and body. This field is the result of a sum. Example: `0.876`. **In case of cache, the response is `-`** |
 | Upstream Status | HTTP status code of the origin. If a server can't be selected, the variable keeps the 502 (Bad Gateway) status code. Example: `200`. **In case of cache, the response is `-`.** |

--- a/src/content/docs/pt-br/pages/devtools/api-graphql/recursos/events-campos.mdx
+++ b/src/content/docs/pt-br/pages/devtools/api-graphql/recursos/events-campos.mdx
@@ -193,7 +193,7 @@ Veja cada campo disponível e suas descrições abaixo.
 | sslProtocol | Protocolo de uma conexão TLS estabelecida. Exemplo: `TLS v1.2` |
 | sslSessionReused | Retorna `r` se uma sessão SSL foi reutilizada ou`.` se não foi. |
 | status | Código de status HTTP da requisição. Exemplo: `200` |
-| tcpinfoRtt | Round-Trip Time (RTT), em milissegundos, medido pelo edge para o usuário. Disponível em sistemas que suportam a opção de socket TCP_INFO. Exemplo: `72052` |
+| tcpinfoRtt | Tempo de ida e volta (RTT), em microsegundos, medido pelo edge para o usuário. Disponível em sistemas que suportam a opção de socket TCP_INFO. Exemplo: `72052` |
 | ts | Data e hora de quando o evento foi criado. Exemplo: `2022-10-20T10:10:10` |
 | upstreamCacheStatus | Status do cache local do edge. Pode ser: `MISS`, `BYPASS`, `EXPIRED`, `STALE`, `UPDATING`, `REVALIDATED`, `HIT` ou `-` |
 | upstreamResponseTime | Tempo para o edge receber uma resposta padrão da origem, em segundos, incluindo cabeçalhos e corpo. Exemplo: `0.876`. **No caso de cache, a resposta é `-`** |
@@ -228,7 +228,7 @@ Veja cada campo disponível e suas descrições abaixo.
 | solution | Identificação da edge application. Exemplo: `1321` |
 | source | Servidor que gerou a linha do log. Exemplo: `edg-fln-ggn001p` |
 | status | Código de status HTTP da requisição. Exemplo: `200` |
-| tcpinfoRtt | Round-Trip Time (RTT), em milissegundos, medido pelo edge para o usuário. Disponível em sistemas que suportam a opção de socket TCP_INFO. Exemplo: `72052` |
+| tcpinfoRtt | Tempo de ida e volta (RTT), em microsegundos, medido pelo edge para o usuário. Disponível em sistemas que suportam a opção de socket TCP_INFO. Exemplo: `72052` |
 | ts | Data e hora de quando o evento foi criado. Exemplo: `2022-10-20T10:10:10` |
 | upstreamBytesReceived | Número de bytes recebidos pelo edge da origem, se o conteúdo não estiver em cache. Exemplo: `8304` |
 | upstreamBytesReceivedStr | Lista com todas as respostas `upstreamBytesReceived`. |
@@ -319,7 +319,7 @@ Os seguintes conjuntos de dados foram descontinuados. Recomenda-se utilizar os [
 | solution | Identificação da edge application. Exemplo: `1321` |
 | source | Servidor que gerou a linha do log. Exemplo: `edg-fln-ggn001p` |
 | status | Código de status HTTP da requisição. Exemplo: `200` |
-| tcpinfoRtt | Round-Trip Time (RTT), em milissegundos, medido pelo edge para o usuário. Disponível em sistemas que suportam a opção de socket TCP_INFO. Exemplo: `72052` |
+| tcpinfoRtt | Tempo de ida e volta (RTT), em microsegundos, medido pelo edge para o usuário. Disponível em sistemas que suportam a opção de socket TCP_INFO. Exemplo: `72052` |
 | ts | Data e hora de quando o evento foi criado. Exemplo: `2022-10-20T10:10:10` |
 | upstreamBytesReceived | Número de bytes recebidos pelo edge da origem, se o conteúdo não estiver em cache. Exemplo: `8304` |
 | upstreamBytesReceivedStr | Lista com todas as respostas `upstreamBytesReceived`. |

--- a/src/content/docs/pt-br/pages/menu-principal/referencia/observe/data-streaming/data-streaming.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/referencia/observe/data-streaming/data-streaming.mdx
@@ -122,7 +122,7 @@ O data source **Edge Applications** exibe os dados das requisições feitas para
 | $state | Estado do cliente detectado pela geolocalização de endereço IP. Exemplo: CA |
 | $status | Código de status HTTP da requisição. Exemplo: 200 |
 | $stream | ID definida através de configuração de host virtual com base na diretiva de localização. Definido no arquivo de configuração do host virtual. |
-| $tcpinfo_rtt | Tempo de Round-Trip Time (RTT) medido pelo edge para o usuário. Disponível em sistemas que suportam a opção TCP_INFO socket. |
+| $tcpinfo_rtt | Tempo de ida e volta (RTT), em microsegundos, medido pelo edge para o usuário. Disponível em sistemas que suportam a opção de socket TCP_INFO. Exemplo: `72052` |
 | $time | Data e hora da requisição. Exemplo: Oct. 31st, 2022 - 19:30:41 |
 | $traceback | Informa os nomes dos Rules Engine do Edge Application e do Edge Firewall executadas pela requisição. |
 | $upstream_addr | Endereço IP e porta do cliente. Também pode armazenar múltiplos servidores ou grupos de servidores. Exemplo: 192.168.1.1:80. Quando a resposta é `127.0.0.1:1666`, o upstream é o Azion [Cells Runtime](/pt-br/documentacao/runtime/visao-geral/). |

--- a/src/content/docs/pt-br/pages/menu-principal/referencia/observe/real-time-events/real-time-events.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/referencia/observe/real-time-events/real-time-events.mdx
@@ -185,7 +185,7 @@ Exibe os registros de eventos de requisições feitas às edge applications que 
 | SSL Protocol | Protocolo de uma conexão TLS estabelecida. Exemplo: `TLS v1.2` |
 | SSL Session Reused | Retorna `r` se uma sessão SSL foi reutilizada ou`.` se não foi |
 | Status | Código de status HTTP da requisição. Exemplo: `200` |
-| TCP Info RTT | Round-Trip Time (RTT), em milissegundos, medido pelo edge para o usuário. Disponível em sistemas que suportam a opção de socket TCP_INFO. Exemplo: `72052` |
+| TCP Info RTT | Tempo de ida e volta (RTT), em microsegundos, medido pelo edge para o usuário. Disponível em sistemas que suportam a opção de socket TCP_INFO. Exemplo: `72052 |
 | Upstream Cache Status | Status do cache local do edge. Pode ser: `MISS`, `BYPASS`, `EXPIRED`, `STALE`, `UPDATING`, `REVALIDATED`, `HIT` ou `-` |
 | Upstream Response Time | Tempo, em segundos, para o edge receber uma resposta padrão da origem, incluindo cabeçalhos e corpo. Este campo é o resultado de uma soma. Exemplo: `0.876`. **Em caso de cache, a resposta é `-`** |
 | Upstream Status | Código de status HTTP da origem. Se um servidor não puder ser selecionado, a variável mantém o código de status 502 (Bad Gateway). Exemplo: `200` **Em caso de cache, a resposta é `-`.** |
@@ -219,7 +219,7 @@ Exibe os registros de eventos de requisições feitas às edge applications que 
 | Server Protocol | Protocolo da requisição. Exemplo: `HTTP/1.1`, `HTTP/2.0`, `HTTP/3.0` |
 | Solution | Identificação da edge application. Exemplo: `1321` |
 | Status | Código de status HTTP da requisição. Exemplo: `200` |
-| TCP Info RTT | Round-Trip Time (RTT), em milissegundos, medido pelo edge para o usuário. Disponível em sistemas que suportam a opção de socket TCP_INFO. Exemplo: `72052` |
+| TCP Info RTT | Tempo de ida e volta (RTT), em microsegundos, medido pelo edge para o usuário. Disponível em sistemas que suportam a opção de socket TCP_INFO. Exemplo: `72052 |
 | Upstream Addr | Endereço IP e porta do cliente. Também pode armazenar múltiplos servidores ou grupos de servidores. Exemplo: `192.168.1.1:80`. Quando a resposta é `127.0.0.1:1666`, o upstream é o [Azion Cells Runtime](/pt-br/documentacao/runtime/visao-geral/) |
 | Upstream Bytes Received | Número de bytes recebidos pelo edge da origem, se o conteúdo não estiver em cache. Exemplo: `8304` |
 | Upstream Cache Status | Status do cache local do edge. Pode ser: `MISS`, `BYPASS`, `EXPIRED`, `STALE`, `UPDATING`, `REVALIDATED`, `HIT` ou `-` |


### PR DESCRIPTION
### Related issue: 

[no-issue]

### Changes

adjust tcpInfoRtt metric description in Observe docs

### Additional links

n/a.