### PR TITLE
[no-issue] - Remove Vite entry from frameworks compatibility

### DIFF
--- a/src/content/docs/en/pages/devtools/azion-edge-runtime/compatibility/frameworks.mdx
+++ b/src/content/docs/en/pages/devtools/azion-edge-runtime/compatibility/frameworks.mdx
@@ -221,7 +221,7 @@ Learn more about [VitePress](https://vitepress.dev/guide/what-is-vitepress).
 
 Implementation:
 
-- [Azion CLI how to build with Vite](/en/documentation/products/cli/frameworks/vite/)
+- [How to build with VitePress using Azion CLI](/en/documentation/products/cli/frameworks/vite/)
 - [Azion Console VitePress with JavaScript Boilerplate](/en/documentation/products/guides/vitepress-javascript-boilerplate/)
 - [Azion Console VitePress with TypeScript Boilerplate](/en/documentation/products/guides/vitepress-typescript-boilerplate/)
 

--- a/src/content/docs/en/pages/devtools/azion-edge-runtime/compatibility/frameworks.mdx
+++ b/src/content/docs/en/pages/devtools/azion-edge-runtime/compatibility/frameworks.mdx
@@ -211,25 +211,6 @@ The compute mode isn't implemented for Jekyll yet.
 
 ---
 
-## Vite
-<Tag severity="info" client:only="vue" value="Static" />
-
-Vite is listed on the [Jamstack documentation](https://jamstack.org/generators/vite/) as a static site generator, aligned to the Jamstack approach.
-
-Learn more about [Vite](https://vitejs.dev/).
-
-Implementation:
-
-- [Azion CLI how to build with Vite](/en/documentation/products/cli/frameworks/vite/)
-
-<Tag severity="info" client:only="vue" value="Compute" />
-
- :::note 
- The compute mode isn't implemented for Vite yet.
- :::
-
----
-
 ## VitePress
 
 <Tag severity="info" client:only="vue" value="Static" />
@@ -240,6 +221,7 @@ Learn more about [VitePress](https://vitepress.dev/guide/what-is-vitepress).
 
 Implementation:
 
+- [Azion CLI how to build with Vite](/en/documentation/products/cli/frameworks/vite/)
 - [Azion Console VitePress with JavaScript Boilerplate](/en/documentation/products/guides/vitepress-javascript-boilerplate/)
 - [Azion Console VitePress with TypeScript Boilerplate](/en/documentation/products/guides/vitepress-typescript-boilerplate/)
 

--- a/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/compatibilidade/frameworks.mdx
+++ b/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/compatibilidade/frameworks.mdx
@@ -212,25 +212,6 @@ O modo `compute` ainda não é suportado para Jekyll.
 
 ---
 
-## Vite
-<Tag severity="info" client:only="vue" value="Estático" />
-
-O Vite está listado na [documentação Jamstack](https://jamstack.org/generators/vite/) como um gerador de sites estáticos alinhado à abordagem Jamstack.
-
-Saiba mais sobre [Vite](https://vitejs.dev/).
-
-Implementação:
-
-- [Como construir com Vite usando a Azion CLI](/pt-br/documentacao/produtos/cli/frameworks/vite/)
-
-<Tag severity="info" client:only="vue" value="Compute" />
-
- :::note 
- O modo `compute` ainda não é suportado para Vite.
- :::
-
----
-
 ## VitePress
 
 <Tag severity="info" client:only="vue" value="Estático" />
@@ -241,6 +222,7 @@ Saiba mais sobre [VitePress](https://vitepress.dev/guide/what-is-vitepress).
 
 Implementação:
 
+- [Como construir com Vite usando a Azion CLI](/pt-br/documentacao/produtos/cli/frameworks/vite/)
 - [VitePress JavaScript Boilerplate no Azion Console](/pt-br/documentacao/produtos/guias/vitepress-javascript-boilerplate/)
 - [VitePress TypeScript Boilerplate no Azion Console](/pt-br/documentacao/produtos/guias/vitepress-typescript-boilerplate/)
 

--- a/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/compatibilidade/frameworks.mdx
+++ b/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/compatibilidade/frameworks.mdx
@@ -222,7 +222,7 @@ Saiba mais sobre [VitePress](https://vitepress.dev/guide/what-is-vitepress).
 
 Implementação:
 
-- [Como construir com Vite usando a Azion CLI](/pt-br/documentacao/produtos/cli/frameworks/vite/)
+- [Como construir com VitePress usando a Azion CLI](/pt-br/documentacao/produtos/cli/frameworks/vite/)
 - [VitePress JavaScript Boilerplate no Azion Console](/pt-br/documentacao/produtos/guias/vitepress-javascript-boilerplate/)
 - [VitePress TypeScript Boilerplate no Azion Console](/pt-br/documentacao/produtos/guias/vitepress-typescript-boilerplate/)
 


### PR DESCRIPTION

### Changes
Removes the Vite entry from the Frameworks Compatibility page, as we cover Vite in VitePress and Vue/Vite templates and not on its own.
