### PR TITLE
[EDU-5621] Update Node Compatibility reference

### DIFF
--- a/src/content/docs/en/pages/devtools/azion-edge-runtime/compatibility/cells-node.mdx
+++ b/src/content/docs/en/pages/devtools/azion-edge-runtime/compatibility/cells-node.mdx
@@ -24,9 +24,9 @@ import { API } from "import-origin";
 | API | Support Level | Code sample  | Comments |
 |---------|---------------|----------|-------------|
 | async_hooks | 🟡 Partially supported | [Access code sample](https://github.com/aziontech/azion-samples/tree/dev/samples/node-async-hooks) | Only [AsyncLocalStorage](https://nodejs.org/api/async_context.html#class-asynclocalstorage) and [AsyncResource](https://nodejs.org/api/async_hooks.html#class-asyncresource) are implemented |
+| fs | 🟡 Partially supported| | Only async methods ([check the list below](#fs-support)), others through [polyfills](#node-polyfills) |
 | module | 🟡 Partially supported | | Also supported in local dev through polyfills ([check table below](#node-polyfills)) |
 | process.env | 🟢 Supported | `process.env.VAR_NAME`| Other features supported through polyfills ([check table below](#node-polyfills)) |
-| fs | 🟡 Partially supported| | Only async methods ([check the list below](#fs-support)), others through [polyfills](#node-polyfills) |
 | url | 🟡 Partially supported | | Only global `URL` and `URLSearchParams` |
 
 ### FS support 

--- a/src/content/docs/en/pages/devtools/azion-edge-runtime/compatibility/cells-node.mdx
+++ b/src/content/docs/en/pages/devtools/azion-edge-runtime/compatibility/cells-node.mdx
@@ -24,8 +24,10 @@ import { API } from "import-origin";
 | API | Support Level | Code sample  | Comments |
 |---------|---------------|----------|-------------|
 | async_hooks | 🟡 Partially supported | [Access code sample](https://github.com/aziontech/azion-samples/tree/dev/samples/node-async-hooks) | Only [AsyncLocalStorage](https://nodejs.org/api/async_context.html#class-asynclocalstorage) and [AsyncResource](https://nodejs.org/api/async_hooks.html#class-asyncresource) are implemented |
+| module | 🟡 Partially supported | | Also supported in local dev through polyfills ([check table below](#node-polyfills)) |
 | process.env | 🟢 Supported | `process.env.VAR_NAME`| Other features supported through polyfills ([check table below](#node-polyfills)) |
 | fs | 🟡 Partially supported| | Only async methods ([check the list below](#fs-support)), others through [polyfills](#node-polyfills) |
+| url | 🟡 Partially supported | | Only global `URL` and `URLSearchParams` |
 
 ### FS support 
 
@@ -58,41 +60,21 @@ Here's a list of Node APIs supported through polyfills:
 | API | Support Level | Code sample |
 |---------|---------------|-------------|
 | buffer | 🟡 Partially supported | [Access code sample](https://github.com/aziontech/azion-samples/tree/dev/samples/polyfills/buffer) |
+| crypto | 🟡 Partially supported | [Access code sample](https://github.com/aziontech/bundler-examples/blob/main/examples/runtime-apis/nodejs/crypto/main.js) |
+| events | 🟡 Partially supported | [Access code sample](https://github.com/aziontech/bundler-examples/blob/main/examples/runtime-apis/nodejs/events/main.js) |
 | fs | 🟡 Partially supported | [Access code sample](https://github.com/aziontech/azion-samples/tree/dev/samples/polyfills/fs) | 
-| crypto | 🟡 Partially supported | - | 
-| http2 | 🟡 Partially supported | - | 
-| module | 🟡 Partially supported | - | 
-| navigator | 🟡 Partially supported | - | 
-| path_dirname | 🟡 Partially supported | - | 
-| performance | 🟡 Partially supported | - | 
-| process | 🟡 Partially supported | - |
-| accepts | 🟡 Partially supported | - |
-| child_process | 🟡 Partially supported | - |
-| cluster | 🟡 Partially supported | - |
-| console | 🟡 Partially supported | - |
-| dgram | 🟡 Partially supported | - |
-| events | 🟡 Partially supported | - |
-| http | 🟡 Partially supported | - |
-| inspector | 🟡 Partially supported | - |
-| os | 🟡 Partially supported | - |
-| path | 🟡 Partially supported | - |
-| perf_hooks | 🟡 Partially supported | - |
-| querystring | 🟡 Partially supported | - |
-| readline | 🟡 Partially supported | - |
-| repl | 🟡 Partially supported | - |
-| stream | 🟡 Partially supported | - |
-| _stream_passthrough | 🟡 Partially supported | - |
-| _stream_readable | 🟡 Partially supported | - |
-| _stream_transform | 🟡 Partially supported | - |
-| _stream_writable | 🟡 Partially supported | - |
-| string_decoder | 🟡 Partially supported | - |
-| sys | 🟡 Partially supported | - |
-| timers | 🟡 Partially supported | - |
-| tty | 🟡 Partially supported | - |
-| url | 🟡 Partially supported | - |
-| util | 🟡 Partially supported | - |
-| vm | 🟡 Partially supported | - |
-| zlib | 🟡 Partially supported | - |
+| http | 🟡 Partially supported | [Access code sample](https://github.com/aziontech/bundler-examples/blob/main/examples/runtime-apis/nodejs/http/main.js) |
+| module | 🟡 Partially supported | [Access code sample](https://github.com/aziontech/bundler-examples/blob/main/examples/runtime-apis/nodejs/module/main.js) | 
+| os | 🟡 Partially supported | [Access code sample](https://github.com/aziontech/bundler-examples/blob/main/examples/runtime-apis/nodejs/os/main.js) |
+| path | 🟡 Partially supported | [Access code sample](https://github.com/aziontech/bundler-examples/blob/main/examples/runtime-apis/nodejs/path/main.js) |
+| process | 🟡 Partially supported | [Access code sample](https://github.com/aziontech/bundler-examples/blob/main/examples/runtime-apis/nodejs/process/main.js) |
+| stream | 🟡 Partially supported | [Access code sample](https://github.com/aziontech/bundler-examples/blob/main/examples/runtime-apis/nodejs/stream/main.js) |
+| string_decoder | 🟡 Partially supported | [Access code sample](https://github.com/aziontech/bundler-examples/blob/main/examples/runtime-apis/nodejs/string-decoder/main.js) |
+| timers | 🟡 Partially supported | [Access code sample](https://github.com/aziontech/bundler-examples/blob/main/examples/runtime-apis/nodejs/timers/main.js) |
+| url | 🟡 Partially supported | [Access code sample](https://github.com/aziontech/bundler-examples/blob/main/examples/runtime-apis/nodejs/url/main.js) |
+| util | 🟡 Partially supported | [Access code sample](https://github.com/aziontech/bundler-examples/blob/main/examples/runtime-apis/nodejs/util/main.js) |
+| vm | 🟡 Partially supported | [Access code sample](https://github.com/aziontech/bundler-examples/blob/main/examples/runtime-apis/nodejs/vm/main.js) |
+| zlib | 🟡 Partially supported | [Access code sample](https://github.com/aziontech/bundler-examples/blob/main/examples/runtime-apis/nodejs/zlib/main.js) |
 
 :::note 
 You can check the list of APIs resolved through polyfills in [Azion Bundler's repository](https://github.com/aziontech/bundler/blob/main/lib/build/bundlers/polyfills/polyfills-manager.js), as well as contribute with the project.

--- a/src/content/docs/en/pages/devtools/azion-edge-runtime/compatibility/cells-node.mdx
+++ b/src/content/docs/en/pages/devtools/azion-edge-runtime/compatibility/cells-node.mdx
@@ -24,8 +24,8 @@ import { API } from "import-origin";
 | API | Support Level | Code sample  | Comments |
 |---------|---------------|----------|-------------|
 | async_hooks | 🟡 Partially supported | [Access code sample](https://github.com/aziontech/azion-samples/tree/dev/samples/node-async-hooks) | Only [AsyncLocalStorage](https://nodejs.org/api/async_context.html#class-asynclocalstorage) and [AsyncResource](https://nodejs.org/api/async_hooks.html#class-asyncresource) are implemented |
-| process.env | 🟢 Supported | `process.env.VAR_NAME`| |
-| fs | 🟡 Partially supported| | [Check the list below](#fs-support) |
+| process.env | 🟢 Supported | `process.env.VAR_NAME`| Other features supported through polyfills ([check table below](#node-polyfills)) |
+| fs | 🟡 Partially supported| | Only async methods ([check the list below](#fs-support)), others through [polyfills](#node-polyfills) |
 
 ### FS support 
 
@@ -60,7 +60,6 @@ Here's a list of Node APIs supported through polyfills:
 | buffer | 🟡 Partially supported | [Access code sample](https://github.com/aziontech/azion-samples/tree/dev/samples/polyfills/buffer) |
 | fs | 🟡 Partially supported | [Access code sample](https://github.com/aziontech/azion-samples/tree/dev/samples/polyfills/fs) | 
 | crypto | 🟡 Partially supported | - | 
-| dns | 🟡 Partially supported | - | 
 | http2 | 🟡 Partially supported | - | 
 | module | 🟡 Partially supported | - | 
 | navigator | 🟡 Partially supported | - | 
@@ -74,9 +73,7 @@ Here's a list of Node APIs supported through polyfills:
 | dgram | 🟡 Partially supported | - |
 | events | 🟡 Partially supported | - |
 | http | 🟡 Partially supported | - |
-| https | 🟡 Partially supported | - |
 | inspector | 🟡 Partially supported | - |
-| net | 🟡 Partially supported | - |
 | os | 🟡 Partially supported | - |
 | path | 🟡 Partially supported | - |
 | perf_hooks | 🟡 Partially supported | - |
@@ -91,7 +88,6 @@ Here's a list of Node APIs supported through polyfills:
 | string_decoder | 🟡 Partially supported | - |
 | sys | 🟡 Partially supported | - |
 | timers | 🟡 Partially supported | - |
-| tls | 🟡 Partially supported | - |
 | tty | 🟡 Partially supported | - |
 | url | 🟡 Partially supported | - |
 | util | 🟡 Partially supported | - |

--- a/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/compatibilidade/node.mdx
+++ b/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/compatibilidade/node.mdx
@@ -26,8 +26,10 @@ import { API } from "import-origin";
 | API | Nível de suporte | Exemplo de código | Comentários |
 |---------|---------------|----------|-------------|
 | async_hooks | 🟡 Parcialmente suportada  | [Acessar o exemplo de código](https://github.com/aziontech/azion-samples/tree/dev/samples/node-async-hooks) | Apenas [AsyncLocalStorage](https://nodejs.org/api/async_context.html#class-asynclocalstorage) e [AsyncResource](https://nodejs.org/api/async_hooks.html#class-asyncresource) estão implementadas. |
-| process.env | 🟢 Suportada | `process.env.NOME_VAR`| |
-| fs | 🟡 Parcialmente suportado | | [Verifique a lista abaixo](#suporte-fs) |
+| module | 🟡 Parcialmente suportado | | |
+| process.env | 🟢 Suportada | `process.env.VAR_NAME`| Outros recursos suportados através de polyfills ([confira a tabela abaixo](#node-polyfills)) |
+| fs | 🟡 Parcialmente suportado | | Apenas métodos assíncronos ([confira a lista abaixo](#fs-support)), outros através de [polyfills](#node-polyfills) |
+| url | 🟡 Parcialmente suportado | | Apenas os globais `URL` e `URLSearchParams` |
 
 ### Suporte de FS 
 
@@ -60,45 +62,22 @@ Aqui está a lista de APIs do Node suportadas através de polyfills:
 | API | Nível de suporte | Exemplo de código |
 |---------|---------------|----------|
 | buffer | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/azion-samples/tree/dev/samples/polyfills/buffer) |
+| crypto | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/bundler-examples/blob/main/examples/runtime-apis/nodejs/crypto/main.js) |
+| events | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/bundler-examples/tree/main/examples/runtime-apis/nodejs/events) |
 | fs | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/azion-samples/tree/dev/samples/polyfills/fs) |
-| crypto | 🟡 Parcialmente suportada | - |
-| dns | 🟡 Parcialmente suportada | - |
-| http2 | 🟡 Parcialmente suportada | - |
-| module | 🟡 Parcialmente suportada | - |
-| navigator | 🟡 Parcialmente suportada | - |
-| path_dirname | 🟡 Parcialmente suportada | - |
-| performance | 🟡 Parcialmente suportada | - |
-| process | 🟡 Parcialmente suportada | - |
-| accepts | 🟡 Parcialmente suportada | - |
-| child_process | 🟡 Parcialmente suportada | - |
-| cluster | 🟡 Parcialmente suportada | - |
-| console | 🟡 Parcialmente suportada | - |
-| dgram | 🟡 Parcialmente suportada | - |
-| events | 🟡 Parcialmente suportada | - |
-| http | 🟡 Parcialmente suportada | - |
-| https | 🟡 Parcialmente suportada | - |
-| inspector | 🟡 Parcialmente suportada | - |
-| net | 🟡 Parcialmente suportada | - |
-| os | 🟡 Parcialmente suportada | - |
-| path | 🟡 Parcialmente suportada | - |
-| perf_hooks | 🟡 Parcialmente suportada | - |
-| querystring | 🟡 Parcialmente suportada | - |
-| readline | 🟡 Parcialmente suportada | - |
-| repl | 🟡 Parcialmente suportada | - |
-| stream | 🟡 Parcialmente suportada | - |
-| _stream_passthrough | 🟡 Parcialmente suportada | - |
-| _stream_readable | 🟡 Parcialmente suportada | - |
-| _stream_transform | 🟡 Parcialmente suportada | - |
-| _stream_writable | 🟡 Parcialmente suportada | - |
-| string_decoder | 🟡 Parcialmente suportada | - |
-| sys | 🟡 Parcialmente suportada | - |
-| timers | 🟡 Parcialmente suportada | - |
-| tls | 🟡 Parcialmente suportada | - |
-| tty | 🟡 Parcialmente suportada | - |
-| url | 🟡 Parcialmente suportada | - |
-| util | 🟡 Parcialmente suportada | - |
-| vm | 🟡 Parcialmente suportada | - |
-| zlib | 🟡 Parcialmente suportada | - |
+| http | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/bundler-examples/tree/main/examples/runtime-apis/nodejs/http) |
+| module | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/bundler-examples/tree/main/examples/runtime-apis/nodejs/module)  |
+| os | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/bundler-examples/tree/main/examples/runtime-apis/nodejs/os)  |
+| path | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/bundler-examples/tree/main/examples/runtime-apis/nodejs/path)  |
+| process | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/bundler-examples/tree/main/examples/runtime-apis/nodejs/process)  |
+| stream | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/bundler-examples/tree/main/examples/runtime-apis/nodejs/stream)  |
+| string_decoder | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/bundler-examples/tree/main/examples/runtime-apis/nodejs/stream_decoder)  |
+| sys | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/bundler-examples/tree/main/examples/runtime-apis/nodejs/sys)  |
+| timers | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/bundler-examples/tree/main/examples/runtime-apis/nodejs/timers)  |
+| url | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/bundler-examples/tree/main/examples/runtime-apis/nodejs/url)  |
+| util | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/bundler-examples/tree/main/examples/runtime-apis/nodejs/util)  |
+| vm | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/bundler-examples/tree/main/examples/runtime-apis/nodejs/vm)  |
+| zlib | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/bundler-examples/tree/main/examples/runtime-apis/nodejs/zlib)  |
 
 :::note 
 Você pode verificar a lista de APIs resolvidas através de polyfills no [repositório do Azion Bundler](https://github.com/aziontech/bundler/blob/main/lib/build/bundlers/polyfills/polyfills-manager.js) e contribuir com o projeto.

--- a/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/compatibilidade/node.mdx
+++ b/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/compatibilidade/node.mdx
@@ -26,9 +26,9 @@ import { API } from "import-origin";
 | API | Nível de suporte | Exemplo de código | Comentários |
 |---------|---------------|----------|-------------|
 | async_hooks | 🟡 Parcialmente suportada  | [Acessar o exemplo de código](https://github.com/aziontech/azion-samples/tree/dev/samples/node-async-hooks) | Apenas [AsyncLocalStorage](https://nodejs.org/api/async_context.html#class-asynclocalstorage) e [AsyncResource](https://nodejs.org/api/async_hooks.html#class-asyncresource) estão implementadas. |
+| fs | 🟡 Parcialmente suportada | | Apenas métodos assíncronos ([confira a lista abaixo](#fs-support)), outros através de [polyfills](#node-polyfills) |
 | module | 🟡 Parcialmente suportada | | |
 | process.env | 🟢 Suportada | `process.env.VAR_NAME`| Outros recursos suportados através de polyfills ([confira a tabela abaixo](#node-polyfills)) |
-| fs | 🟡 Parcialmente suportada | | Apenas métodos assíncronos ([confira a lista abaixo](#fs-support)), outros através de [polyfills](#node-polyfills) |
 | url | 🟡 Parcialmente suportada | | Apenas os globais `URL` e `URLSearchParams` |
 
 ### Suporte de FS 

--- a/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/compatibilidade/node.mdx
+++ b/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/compatibilidade/node.mdx
@@ -26,10 +26,10 @@ import { API } from "import-origin";
 | API | Nível de suporte | Exemplo de código | Comentários |
 |---------|---------------|----------|-------------|
 | async_hooks | 🟡 Parcialmente suportada  | [Acessar o exemplo de código](https://github.com/aziontech/azion-samples/tree/dev/samples/node-async-hooks) | Apenas [AsyncLocalStorage](https://nodejs.org/api/async_context.html#class-asynclocalstorage) e [AsyncResource](https://nodejs.org/api/async_hooks.html#class-asyncresource) estão implementadas. |
-| module | 🟡 Parcialmente suportado | | |
+| module | 🟡 Parcialmente suportada | | |
 | process.env | 🟢 Suportada | `process.env.VAR_NAME`| Outros recursos suportados através de polyfills ([confira a tabela abaixo](#node-polyfills)) |
-| fs | 🟡 Parcialmente suportado | | Apenas métodos assíncronos ([confira a lista abaixo](#fs-support)), outros através de [polyfills](#node-polyfills) |
-| url | 🟡 Parcialmente suportado | | Apenas os globais `URL` e `URLSearchParams` |
+| fs | 🟡 Parcialmente suportada | | Apenas métodos assíncronos ([confira a lista abaixo](#fs-support)), outros através de [polyfills](#node-polyfills) |
+| url | 🟡 Parcialmente suportada | | Apenas os globais `URL` e `URLSearchParams` |
 
 ### Suporte de FS 
 
@@ -63,21 +63,20 @@ Aqui está a lista de APIs do Node suportadas através de polyfills:
 |---------|---------------|----------|
 | buffer | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/azion-samples/tree/dev/samples/polyfills/buffer) |
 | crypto | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/bundler-examples/blob/main/examples/runtime-apis/nodejs/crypto/main.js) |
-| events | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/bundler-examples/tree/main/examples/runtime-apis/nodejs/events) |
-| fs | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/azion-samples/tree/dev/samples/polyfills/fs) |
-| http | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/bundler-examples/tree/main/examples/runtime-apis/nodejs/http) |
-| module | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/bundler-examples/tree/main/examples/runtime-apis/nodejs/module)  |
-| os | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/bundler-examples/tree/main/examples/runtime-apis/nodejs/os)  |
-| path | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/bundler-examples/tree/main/examples/runtime-apis/nodejs/path)  |
-| process | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/bundler-examples/tree/main/examples/runtime-apis/nodejs/process)  |
-| stream | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/bundler-examples/tree/main/examples/runtime-apis/nodejs/stream)  |
-| string_decoder | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/bundler-examples/tree/main/examples/runtime-apis/nodejs/stream_decoder)  |
-| sys | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/bundler-examples/tree/main/examples/runtime-apis/nodejs/sys)  |
-| timers | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/bundler-examples/tree/main/examples/runtime-apis/nodejs/timers)  |
-| url | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/bundler-examples/tree/main/examples/runtime-apis/nodejs/url)  |
-| util | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/bundler-examples/tree/main/examples/runtime-apis/nodejs/util)  |
-| vm | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/bundler-examples/tree/main/examples/runtime-apis/nodejs/vm)  |
-| zlib | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/bundler-examples/tree/main/examples/runtime-apis/nodejs/zlib)  |
+| events | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/bundler-examples/tree/main/examples/runtime-apis/nodejs/events/main.js) |
+| fs | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/azion-samples/tree/dev/samples/polyfills/fs/main.js) |
+| http | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/bundler-examples/tree/main/examples/runtime-apis/nodejs/http/main.js) |
+| module | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/bundler-examples/tree/main/examples/runtime-apis/nodejs/module/main.js) |
+| os | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/bundler-examples/tree/main/examples/runtime-apis/nodejs/os/main.js) |
+| path | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/bundler-examples/tree/main/examples/runtime-apis/nodejs/path/main.js) |
+| process | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/bundler-examples/tree/main/examples/runtime-apis/nodejs/process/main.js) |
+| stream | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/bundler-examples/tree/main/examples/runtime-apis/nodejs/stream/main.js) |
+| string_decoder | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/bundler-examples/tree/main/examples/runtime-apis/nodejs/string-decoder/main.js) |
+| timers | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/bundler-examples/tree/main/examples/runtime-apis/nodejs/timers/main.js) |
+| url | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/bundler-examples/tree/main/examples/runtime-apis/nodejs/url/main.js) |
+| util | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/bundler-examples/tree/main/examples/runtime-apis/nodejs/util/main.js) |
+| vm | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/bundler-examples/tree/main/examples/runtime-apis/nodejs/vm/main.js) |
+| zlib | 🟡 Parcialmente suportada | [Acessar exemplo de código](https://github.com/aziontech/bundler-examples/tree/main/examples/runtime-apis/nodejs/zlib/main.js) |
 
 :::note 
 Você pode verificar a lista de APIs resolvidas através de polyfills no [repositório do Azion Bundler](https://github.com/aziontech/bundler/blob/main/lib/build/bundlers/polyfills/polyfills-manager.js) e contribuir com o projeto.


### PR DESCRIPTION
### Changes

Updates the page on Node.js APIs compatibility in accordance with the actual support through Cells and Bundler.
Adds code samples for the polyfills.