### PR TITLE
[EDU-6085] fix: broken links in Docs

### DIFF
--- a/src/content/docs/en/pages/guides/graphql/query-bot-manager-data.mdx
+++ b/src/content/docs/en/pages/guides/graphql/query-bot-manager-data.mdx
@@ -23,7 +23,7 @@ To retrieve this data, you must be subscribed to Azion Bot Manager and use the [
 
 To query your data, proceed as follows:
 
-1. Access the [GraphiQL playground](https://manager.azion.com/metrics/graphql).
+1. Access the GraphiQL playground going to the following link: `https://manager.azion.com/metrics/graphql`.
     - You must be logged in to your Azion account. Otherwise, you'll receive an error message.
 2. Send a query following this format:
 

--- a/src/content/docs/en/pages/guides/marketplace/templates/videoteca-static-cache.mdx
+++ b/src/content/docs/en/pages/guides/marketplace/templates/videoteca-static-cache.mdx
@@ -23,7 +23,7 @@ The deployment of this template creates a GitHub repository containing your proj
 
 - A [GitHub account](https://github.com/signup) to connect with Azion and create your new repository.
     - Every push will be deployed automatically to this repository to keep your project updated.
-- The [Videoteca Player integration](/en/products/guides/videoteca-player/) installed and configured in your Azion account.
+- The [Videoteca Player integration](/en/documentation/products/guides/videofront-player/) installed and configured in your Azion account.
 - This template uses [Application Accelerator](/en/documentation/products/build/edge-application/application-accelerator/), [Edge Functions](/en/documentation/products/build/edge-application/edge-functions/), [Image Processor](/en/documentation/products/build/edge-application/image-processor/), and [Edge Cache](/en/documentation/products/build/edge-application/edge-cache/), and it could generate usage-related costs. Check the [pricing page](https://www.azion.com/en/pricing/) for more information.
 
 ---

--- a/src/content/docs/pt-br/pages/guias/marketplace/templates/videoteca-static-cache.mdx
+++ b/src/content/docs/pt-br/pages/guias/marketplace/templates/videoteca-static-cache.mdx
@@ -22,7 +22,7 @@ A implantação deste template cria um repositório no GitHub contendo seu proje
 
 - Uma [conta no GitHub](https://github.com/signup) para conectar-se à Azion e criar seu novo repositório.
     - Cada push será implantado automaticamente neste repositório para manter seu projeto atualizado.
-- A [integração do Videoteca Player](/pt-br/produtos/guias/videoteca-player/) instalada e configurada em sua conta Azion.
+- A [integração do Videoteca Player](/pt-br/documentacao/produtos/guias/videofront-player/) instalada e configurada em sua conta Azion.
 - Este template utiliza [Application Accelerator](/pt-br/documentacao/produtos/build/edge-application/application-accelerator/), [Edge Functions](/pt-br/documentacao/produtos/build/edge-application/edge-functions/), [Image Processor](/pt-br/documentacao/produtos/build/edge-application/image-processor/) e [Edge Cache](/pt-br/documentacao/produtos/build/edge-application/edge-cache/), e pode gerar custos relacionados ao uso. Consulte a [página de preços](https://www.azion.com/pt-br/precos/) para mais informações.
 
 ---


### PR DESCRIPTION
### Related issue: 

[EDU-6085]

### Changes

Fix broken links in Docs:
- Query Bot Manager data guide.
- Videoteca Static Cache template guide.

### Additional links

n/a.

[EDU-6085]: https://aziontech.atlassian.net/browse/EDU-6085?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ