### PR TITLE
[EDU-6114] AI documentation update - 2025-01-24 - tune cache settings

### DIFF
--- a/src/content/docs/en/pages/build-journey/edit-edge-app/edit-cache-settings/cache-settings.mdx
+++ b/src/content/docs/en/pages/build-journey/edit-edge-app/edit-cache-settings/cache-settings.mdx
@@ -65,6 +65,18 @@ The maximum and default TTL values for the edge should be between `60` and `3153
 A TTL zero isn't the same as a cache bypass. For more details, read about the difference between these settings on the [Bypass Cache behavior](/en/documentation/products/build/edge-application/rules-engine/#bypass-cache) documentation.
 :::
 
+**Stale Cache Handling**
+
+Azion provides the capability to serve stale content from the cache when the origin server is down or while the cache is being renewed. The 'Stale Cache' feature is enabled by default, allowing your application to continue serving the most recent cache content during these events.
+
+**UPDATING Status**
+
+The 'UPDATING' status indicates that the cache is being refreshed. During this time, the system will serve the stale cache content to ensure continuous availability.
+
+To create or modify rules to handle stale cache scenarios, you can use the Azion API with the following instructions:
+
+1. [TECHWRITER TODO: INSERT INFORMATION ABOUT HOW TO CREATE/CONFIGURE RULES WITH AZION API FOR STALE CACHE]
+
 **Large File Optimization**
 
 Instead of downloading a large content file and risking timeouts or connection terminations, [files can be fragmented](/en/documentation/products/build/edge-application/cache-settings/#large-file-optimization) in pieces and cached on-demand.
@@ -190,6 +202,18 @@ The maximum and default TTL values for the edge should be between `60` and `3153
 
 A TTL zero isn't the same as a cache bypass. For more details, read about the difference between these settings on the [Bypass Cache behavior](/en/documentation/products/build/edge-application/rules-engine/#bypass-cache) documentation.
 :::
+
+**Stale Cache Handling**
+
+Azion provides the capability to serve stale content from the cache when the origin server is down or while the cache is being renewed. The 'Stale Cache' feature is enabled by default, allowing your application to continue serving the most recent cache content during these events.
+
+**UPDATING Status**
+
+The 'UPDATING' status indicates that the cache is being refreshed. During this time, the system will serve the stale cache content to ensure continuous availability.
+
+To create or modify rules to handle stale cache scenarios, you can use the Azion API with the following instructions:
+
+1. [TECHWRITER TODO: INSERT INFORMATION ABOUT HOW TO CREATE/CONFIGURE RULES WITH AZION API FOR STALE CACHE]
 
 **Large File Optimization**
 
@@ -437,5 +461,3 @@ Check the [Azion API documentation](https://api.azion.com/) and the [OpenAPI spe
 </Tabs>
 
 When you first [create an edge application](/en/documentation/products/start-with-a-template/), a cache setting variable will be created and activated by default. This guide will show you how to create and activate a brand new cache setting instance.
-
-


### PR DESCRIPTION
AI Comment: The documentation was enhanced to include details on the 'UPDATING' status and its role in serving stale content. It also clarifies that 'Stale Cache' is enabled by default and suggests using the Azion API to create rules for handling stale cache scenarios. These additions address user questions about serving the most recent cache when the origin server is down or while the cache is being renewed.

Código: 19080