### PR TITLE
[EDU-6002] [EDU-6014] feature: add 2 guides using GraphQL queries

### DIFF
--- a/src/content/docs/en/pages/devtools/api-graphql/features/events-fields.mdx
+++ b/src/content/docs/en/pages/devtools/api-graphql/features/events-fields.mdx
@@ -141,6 +141,7 @@ See each available field and their descriptions below.
 | upstreamStatus | HTTP status code of the origin. If a server can't be selected, the variable keeps the 502 (Bad Gateway) status code. Example: `200`. **In case of cache, the response is `-`**. |
 | upstreamStatusStr | List with all `upstreamStatus` responses. |
 | virtualhostId | Unique ID available on Azion Console set on virtual host configuration file. Example: `2410001a` |
+| wafAttackFamily | Category or type of attack detected by the Web Application Firewall (WAF), based on their characteristics. Example: `$SQL`, `$RFI`, `$SQL`, `$XSS`, `$OTHERS` |
 | wafBlock | Informs whether WAF blocked the action or not. `0` when action wasn’t blocked; `1` when action was blocked. When in *Learning Mode*, it won’t be blocked regardless of the return. |
 | wafEvheaders | When the request headers sent by the user are analyzed by the WAF module and tagged as **blocked** with `$waf_block = 1`, it contains a base64 encoded string. Otherwise, it contains a dash character `-`. It applies to both WAF *Learning* or *Blocking* modes. |
 | wafLearning | Informs if WAF is in Learning mode. Returns `0` if it isn't and `1` if it's. |

--- a/src/content/docs/en/pages/guides/graphql/query-top-attacks.mdx
+++ b/src/content/docs/en/pages/guides/graphql/query-top-attacks.mdx
@@ -11,7 +11,7 @@ You can use information from the `httpMetrics` dataset to monitor traffic patter
 
 ---
 
-# Querying data
+## Querying data
 
 To query the Top 5 attacks, identified by the WAF and ranked by occurrence, proceed as follows:
 

--- a/src/content/docs/en/pages/guides/graphql/query-top-attacks.mdx
+++ b/src/content/docs/en/pages/guides/graphql/query-top-attacks.mdx
@@ -1,0 +1,95 @@
+---
+title: How to identify the top attacks using GraphQL API
+description: This guide will explain how to filter the top attack types, ranked by occurrence, as identified by the WAF.
+meta_tags: graphql, api, query, GraphiQL Playground, attack traffic, WAF
+namespace: docs_guides_query_top_attacks
+permalink: /documentation/products/guides/query-top-attacks-with-graphql/
+menu_namespace: graphqlMenu
+---
+
+You can use information from the `httpMetrics` dataset to monitor traffic patterns, detect anomalies, and analyze potential threats. This guide explains how to filter the top attack types, ranked by occurrence, as identified by the WAF.
+
+---
+
+# Querying data
+
+To query the Top 5 attacks, identified by the WAF and ranked by occurrence, proceed as follows:
+
+1. Access the GraphiQL Playground at this link: `https://manager.azion.com/metrics/graphql`.
+    - You must be logged in to your Azion account. Otherwise, you'll receive an error message.
+2. Send a query following this format:
+
+```graphql
+query Top5Attacks {
+  httpMetrics(
+    limit: 5
+    filter: {
+      tsRange: {
+        begin:"2025-01-15T00:00:00"
+        end:"2025-01-15T20:00:00"
+      }
+    }
+    groupBy:[wafAttackFamily]
+    orderBy:[wafRequestsThreat_DESC]
+  )
+  {
+    wafAttackFamily
+    wafRequestsThreat
+  }
+}
+```
+Where:
+
+| Field | Description |
+|----------|----------|
+| `limit` | Specifies the maximum number of results to return. In this case, `5` |
+| `filter` | Defines the criteria used to filter the data returned by the query |
+| `tsRange` | A subfield of `filter`. Specifies a time range for filtering data. It includes `begin` and `end` fields to define the start and end date and times. Format: `"YYYY-MM-DDTHH:mm:ss"`; example: `"2024-04-11T00:00:00"` |
+| `orderBy` | Specifies the order in which the results should be returned. Examples: `[wafRequestsThreat_DESC]`, for descending order, and `[wafRequestsThreat_ASC]`, for ascending order |
+| `groupBy` | Specifies the fields by which the query results should be grouped. In the example: `[wafAttackFamily]` to group by attack families detected by the WAF |
+
+:::note
+This example retrieves data for `wafAttackFamily` and the total of requests  (`wafRequestsThreat`) flagged as threats by the WAF within the specified time range. The results are grouped by attack families and ranked by the number of requests in descending order. To learn more about the available fields, check the [Real-Time Metrics GraphQL API Fields documentation](/en/documentation/devtools/graphql-api/features/gql-real-time-metrics-fields/#httpmetrics-edge-applications-waf).
+:::
+
+3. You'll receive a response similar to this: 
+
+```graphql
+{
+  "data": {
+    "httpMetrics": [
+      {
+        "wafAttackFamily": "$OTHERS",
+       "wafRequestsThreat": 1449942
+      },
+       {
+        "wafAttackFamily": "$SQL, $XSS",
+       "wafRequestsThreat": 1171825
+      },
+      {
+        "wafAttackFamily": "$RFI",
+       "wafRequestsThreat": 370811
+      },
+       {
+        "wafAttackFamily": "$SQL, $XSS, $TRAVERSAL",
+       "wafRequestsThreat": 216747
+      },
+      {
+        "wafAttackFamily": "$SQL",
+       "wafRequestsThreat": 191808
+      }
+    ]
+  }
+}
+```
+
+Where: 
+
+| Field | Description |
+|----------|----------|
+| `wafAttackFamily` | Category or type of attack detected by the Web Application Firewall (WAF), based on their characteristics. Example: `$SQL`, `$RFI`, `$SQL`, `$XSS`, `$OTHERS` |
+| `wafRequestsThreat` | Total number of requests flagged as threats by the WAF, ranked by the most frequent attack types. Example: `216747` |
+
+:::tip
+To know more about the available fields, check the [Real-Time Metrics GraphQL API Fields documentation](/en/documentation/devtools/graphql-api/features/gql-real-time-metrics-fields/#httpmetrics-edge-applications-waf).
+:::

--- a/src/content/docs/en/pages/guides/graphql/query-top-ips.mdx
+++ b/src/content/docs/en/pages/guides/graphql/query-top-ips.mdx
@@ -11,7 +11,7 @@ You can use information from the `httpEvents` dataset to monitor traffic pattern
 
 ---
 
-# Querying data
+## Querying data
 
 To query the Top 5 IPs generating attack traffic, according to the WAF, proceed as follows:
 
@@ -52,9 +52,9 @@ Where:
 | `limit` | Specifies the maximum number of results to return. In this case, `5` |
 | `filter` | Defines the criteria used to filter the data returned by the query |
 | `tsRange` | A subfield of `filter`. Specifies a time range for filtering data. It includes `begin` and `end` fields to define the start and end date and times. Format: `"YYYY-MM-DDTHH:mm:ss"`; example: `"2024-04-11T00:00:00"` |
-| `wafMatchNe` | Filters out entries where the wafMatch field is equal to "-", meaning it only includes events with valid WAF matches |
-| `wafAttackFamilyNe` | Filters out entries where the wafAttackFamily field is equal to "-", ensuring only events with identified WAF attack families are included |
-| count: rows | As a subfield of `aggregate`, counts the number of events matching the query's filters and groups |
+| `wafMatchNe` | Filters out entries where the `wafMatch` field is equal to "-", meaning it only includes events with valid WAF matches |
+| `wafAttackFamilyNe` | Filters out entries where the `wafAttackFamily` field is equal to "-", ensuring only events with identified WAF attack families are included |
+| `count: rows` | As a subfield of `aggregate`, counts the number of events matching the query's filters and groups |
 | `orderBy` | Specifies the order in which the results should be returned. Examples: `[count_DESC]`, for descending order, and `[count_ASC]`, for ascending order |
 | `groupBy` | Specifies the fields by which the query results should be grouped. In the example: `[remoteAddress, wafAttackFamily]` to group by IP and the family of attacks detected by the WAF |
 

--- a/src/content/docs/en/pages/guides/graphql/query-top-ips.mdx
+++ b/src/content/docs/en/pages/guides/graphql/query-top-ips.mdx
@@ -1,0 +1,111 @@
+---
+title: How to identify the Top IPs generating attack traffic using GraphQL API
+description: This guide will explain how to filter the IPs that generated the most requests identified by the WAF as attacks.
+meta_tags: graphql, api, query, GraphiQL Playground, attack traffic, WAF
+namespace: docs_guides_query_top_ips_attack
+permalink: /documentation/products/guides/query-top-ips-attack-traffic-with-graphql/
+menu_namespace: graphqlMenu
+---
+
+You can use information from the `httpEvents` dataset to monitor traffic patterns, detect anomalies, and analyze potential threats. This guide explains how to filter the 5 IPs that generated the most requests identified by the WAF as attacks.
+
+---
+
+# Querying data
+
+To query the Top 5 IPs generating attack traffic, according to the WAF, proceed as follows:
+
+1. Access the GraphiQL Playground at this link: `https://manager.azion.com/metrics/graphql`.
+    - You must be logged in to your Azion account. Otherwise, you'll receive an error message.
+2. Send a query following this format:
+
+```graphql
+query TOP5IPsWAFRequests {
+  httpEvents(
+    limit: 5
+    filter: {
+      tsRange: {
+        begin:"2025-01-15T00:00:00"
+        end:"2025-01-15T20:00:00"
+      },
+      wafMatchNe: "-"
+      wafAttackFamilyNe: "-"
+    }
+    aggregate: {
+      count: rows
+    }
+    groupBy:[remoteAddress, wafAttackFamily]
+    orderBy:[count_DESC]
+  )
+  {
+    remoteAddress
+    wafAttackFamily
+    count
+  }
+}
+```
+
+Where:
+
+| Field | Description |
+|----------|----------|
+| `limit` | Specifies the maximum number of results to return. In this case, `5` |
+| `filter` | Defines the criteria used to filter the data returned by the query |
+| `tsRange` | A subfield of `filter`. Specifies a time range for filtering data. It includes `begin` and `end` fields to define the start and end date and times. Format: `"YYYY-MM-DDTHH:mm:ss"`; example: `"2024-04-11T00:00:00"` |
+| `wafMatchNe` | Filters out entries where the wafMatch field is equal to "-", meaning it only includes events with valid WAF matches |
+| `wafAttackFamilyNe` | Filters out entries where the wafAttackFamily field is equal to "-", ensuring only events with identified WAF attack families are included |
+| count: rows | As a subfield of `aggregate`, counts the number of events matching the query's filters and groups |
+| `orderBy` | Specifies the order in which the results should be returned. Examples: `[count_DESC]`, for descending order, and `[count_ASC]`, for ascending order |
+| `groupBy` | Specifies the fields by which the query results should be grouped. In the example: `[remoteAddress, wafAttackFamily]` to group by IP and the family of attacks detected by the WAF |
+
+:::note
+This example retrieves data for `remoteAddress` and the total (count) of requests identified by the WAF as attacks within the specified time range, grouped by IPs first and then by the attack family. To know more about the available fields, check the [Real-Time Events GraphQL API Fields documentation](/en/documentation/devtools/graphql-api/features/gql-real-time-events-fields/#httpevents-edge-applications-waf).
+:::
+
+3. You'll receive a response similar to this: 
+
+```graphql
+{
+  "data": {
+    "httpEvents": [
+      {
+        "remoteAddress": "123.456.789.123",
+        "wafAttackFamily": "$SQL, $XSS",
+       "count": 1384
+      },
+       {
+        "remoteAddress": "987.654.321.123",
+        "wafAttackFamily": "$TRAVERSAL",
+       "count": 1224
+      },
+      {
+        "remoteAddress": "12.123.1.123",
+        "wafAttackFamily": "$SQL, $XSS",
+       "count": 1194
+      },
+       {
+        "remoteAddress": "123.321.123.321",
+        "wafAttackFamily": "$OTHERS",
+       "count": 690
+      },
+      {
+        "remoteAddress": "123.456.456.000",
+        "wafAttackFamily": "$RFI",
+       "count": 363
+      }
+    ]
+  }
+}
+```
+
+Where: 
+
+| Field | Description |
+|----------|----------|
+| `remoteAddress` | IP address of the origin that generated the requests. Example: 127.0.0.1 |
+| `wafAttackFamily` | Category or type of attack detected by the Web Application Firewall (WAF), based on their characteristics. Example: `$SQL`, `$RFI`, `$SQL`, `$XSS`, `$OTHERS` |
+| `count` | Requests identified by the WAF as attacks. Example: `1194` |
+
+:::tip
+To know more about the available fields, check the [Real-Time Events GraphQL API Fields documentation](/en/documentation/devtools/graphql-api/features/gql-real-time-events-fields/#httpevents-edge-applications-waf).
+:::

--- a/src/content/docs/en/pages/guides/index.mdx
+++ b/src/content/docs/en/pages/guides/index.mdx
@@ -206,6 +206,8 @@ permalink: /documentation/products/guides/
 - [How to query Connected Users data with GraphQL API](/en/documentation/products/guides/query-connected-users-data-with-graphql/)
 - [How to query Bot Manager data with GraphQL API](/en/documentation/products/guides/query-bot-manager-data-with-graphql/)
 - [How to query the top URLs impacted by bots with GraphQL API](/en/documentation/products/guides/query-bot-manager-breakdown-data-with-graphql/)
+- [How to identify the Top IPs generating attack traffic using GraphQL API](/en/documentation/products/guides/query-top-ips-attack-traffic-with-graphql/)
+- [How to identify the top attacks using GraphQL API](/en/documentation/products/guides/query-top-attacks-with-graphql/)
 
 ---
 

--- a/src/content/docs/en/pages/main-menu/additional-resources/developer-tools/graphql-playground.mdx
+++ b/src/content/docs/en/pages/main-menu/additional-resources/developer-tools/graphql-playground.mdx
@@ -168,6 +168,10 @@ query TOP5IPsWAFRequests {
 }
 ```
 
+:::tip
+For more details, check the [How to identify the Top IPs generating attack traffic using GraphQL API](/en/documentation/products/guides/query-top-ips-attack-traffic-with-graphql/) guide.
+:::
+
 Or use this one to filter the top attack types, ranked by occurrence.
 
 ```graphql

--- a/src/content/docs/pt-br/pages/devtools/api-graphql/recursos/events-campos.mdx
+++ b/src/content/docs/pt-br/pages/devtools/api-graphql/recursos/events-campos.mdx
@@ -144,6 +144,7 @@ Veja cada campo disponível e suas descrições abaixo.
 | upstreamStatus | Código de status HTTP da origem. Se um servidor não puder ser selecionado, a variável mantém o código de status 502 (Bad Gateway). Exemplo: `200`. **Em caso de cache, a resposta é `-`**. |
 | upstreamStatusStr | Lista com todas as respostas `upstreamStatus`. |
 | virtualHostId | Identificador disponível no Azion Console. Definido no arquivo de configuração do virtual host. Exemplo: `2410001a` |
+| wafAttackFamily | Categoria ou tipo de ataque detectado pelo Web Application Firewall (WAF), com base em suas características. Exemplo: `$SQL`, `$RFI`, `$SQL`, `$XSS`, `$OTHERS` |
 | wafBlock | Informa se o WAF bloqueou ou não a ação. `0` quando a ação não foi bloqueada e `1` quando a ação foi bloqueada. Quando estiver em *Learning Mode*, ela não será bloqueada, independentemente do retorno. |
 | wafEvheaders | Quando os cabeçalhos de solicitação enviados pelo usuário são analisados pelo módulo WAF e marcados como **bloqueados** com `$waf_block = 1`, ele contém uma string codificada em base64. Caso contrário, ele contém um caractere de traço `-`. Aplica-se aos modos WAF *Learning* ou *Blocking*. |
 | wafLearning | Informa se o WAF está em Learning Mode. Retorna `0` se não for e `1` se for. |

--- a/src/content/docs/pt-br/pages/guias/graphql/query-top-attacks.mdx
+++ b/src/content/docs/pt-br/pages/guias/graphql/query-top-attacks.mdx
@@ -1,0 +1,97 @@
+---
+title: Como identificar os principais ataques usando a API GraphQL
+description: Este guia explicará como filtrar os principais tipos de ataque, classificados por ocorrência, conforme identificado pelo WAF.
+meta_tags: graphql, api, query, GraphiQL Playground, tráfego de ataque, WAF
+namespace: docs_guides_query_top_attacks
+permalink: /documentacao/produtos/guias/consultar-top-attacks-com-graphql/
+menu_namespace: graphqlMenu
+---
+
+Você pode usar informações do conjunto de dados `httpMetrics` para monitorar padrões de tráfego, detectar anomalias e analisar ameaças potenciais. Este guia explica como filtrar os principais tipos de ataque, classificados por ocorrência, conforme identificado pelo WAF.
+
+---
+
+## Consulte os dados
+
+Para consultar os 5 principais ataques, identificados pelo WAF e classificados por ocorrência, siga os passos abaixo:
+
+1. Acesse o GraphiQL Playground neste link: `https://manager.azion.com/metrics/graphql`.
+    - Você deve estar logado na sua conta Azion. Caso contrário, você receberá uma mensagem de erro.
+2. Envie uma consulta seguindo este formato:
+
+```graphql
+query Top5Attacks {
+  httpMetrics(
+    limit: 5
+    filter: {
+      tsRange: {
+        begin:"2025-01-15T00:00:00"
+        end:"2025-01-15T20:00:00"
+      }
+    }
+    groupBy:[wafAttackFamily]
+    orderBy:[wafRequestsThreat_DESC]
+  )
+  {
+    wafAttackFamily
+    wafRequestsThreat
+  }
+}
+```
+
+Onde:
+
+| Campo | Descrição |
+|----------|----------|
+| `limit` | Especifica o número máximo de resultados a serem retornados. Neste caso, `5` |
+| `filter` | Define os critérios usados para filtrar os dados retornados pela consulta |
+| `tsRange` | Um subcampo de `filter`. Especifica um intervalo de tempo para filtrar dados. Inclui campos `begin` e `end` para definir a data e hora de início e fim. Formato: `"YYYY-MM-DDTHH:mm:ss"`; exemplo: `"2024-04-11T00:00:00"` |
+| `orderBy` | Especifica a ordem em que os resultados devem ser retornados. Exemplos: `[wafRequestsThreat_DESC]`, para ordem decrescente, e `[wafRequestsThreat_ASC]`, para ordem crescente |
+| `groupBy` | Especifica os campos pelos quais os resultados da consulta devem ser agrupados. No exemplo: `[wafAttackFamily]` para agrupar por famílias de ataque detectadas pelo WAF |
+
+:::note
+Este exemplo recupera dados para `wafAttackFamily` e o total de requisições (`wafRequestsThreat`) sinalizadas como ameaças pelo WAF dentro do intervalo de tempo especificado. Os resultados são agrupados por famílias de ataque e classificados pelo número de requisições em ordem decrescente. Para saber mais sobre os campos disponíveis, consulte a documentação sobre os [Campos da API GraphQL do Real-Time Metrics](/pt-br/documentacao/devtools/graphql-api/recursos/campos-gql-real-time-metrics/#httpmetrics-edge-applications-waf).
+:::
+
+3. Você receberá uma resposta semelhante a esta:
+
+```graphql
+{
+  "data": {
+    "httpMetrics": [
+      {
+        "wafAttackFamily": "$OTHERS",
+       "wafRequestsThreat": 1449942
+      },
+       {
+        "wafAttackFamily": "$SQL, $XSS",
+       "wafRequestsThreat": 1171825
+      },
+      {
+        "wafAttackFamily": "$RFI",
+       "wafRequestsThreat": 370811
+      },
+       {
+        "wafAttackFamily": "$SQL, $XSS, $TRAVERSAL",
+       "wafRequestsThreat": 216747
+      },
+      {
+        "wafAttackFamily": "$SQL",
+       "wafRequestsThreat": 191808
+      }
+    ]
+  }
+}
+```
+
+
+Onde:
+
+| Campo | Descrição |
+|----------|----------|
+| `wafAttackFamily` | Categoria ou tipo de ataque detectado pelo Web Application Firewall (WAF), com base em suas características. Exemplo: `$SQL`, `$RFI`, `$SQL`, `$XSS`, `$OTHERS` |
+| `wafRequestsThreat` | Total de solicitações sinalizadas como ameaças pelo WAF, classificadas pelos tipos de ataque mais frequentes. Exemplo: `216747` |
+
+:::tip
+Para saber mais sobre os campos disponíveis, consulte a documentação sobre os [Campos da API GraphQL do Real-Time Metrics](/pt-br/documentacao/devtools/graphql-api/recursos/campos-gql-real-time-metrics/#httpmetrics-edge-applications-waf).
+:::

--- a/src/content/docs/pt-br/pages/guias/graphql/query-top-ips.mdx
+++ b/src/content/docs/pt-br/pages/guias/graphql/query-top-ips.mdx
@@ -59,7 +59,7 @@ Onde:
 | `groupBy` | Especifica os campos pelos quais os resultados da consulta devem ser agrupados. No exemplo: `[remoteAddress, wafAttackFamily]` para agrupar por IP e pela família de ataques detectados pelo WAF |
 
 :::note
-Este exemplo recupera dados para `remoteAddress` e o total (count) de requisições identificadas pelo WAF como ataques dentro do intervalo de tempo especificado, agrupados primeiro por IPs e depois pela família de ataques. Para saber mais sobre os campos disponíveis, consulte a documentação sobre os [Campos da API GraphQL do Real-Time Events](/pt-br/documentacao/devtools/graphql-api/recursos/campos-gql-real-time-events/).
+Este exemplo recupera dados para `remoteAddress` e o total (count) de requisições identificadas pelo WAF como ataques dentro do intervalo de tempo especificado, agrupados primeiro por IPs e depois pela família de ataques. Para saber mais sobre os campos disponíveis, consulte a documentação sobre os [Campos da API GraphQL do Real-Time Events](/pt-br/documentacao/devtools/graphql-api/recursos/campos-gql-real-time-events/#httpevents-edge-applications-waf).
 :::
 
 3. Você receberá uma resposta semelhante a esta: 
@@ -107,5 +107,5 @@ Onde:
 | `count` | Requisições identificadas pelo WAF como ataques. Exemplo: `1194` |
 
 :::tip
-Para saber mais sobre os campos disponíveis, consulte a documentação sobre os [Campos da API GraphQL do Real-Time Events](/pt-br/documentacao/devtools/graphql-api/recursos/campos-gql-real-time-events/).
+Para saber mais sobre os campos disponíveis, consulte a documentação sobre os [Campos da API GraphQL do Real-Time Events](/pt-br/documentacao/devtools/graphql-api/recursos/campos-gql-real-time-events/#httpevents-edge-applications-waf).
 :::

--- a/src/content/docs/pt-br/pages/guias/graphql/query-top-ips.mdx
+++ b/src/content/docs/pt-br/pages/guias/graphql/query-top-ips.mdx
@@ -1,0 +1,111 @@
+---
+title: Como identificar os principais IPs gerando tráfego de ataque com a API GraphQL
+description: Este guia explicará como filtrar os IPs que geraram o maior número de requisições identificadas pelo WAF como ataques.
+meta_tags: graphql, api, query, GraphiQL Playground, tráfego de ataque, WAF
+namespace: docs_guides_query_top_ips_attack
+permalink: /documentacao/produtos/guias/consultar-top-ips-gerando-trafego-de-ataque-com-graphql/
+menu_namespace: graphqlMenu
+---
+
+Você pode usar informações do conjunto de dados `httpEvents` para monitorar padrões de tráfego, detectar anomalias e analisar potenciais ameaças. Este guia explica como filtrar os 5 IPs que geraram o maior número de requisições identificadas pelo WAF como ataques.
+
+---
+
+## Consulte os dados
+
+Para consultar os 5 principais IPs gerando tráfego de ataque, de acordo com o WAF, siga os passos abaixo:
+
+1. Acesse o GraphiQL Playground neste link: `https://manager.azion.com/metrics/graphql`.
+    - Você deve estar logado na sua conta Azion. Caso contrário, você receberá uma mensagem de erro.
+2. Envie uma consulta seguindo este formato:
+
+```graphql
+query TOP5IPsWAFRequests {
+  httpEvents(
+    limit: 5
+    filter: {
+      tsRange: {
+        begin:"2025-01-15T00:00:00"
+        end:"2025-01-15T20:00:00"
+      },
+      wafMatchNe: "-"
+      wafAttackFamilyNe: "-"
+    }
+    aggregate: {
+      count: rows
+    }
+    groupBy:[remoteAddress, wafAttackFamily]
+    orderBy:[count_DESC]
+  )
+  {
+    remoteAddress
+    wafAttackFamily
+    count
+  }
+}
+```
+
+Onde:
+
+| Campo | Descrição |
+|----------|----------|
+| `limit` | Especifica o número máximo de resultados a serem retornados. Neste caso, `5` |
+| `filter` | Define os critérios usados para filtrar os dados retornados pela consulta |
+| `tsRange` | Um subcampo de `filter`. Especifica um intervalo de tempo para filtrar os dados. Inclui campos `begin` e `end` para definir a data e hora de início e fim. Formato: `"YYYY-MM-DDTHH:mm:ss"`; exemplo: `"2024-04-11T00:00:00"` |
+| `wafMatchNe` | Filtra entradas onde o campo `wafMatch` é igual a "-", significando que inclui apenas eventos com correspondências válidas do WAF |
+| `wafAttackFamilyNe` | Filtra entradas onde o campo `wafAttackFamily` é igual a "-", garantindo que apenas eventos com famílias de ataque do WAF identificadas sejam incluídos |
+| `count: rows` | Como um subcampo de `aggregate`, conta o número de eventos que correspondem aos filtros da consulta e agrupa |
+| `orderBy` | Especifica a ordem em que os resultados devem ser retornados. Exemplos: `[count_DESC]`, para ordem decrescente, e `[count_ASC]`, para ordem crescente |
+| `groupBy` | Especifica os campos pelos quais os resultados da consulta devem ser agrupados. No exemplo: `[remoteAddress, wafAttackFamily]` para agrupar por IP e pela família de ataques detectados pelo WAF |
+
+:::note
+Este exemplo recupera dados para `remoteAddress` e o total (count) de requisições identificadas pelo WAF como ataques dentro do intervalo de tempo especificado, agrupados primeiro por IPs e depois pela família de ataques. Para saber mais sobre os campos disponíveis, consulte a documentação sobre os [Campos da API GraphQL do Real-Time Events](/pt-br/documentacao/devtools/graphql-api/recursos/campos-gql-real-time-events/).
+:::
+
+3. Você receberá uma resposta semelhante a esta: 
+
+```graphql
+{
+  "data": {
+    "httpEvents": [
+      {
+        "remoteAddress": "123.456.789.123",
+        "wafAttackFamily": "$SQL, $XSS",
+       "count": 1384
+      },
+       {
+        "remoteAddress": "987.654.321.123",
+        "wafAttackFamily": "$TRAVERSAL",
+       "count": 1224
+      },
+      {
+        "remoteAddress": "12.123.1.123",
+        "wafAttackFamily": "$SQL, $XSS",
+       "count": 1194
+      },
+       {
+        "remoteAddress": "123.321.123.321",
+        "wafAttackFamily": "$OTHERS",
+       "count": 690
+      },
+      {
+        "remoteAddress": "123.456.456.000",
+        "wafAttackFamily": "$RFI",
+       "count": 363
+      }
+    ]
+  }
+}
+```
+
+Onde: 
+
+| Campo | Descrição |
+|----------|----------|
+| `remoteAddress` | Endereço IP da origem que gerou as requisições. Exemplo: 127.0.0.1 |
+| `wafAttackFamily` | Categoria ou tipo de ataque detectado pelo Web Application Firewall (WAF), com base em suas características. Exemplo: `$SQL`, `$RFI`, `$SQL`, `$XSS`, `$OTHERS` |
+| `count` | Requisições identificadas pelo WAF como ataques. Exemplo: `1194` |
+
+:::tip
+Para saber mais sobre os campos disponíveis, consulte a documentação sobre os [Campos da API GraphQL do Real-Time Events](/pt-br/documentacao/devtools/graphql-api/recursos/campos-gql-real-time-events/).
+:::

--- a/src/content/docs/pt-br/pages/guias/guides.mdx
+++ b/src/content/docs/pt-br/pages/guias/guides.mdx
@@ -206,6 +206,8 @@ permalink: /documentacao/produtos/guias/
 - [Como consultar dados de usuários conectados com a GraphQL API](/pt-br/documentacao/produtos/guias/query-dados-connected-users-com-graphql/)
 - [Como consultar dados do Bot Manager com a GraphQL API](/pt-br/documentacao/produtos/guias/consultar-dados-bot-manager-com-graphql/)
 - [Como consultar as principais URLs impactadas por bots com a GraphQL API](/pt-br/documentacao/produtos/guias/consultar-dados-bot-manager-breakdown-com-graphql/)
+- [Como identificar os principais IPs gerando tráfego de ataque com a API GraphQL](/pt-br/documentacao/produtos/guias/consultar-top-ips-gerando-trafego-de-ataque-com-graphql/)
+- [Como identificar os principais ataques usando a API GraphQL](/pt-br/documentacao/produtos/guias/consultar-top-attacks-com-graphql/)
 
 ---
 

--- a/src/content/docs/pt-br/pages/menu-principal/recursos-adicionais/developer-tools/graphql-playground.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/recursos-adicionais/developer-tools/graphql-playground.mdx
@@ -168,6 +168,10 @@ query TOP5IPsWAFRequests {
 }
 ```
 
+:::tip
+Para mais detalhes, consulte o guia [Como identificar os principais IPs gerando tráfego de ataque com a API GraphQL](/pt-br/documentacao/produtos/guias/consultar-top-ips-gerando-trafego-de-ataque-com-graphql/).
+:::
+
 Ou use esta query para filtrar os principais tipos de ataques, classificados por ocorrência.
 
 ```graphql

--- a/src/i18n/en/graphqlMenu.ts
+++ b/src/i18n/en/graphqlMenu.ts
@@ -38,7 +38,10 @@
 		{ text: 'How to select Top X queries', slug: '/documentation/products/guides/graphql-top-x-query', key: 'guides/graphql-top-x' },
 		{ text: 'How to query Connected Users data', slug: '/documentation/products/guides/query-connected-users-data-with-graphql/', key: 'guides/connected-users-graphql' },
 		{ text: 'How to query Bot Manager data', slug: '/documentation/products/guides/query-bot-manager-data-with-graphql/', key: 'guides/bot-data-graphql' },
-		{ text: 'How to query the top URLs impacted by bots', slug: '/documentation/products/guides/query-bot-manager-breakdown-data-with-graphql/', key: 'guides/bot-breakdown-data-graphql' }
+		{ text: 'How to query the top URLs impacted by bots', slug: '/documentation/products/guides/query-bot-manager-breakdown-data-with-graphql/', key: 'guides/bot-breakdown-data-graphql' },
+		{ text: 'How to identify the Top IPs generating attack traffic', slug: '/documentation/products/guides/query-top-ips-attack-traffic-with-graphql/', key: 'guides/top-ips-graphql' },
+		{ text: 'How to identify the top attacks', slug: '/documentation/products/guides/query-top-attacks-with-graphql/', key: 'guides/bot-top-attacks-graphql' }
+
 	] },
 
 

--- a/src/i18n/pt-br/graphqlMenu.ts
+++ b/src/i18n/pt-br/graphqlMenu.ts
@@ -39,7 +39,9 @@
 		{ text: 'Como selecionar Top X queries', slug: '/documentacao/produtos/guias/graphql-query-top-x', key: 'guides/graphql-top-x' },
 		{ text: 'Como consultar dados de usuários conectados', slug: '/documentacao/produtos/guias/query-dados-connected-users-com-graphql/', key: 'guides/connected-users-graphql' },
 		{ text: 'Como consultar dados do Bot Manager', slug: '/documentacao/produtos/guias/consultar-dados-bot-manager-com-graphql/', key: 'guides/bot-data-graphql' },
-		{ text: 'Como consultar as principais URLs impactadas por bots', slug: '/documentacao/produtos/guias/consultar-dados-bot-manager-breakdown-com-graphql/', key: 'guides/bot-breakdown-data-graphql' }
+		{ text: 'Como consultar as principais URLs impactadas por bots', slug: '/documentacao/produtos/guias/consultar-dados-bot-manager-breakdown-com-graphql/', key: 'guides/bot-breakdown-data-graphql' },
+		{ text: 'Como identificar os principais IPs gerando tráfego de ataque', slug: '/documentacao/produtos/guias/consultar-top-ips-gerando-trafego-de-ataque-com-graphql/', key: 'guides/top-ips-graphql' },
+		{ text: 'Como identificar os principais ataques ', slug: '/documentacao/produtos/guias/consultar-top-attacks-com-graphql/', key: 'guides/bot-top-attacks-graphql' }
 	] },
 
 


### PR DESCRIPTION
### Related issue: 

[EDU-6002] [EDU-6014]

### Changes

- Add 2 guides using GraphQL queries: Top IPs and Top Attacks EN/PT.
- Add links to the Guides page and GraphQL menu.
- Add missing field. 

### Additional links

n/a.

[EDU-6002]: https://aziontech.atlassian.net/browse/EDU-6002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EDU-6014]: https://aziontech.atlassian.net/browse/EDU-6014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ