### PR TITLE
[EDU-6287] refactor: update link to resource - JS Tag guide

### DIFF
--- a/src/content/docs/en/pages/guides/marketplace/integrations/javascript-tag-js-tag.mdx
+++ b/src/content/docs/en/pages/guides/marketplace/integrations/javascript-tag-js-tag.mdx
@@ -25,15 +25,15 @@ Then, it creates a unique identifier containing all this information and sets it
 
 Azion provides a code sample for this JavaScript injection that you can include in your project. To do so:
 
-1. Add [this file](https://mal2u8n8zk.map.azionedge.net/274addd29ac1edb2b200a297b98581cd88465e2ee36f18cfdbdc063402063fe5.js) to your HTML source, following this example:
+1. Add [this file](https://assets.azion.com/global/bot-client-fingerprint/azfp-1.0.0.min.js) to your HTML source, following this example:
 
 ```bash
-<script src="https://mal2u8n8zk.map.azionedge.net/274addd29ac1edb2b200a297b98581cd88465e2ee36f18cfdbdc063402063fe5.js"></script>
+<script src="https://assets.azion.com/global/bot-client-fingerprint/azfp-1.0.0.min.js"></script>
 ```
 
 Alternatively, you can also:
 
-1. Copy the code in [this file](https://mal2u8n8zk.map.azionedge.net/274addd29ac1edb2b200a297b98581cd88465e2ee36f18cfdbdc063402063fe5.js).
+1. Copy the code in [this file](https://assets.azion.com/global/bot-client-fingerprint/azfp-1.0.0.min.js).
 2. Create a new JavaScript file with the code.
 3.  Include the JavaScript file in your project folder.
     1. In this example, the file name is `fingerprint-script.js`

--- a/src/content/docs/pt-br/pages/guias/marketplace/integrations/javascript-tag-js-tag.mdx
+++ b/src/content/docs/pt-br/pages/guias/marketplace/integrations/javascript-tag-js-tag.mdx
@@ -25,15 +25,15 @@ Em seguida, ele cria um identificador único contendo todas essas informações 
 
 A Azion fornece um exemplo de código para fazer a injeção de JavaScript que você pode incluir em seu projeto. Para fazer isso:
 
-1. Adicione [esse arquivo](https://mal2u8n8zk.map.azionedge.net/274addd29ac1edb2b200a297b98581cd88465e2ee36f18cfdbdc063402063fe5.js) no seu HTML fonte, seguindo o exemplo:
+1. Adicione [esse arquivo](https://assets.azion.com/global/bot-client-fingerprint/azfp-1.0.0.min.js) no seu HTML fonte, seguindo o exemplo:
 
 ```bash
-<script src="https://mal2u8n8zk.map.azionedge.net/274addd29ac1edb2b200a297b98581cd88465e2ee36f18cfdbdc063402063fe5.js"></script>
+<script src="https://assets.azion.com/global/bot-client-fingerprint/azfp-1.0.0.min.js"></script>
 ```
 
 Alternativamente, você também pode:
 
-1. Copiar o código neste [arquivo](https://mal2u8n8zk.map.azionedge.net/274addd29ac1edb2b200a297b98581cd88465e2ee36f18cfdbdc063402063fe5.js).
+1. Copiar o código neste [arquivo](https://assets.azion.com/global/bot-client-fingerprint/azfp-1.0.0.min.js).
 2. Criar um novo arquivo JavaScript com o código.
 3. Incluir o arquivo JavaScript na pasta do seu projeto.
   - Neste exemplo, o nome do arquivo é `fingerprint-script.js`.

--- a/src/content/docs/pt-br/pages/guias/marketplace/integrations/javascript-tag-js-tag.mdx
+++ b/src/content/docs/pt-br/pages/guias/marketplace/integrations/javascript-tag-js-tag.mdx
@@ -25,7 +25,7 @@ Em seguida, ele cria um identificador único contendo todas essas informações 
 
 A Azion fornece um exemplo de código para fazer a injeção de JavaScript que você pode incluir em seu projeto. Para fazer isso:
 
-1. Adicione [esse arquivo](https://assets.azion.com/global/bot-client-fingerprint/azfp-1.0.0.min.js) no seu HTML fonte, seguindo o exemplo:
+1. Adicione [este arquivo](https://assets.azion.com/global/bot-client-fingerprint/azfp-1.0.0.min.js) no seu HTML fonte, seguindo o exemplo:
 
 ```bash
 <script src="https://assets.azion.com/global/bot-client-fingerprint/azfp-1.0.0.min.js"></script>


### PR DESCRIPTION
### Related issue:

[EDU-6287]

### Changes

- Update link to resource included in the JS Tag how-to guide.
- The link wasn't identified in any file other than the guide.

### Additional links

n/a.

[EDU-6287]: https://aziontech.atlassian.net/browse/EDU-6287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ