### PR TITLE
[EDU-6318] fix: devtools homepage order

### DIFF
--- a/src/content/docs/en/homes/dev-tools.mdx
+++ b/src/content/docs/en/homes/dev-tools.mdx
@@ -11,26 +11,32 @@ menu_namespace: devtoolsMenu
 product_cards:
   - title: ''
     cards:
-      - icon: /assets/docs/images/uploads/icon-cli.svg
-        title: CLI
-        description: >-
-          Create applications and manage services using command lines in a
-          terminal.
-        link: /en/documentation/products/azion-cli/overview/
       - icon: /assets/docs/images/uploads/icon-api.svg
         title: API
         description: >-
           Find reference documentation with examples about Azion products’ APIs
           and test them.
         link: 'https://api.azion.com/'
+      - icon: /assets/docs/images/uploads/vector.svg
+        title: Azion Lib
+        description: >-
+          The Azion Libraries provide a suite of tools to interact with various Azion services.
+        link: /en/documentation/products/azion-lib/overview/
+      - icon: /assets/docs/images/uploads/icon-cli.svg
+        title: CLI
+        description: >-
+          Create applications and manage services using command lines in a
+          terminal.
+        link: /en/documentation/products/azion-cli/overview/
+      - icon: /assets/docs/images/uploads/vector.svg
+        title: Console Kit
+        description: >-
+          Console Kit is a front-end development kit for crafting a customized Azion Console interface.
+        link: /en/documentation/devtools/console-kit/
       - icon: /assets/docs/images/uploads/icon-api.svg
         title: GraphQL API
         description: 'Request the data you want and receive nothing more, nothing less.'
         link: /en/documentation/devtools/graphql-api/
-      - icon: /assets/docs/images/uploads/vector.svg
-        title: Terraform
-        description: Manage your infrastructure as code using the Azion Terraform Provider.
-        link: /en/documentation/products/terraform-provider/
       - icon: /assets/docs/images/uploads/vector.svg
         title: SDK
         description: >-
@@ -38,15 +44,10 @@ product_cards:
           work.
         link: /en/documentation/devtools/sdk/go/
       - icon: /assets/docs/images/uploads/vector.svg
-        title: Azion Lib
-        description: >-
-          The Azion Libraries provide a suite of tools to interact with various Azion services.
-        link: /en/documentation/products/azion-lib/overview/
-      - icon: /assets/docs/images/uploads/vector.svg
-        title: Console Kit
-        description: >-
-          Console Kit is a front-end development kit for crafting a customized Azion Console interface.
-        link: /en/documentation/devtools/console-kit/
+        title: Terraform
+        description: Manage your infrastructure as code using the Azion Terraform Provider.
+        link: /en/documentation/products/terraform-provider/
+
 permalink: /documentation/devtools/
 
 ---

--- a/src/content/docs/pt-br/homes/dev-tools.mdx
+++ b/src/content/docs/pt-br/homes/dev-tools.mdx
@@ -12,12 +12,6 @@ menu_namespace: devtoolsMenu
 product_cards:
   - title: ''
     cards:
-      - icon: /assets/docs/images/uploads/icon-cli.svg
-        title: CLI
-        description: >-
-          Crie aplicações e gerencie serviços utilizando linhas de comando em um
-          terminal.
-        link: /pt-br/documentacao/produtos/azion-cli/visao-geral/
       - icon: /assets/docs/images/uploads/icon-api.svg
         title: API
         description: >-
@@ -25,24 +19,30 @@ product_cards:
           produtos Azion.
         link: 'https://api.azion.com/'
       - icon: /assets/docs/images/uploads/icon-api.svg
-        title: GraphQL API
+        title: API GraphQL
         description: Solicite os dados que deseja e receba exatamente o que foi solicitado.
         link: /pt-br/documentacao/devtools/graphql-api/
       - icon: /assets/docs/images/uploads/vector.svg
-        title: Terraform
-        description: Gerencie sua estrutura como código com o Azion Terraform Provider.
-        link: /pt-br/documentacao/produtos/terraform-provider/
+        title: Azion Lib
+        description: As Azion Libraries fornecem um conjunto de ferramentas para interagir com vários serviços da Azion.
+        link: /pt-br/documentacao/produtos/azion-lib/visao-geral/
+      - icon: /assets/docs/images/uploads/icon-cli.svg
+        title: CLI
+        description: >-
+          Crie aplicações e gerencie serviços utilizando linhas de comando em um
+          terminal.
+        link: /pt-br/documentacao/produtos/azion-cli/visao-geral/
+      - icon: /assets/docs/images/uploads/vector.svg
+        title: Console Kit
+        description: O Console Kit da Azion é um kit de desenvolvimento front-end para criar uma interface personalizada do Console da Azion.
+        link: /pt-br/documentacao/devtools/console-kit/
       - icon: /assets/docs/images/uploads/vector.svg
         title: SDK
         description: Desenvolva aplicações utilizando o Azion SDK para a linguagem Go.
         link: /pt-br/documentacao/devtools/sdk/go/
       - icon: /assets/docs/images/uploads/vector.svg
-        title: Azion Lib
-        description: As Azion Libraries fornecem um conjunto de ferramentas para interagir com vários serviços da Azion.
-        link: /pt-br/documentacao/produtos/azion-lib/visao-geral/
-      - icon: /assets/docs/images/uploads/vector.svg
-        title: Console Kit
-        description: O Console Kit da Azion é um kit de desenvolvimento front-end para criar uma interface personalizada do Console da Azion.
-        link: /pt-br/documentacao/devtools/console-kit/
+        title: Terraform
+        description: Gerencie sua estrutura como código com o Azion Terraform Provider.
+        link: /pt-br/documentacao/produtos/terraform-provider/
 ---
 


### PR DESCRIPTION
devtools pages are now in alphabetical order.