### PR TITLE
[EDU-6318] fix:Order devtools by name in docs home

### DIFF
--- a/src/content/docs/en/homes/home-docs.mdx
+++ b/src/content/docs/en/homes/home-docs.mdx
@@ -86,27 +86,42 @@ product_cards:
         description: >- 
           Manage and monitor your edge applications, services, and resources efficiently.
         link: https://www.azion.com/en/documentation/products/guides/getting-to-know-azion-console/
-      - icon: /assets/docs/images/uploads/icon-cli.svg
-        title: Azion CLI
-        description: >-
-          Create applications and manage services using command lines in a
-          terminal.
-        link: /en/documentation/products/azion-cli/overview/
       - icon: /assets/docs/images/uploads/icon-api.svg
         title: Azion API
         description: >-
           Find reference documentation with examples about Azion products’ APIs
           and test them.
         link: 'https://api.azion.com/'
-      - icon: /assets/docs/images/uploads/vector.svg
-        title: Terraform
-        description: Manage your infrastructure as code using the Azion Terraform Provider.
-        link: /en/documentation/products/terraform-provider/
+      - icon: /assets/docs/images/uploads/icon-cli.svg
+        title: Azion CLI
+        description: >-
+          Create applications and manage services using command lines in a
+          terminal.
+        link: /en/documentation/products/azion-cli/overview/
       - icon: /assets/docs/images/uploads/vector.svg
         title: Azion Lib
         description: >-
           The Azion Libraries provide a suite of tools to interact with various Azion services.
         link: /en/documentation/products/azion-lib/overview/
+      - icon: /assets/docs/images/uploads/vector.svg
+        title: Console Kit
+        description: >-
+          Console Kit is a front-end development kit for crafting a customized Azion Console interface.
+        link: /en/documentation/devtools/console-kit/
+      - icon: /assets/docs/images/uploads/icon-api.svg
+        title: GraphQL API
+        description: 'Request the data you want and receive nothing more, nothing less.'
+        link: /en/documentation/devtools/graphql-api/
+      - icon: /assets/docs/images/uploads/vector.svg
+        title: SDK
+        description: >-
+          Develop applications using the programming language you're used to
+          work.
+        link: /en/documentation/devtools/sdk/go/
+      - icon: /assets/docs/images/uploads/vector.svg
+        title: Terraform
+        description: Manage your infrastructure as code using the Azion Terraform Provider.
+        link: /en/documentation/products/terraform-provider/
   - title: 'Choose your journey'
     cards:
       - icon: /assets/docs/images/uploads/icon-first-setps.svg

--- a/src/content/docs/pt-br/homes/doc-home.mdx
+++ b/src/content/docs/pt-br/homes/doc-home.mdx
@@ -86,24 +86,36 @@ product_cards:
         description: >- 
           Gerencie e monitore suas edge applications, serviços e recursos de forma eficiente.
         link: /pt-br/documentacao/produtos/guias/conhecendo-o-azion-console/
+      - icon: /assets/docs/images/uploads/icon-api.svg
+        title: API Azion
+        description: >-
+          Encontre documentação de referência com exemplos sobre as APIs da Azion.
+        link: 'https://api.azion.com/'
+      - icon: /assets/docs/images/uploads/icon-api.svg
+        title: API GraphQL
+        description: Solicite os dados que deseja e receba exatamente o que foi solicitado.
+        link: /pt-br/documentacao/devtools/graphql-api/
       - icon: /assets/docs/images/uploads/icon-cli.svg
         title: Azion CLI
         description: >-
           Crie aplicações e gerencie serviços usando linhas de comando no terminal.
         link: /pt-br/documentacao/produtos/azion-cli/visao-geral/
-      - icon: /assets/docs/images/uploads/icon-api.svg
-        title: Azion API
-        description: >-
-          Encontre documentação de referência com exemplos sobre as APIs da Azion.
-        link: 'https://api.azion.com/'
-      - icon: /assets/docs/images/uploads/vector.svg
-        title: Terraform
-        description: Gerencie sua IaC usando o Azion Terraform Provider.
-        link: /pt-br/documentacao/produtos/terraform-provider/
       - icon: /assets/docs/images/uploads/vector.svg
         title: Azion Lib
         description: As Azion Libraries fornecem um conjunto de ferramentas para interagir com vários serviços da Azion.
         link: /pt-br/documentacao/produtos/azion-lib/visao-geral/
+      - icon: /assets/docs/images/uploads/vector.svg
+        title: Console Kit
+        description: O Console Kit da Azion é um kit de desenvolvimento front-end para criar uma interface personalizada do Console da Azion.
+        link: /pt-br/documentacao/devtools/console-kit/
+      - icon: /assets/docs/images/uploads/vector.svg
+        title: SDK
+        description: Desenvolva aplicações utilizando o Azion SDK para a linguagem Go.
+        link: /pt-br/documentacao/devtools/sdk/go/
+      - icon: /assets/docs/images/uploads/vector.svg
+        title: Terraform
+        description: Gerencie sua IaC usando o Azion Terraform Provider.
+        link: /pt-br/documentacao/produtos/terraform-provider/
   - title: 'Escolha sua jornada'
     cards:
       - icon: /assets/docs/images/uploads/icon-first-setps.svg


### PR DESCRIPTION
Added missing devtools and reordered by name