### PR TITLE
[EDU-6277] [EDU-6279] feature: add new how-to guides to query data from the Consumption dataset

### DIFF
--- a/src/content/docs/en/pages/guides/graphql/query-edge-functions-usage-data.mdx
+++ b/src/content/docs/en/pages/guides/graphql/query-edge-functions-usage-data.mdx
@@ -1,0 +1,117 @@
+---
+title: How to query usage data from Edge Functions
+description: This guide explains how to query data from the Consumption dataset and check Edge Functions' compute time and invocations using the GraphiQL Playground.
+meta_tags: graphql, api, query, Edge Functions, compute time, invocations, usage data, consumption
+namespace: docs_guides_query_edge_functions_data_graphql
+permalink: /documentation/products/guides/query-edge-functions-usage-data-with-graphql/
+menu_namespace: graphqlMenu
+---
+
+The **workloadConsumptionMetrics** dataset lets you get real-time aggregated data related to consumption and usage of Azion products, including Edge Functions.
+
+The information can be accessed through the GraphQL API, allowing you to transfer this data to a third-party platform, and enabling you to further analyze and review. Additionally, the data is available for up to *6 months*.
+
+This guide explains how to query Edge Functions' compute time and invocations metrics using the [GraphiQL Playground](/en/documentation/products/devtools/graphql-playground/).
+
+---
+
+## Querying Edge Functions' usage data
+
+To query Edge Functions' compute time and invocations, proceed as follows:
+
+1. Access the GraphiQL playground going to the following link: `https://manager.azion.com/consumption/graphql`.
+    - You must be logged in to your Azion account. Otherwise, you'll receive an error message.
+2. Send a query following this format:
+
+```graphql
+query {
+  workloadConsumptionMetrics(
+    filter: {
+      tsRange: { 
+        begin: "2025-02-01T00:00:00",
+        end: "2025-03-01T00:00:00",
+      }
+      productId: 1531930033
+      metricNameIn: ["invocations", "compute_time"]
+    }
+    aggregate: {
+      sum: accounted
+    }
+    limit: 10000
+    groupBy: [clientId, workloadId, productId, metricName, region]
+  ) {
+    clientId
+    workloadId
+    productId
+    metricName
+    region
+    total: sum
+  }
+}
+```
+
+Where:
+
+| Field | Description |
+|----------|----------|
+| `filter` | Defines the criteria used to filter the data returned by the query. |
+| `tsRange` | A subfield of `filter`. Specifies a time range for filtering data. It includes `begin` and `end` fields to define the start and end timestamps. Format: `"YYYY-MM-DDTHH:mm:ss"`; example: `"2024-04-11T00:00:00"`. |
+| `sum: accounted` | As a subfield of `aggregate`, calculates the total accounted usage for events matching the query's filters and groups. |
+| `limit` | Specifies the maximum number of results to return. System maximum: `10000`. |
+| `groupBy` | Specifies the fields by which the query results should be grouped. Example: `[clientId, metricName]`. |
+| `productId` | Unique identifier of the product being used. In this case, `1531930033` for Edge Functions. |
+| `metricName` | Name of the calculated metric for analytics. Example: `invocations` or `compute_time`.  |
+
+:::note
+This example retrieves data for the total number of invocations or compute time used by Edge Functions. The results are grouped by `clientId` and `workloadId`. To learn more about the available fields, check the [Consumption GraphQL API Fields](/en/documentation/devtools/graphql-api/features/gql-consumption-fields/) documentation.
+:::
+
+3. You'll receive a JSON response similar to this: 
+
+```json
+{
+	"data": {
+		"workloadConsumptionMetrics": [
+			{
+				"clientId": "12345a",
+				"workloadId": 1234567890,
+				"productId": 1531930033,
+				"metricName": "invocations",
+				"region": "United States",
+				"Total": 816931
+			},
+			{
+				"clientId": "67890a",
+				"workloadId": 1987654321,
+				"productId": 1531930033,
+				"metricName": "invocations",
+				"region": "Europe",
+				"Total": 33134
+			},
+			{
+				"clientId": "111111b",
+				"workloadId": 1231231230,
+				"productId": 1531930033,
+				"metricName": "compute_time",
+				"region": "All Other Regions",
+				"Total": 436363.41
+			}
+		]
+	}
+}
+```
+
+Where:
+
+| Field | Description |
+|----------|----------|
+| `clientId` | Client unique identifier on Azion. Example: `8437r.` |
+| `workloadId` | Identifier for the workload associated with the usage. Example: `4829301746`. |
+| `productId` | Unique identifier of the product being used. In this case, `1531930033` for Edge Functions. |
+| `metricName` | Name of the measured metric for analytics. Example: `invocations` or `compute_time`.  |
+| `region` | Geographical region where the usage was recorded. Example: `Europe`. |
+| `total` | This field is the result of a sum. <br/> When querying `compute_time`:  total execution time for Edge Functions, measured in seconds. Example: `436363.41`. <br/> When querying `invocations`: total number of function invocations. Example: `33134`. |
+
+:::tip
+To know more about the available fields, check the [Consumption GraphQL API Fields](/en/documentation/devtools/graphql-api/features/gql-consumption-fields/) documentation.
+:::

--- a/src/content/docs/en/pages/guides/graphql/query-image-processor-usage-data.mdx
+++ b/src/content/docs/en/pages/guides/graphql/query-image-processor-usage-data.mdx
@@ -1,0 +1,126 @@
+---
+title: How to query usage data from Image Processor
+description: This guide explains how to query data from the Consumption dataset and check usage related to Image Processor using the GraphiQL Playground.
+meta_tags: graphql, api, query, Image Processor, usage data, consumption
+namespace: docs_guides_query_image_processor_data_graphql
+permalink: /documentation/products/guides/query-image-processor-usage-data-with-graphql/
+menu_namespace: graphqlMenu
+---
+
+The **workloadConsumptionMetrics** dataset lets you get real-time aggregated data related to consumption and usage of Azion products, including Image Processor.
+
+The information can be accessed through the GraphQL API, allowing you to transfer this data to a third-party platform, and enabling you to further analyze and review. Additionally, the data is available for up to *6 months*.
+
+This guide explains how to query images processed by Image Processor using the [GraphiQL Playground](/en/documentation/products/devtools/graphql-playground/).
+
+---
+
+## Querying Image Processor's usage data
+
+To query the total number of images processed by Image Processor, proceed as follows:
+
+1. Access the GraphiQL playground going to the following link: `https://manager.azion.com/consumption/graphql`.
+    - You must be logged in to your Azion account. Otherwise, you'll receive an error message.
+2. Send a query following this format:
+
+```graphql
+query {
+  workloadConsumptionMetrics(
+    filter: {
+      tsRange: { 
+        begin: "2025-02-01T00:00:00",
+        end: "2025-03-01T00:00:00",
+      }
+      productId: 1441110021
+      metricName: "images_processed"
+    }
+    aggregate: {
+      sum: accounted
+    }
+    limit: 10000
+    groupBy: [clientId, workloadId, productId, metricName]
+  ) {
+    clientId
+    workloadId
+    productId
+    metricName
+    total: sum
+  }
+}
+```
+
+Where:
+
+| Field | Description |
+|----------|----------|
+| `filter` | Defines the criteria used to filter the data returned by the query. |
+| `tsRange` | A subfield of `filter`. Specifies a time range for filtering data. It includes `begin` and `end` fields to define the start and end timestamps. Format: `"YYYY-MM-DDTHH:mm:ss"`; example: `"2024-04-11T00:00:00"`. |
+| `sum: accounted` | As a subfield of `aggregate`, calculates the total accounted usage for events matching the query's filters and groups. |
+| `limit` | Specifies the maximum number of results to return. System maximum: `10000`. |
+| `groupBy` | Specifies the fields by which the query results should be grouped. Example: `[clientId, metricName]`. |
+| `productId` | Unique identifier of the product being used. In this case, `1441110021` for Image Processor. |
+| `metricName` | Name of the calculated metric for analytics. In this case, `images_processed`. |
+
+:::note
+This example retrieves data for the total number (*sum*) of images processed by Image Processor. The results are grouped by `clientId` and `workloadId`. To learn more about the available fields, check the [Consumption GraphQL API Fields](/en/documentation/devtools/graphql-api/features/gql-consumption-fields/) documentation.
+:::
+
+3. You'll receive a JSON response similar to this: 
+
+```json
+{
+  "data": {
+    "workloadConsumptionMetrics": [
+      {
+        "clientId": "0000z",
+        "workloadId": 4829103746,
+        "productId": 1441110021,
+        "metricName": "images_processed",
+        "total": 32
+      },
+      {
+        "clientId": "0000z",
+        "workloadId": 1938475620,
+        "productId": 1441110021,
+        "metricName": "images_processed",
+        "total": 19478
+      },
+      {
+        "clientId": "0000z",
+        "workloadId": 7584931026,
+        "productId": 1441110021,
+        "metricName": "images_processed",
+        "total": 299612
+      },
+      {
+        "clientId": "0000z",
+        "workloadId": 6203849175,
+        "productId": 1441110021,
+        "metricName": "images_processed",
+        "total": 1432
+      },
+      {
+        "clientId": "0000z",
+        "workloadId": 3948571023,
+        "productId": 1441110021,
+        "metricName": "images_processed",
+        "total": 268675
+      }
+    ]
+  }
+}
+```
+
+Where:
+
+| Field | Description |
+|----------|----------|
+| `clientId` | Client unique identifier on Azion. Example: `8437r`. |
+| `workloadId` | Identifier for the workload associated with the usage. Example: `4829301746`. |
+| `productId` | Unique identifier of the product being used. In this case, `1441110021` for Image Processor. |
+| `metricName` | Name of the measured metric for analytics. Example: `images_processed`.  |
+| `total` | Total number of images processed by Image Processor. This field is the result of a sum. Example: `268675`. |
+
+:::tip
+To know more about the available fields, check the [Consumption GraphQL API Fields](/en/documentation/devtools/graphql-api/features/gql-consumption-fields/) documentation.
+:::

--- a/src/content/docs/en/pages/guides/index.mdx
+++ b/src/content/docs/en/pages/guides/index.mdx
@@ -210,6 +210,8 @@ permalink: /documentation/products/guides/
 - [How to query the top URLs impacted by bots with GraphQL API](/en/documentation/products/guides/query-bot-manager-breakdown-data-with-graphql/)
 - [How to identify the Top IPs generating attack traffic using GraphQL API](/en/documentation/products/guides/query-top-ips-attack-traffic-with-graphql/)
 - [How to identify the top attacks using GraphQL API](/en/documentation/products/guides/query-top-attacks-with-graphql/)
+- [How to query usage data from Edge Functions](/en/documentation/products/guides/query-edge-functions-usage-data-with-graphql/)
+- [How to query usage data from Image Processor](/en/documentation/products/guides/query-image-processor-usage-data-with-graphql/)
 
 ---
 

--- a/src/content/docs/pt-br/pages/guias/graphql/query-edge-functions-usage-data.mdx
+++ b/src/content/docs/pt-br/pages/guias/graphql/query-edge-functions-usage-data.mdx
@@ -1,0 +1,117 @@
+---
+title: Como consultar dados de uso de Edge Functions
+description: Este guia explica como consultar o conjunto de dados de Consumption e verificar o tempo de computação e invocações de Edge Functions usando o GraphiQL Playground.
+meta_tags: graphql, api, query, Edge Functions, compute time, tempo de computação, invocations, invocações, dados de uso, consumo
+namespace: docs_guides_query_edge_functions_data_graphql
+permalink: /documentacao/produtos/guias/consultar-dados-de-uso-edge-functions-com-graphql/
+menu_namespace: graphqlMenu
+---
+
+O conjunto de dados **workloadConsumptionMetrics** permite obter dados agregados em tempo real relacionados ao consumo e uso dos produtos Azion, incluindo Edge Functions.
+
+As informações podem ser acessadas através da API GraphQL, permitindo transferir esses dados para uma plataforma de terceiros, possibilitando uma análise e revisão mais aprofundadas. Além disso, os dados estão disponíveis por até *6 meses*.
+
+Este guia explica como consultar as métricas de tempo de computação e invocações de Edge Functions usando o [GraphiQL Playground](/pt-br/documentacao/produtos/devtools/playground-graphql/).
+
+---
+
+## Consulte dados de uso de Edge Functions
+
+Para consultar o tempo de computação e as invocações de Edge Functions, proceda da seguinte forma:
+
+1. Acesse o playground GraphiQL indo para o seguinte link: `https://manager.azion.com/consumption/graphql`.
+    - Você deve estar logado em sua conta Azion. Caso contrário, você receberá uma mensagem de erro.
+2. Envie uma consulta seguindo este formato:
+
+```graphql
+query {
+  workloadConsumptionMetrics(
+    filter: {
+      tsRange: { 
+        begin: "2025-02-01T00:00:00",
+        end: "2025-03-01T00:00:00",
+      }
+      productId: 1531930033
+      metricNameIn: ["invocations", "compute_time"]
+    }
+    aggregate: {
+      sum: accounted
+    }
+    limit: 10000
+    groupBy: [clientId, workloadId, productId, metricName, region]
+  ) {
+    clientId
+    workloadId
+    productId
+    metricName
+    region
+    total: sum
+  }
+}
+```
+
+Onde:
+
+| Campo | Descrição |
+|----------|----------|
+| `filter` | Define os critérios usados para filtrar os dados retornados pela consulta. |
+| `tsRange` | Um subcampo de `filter`. Especifica um intervalo de tempo para filtrar os dados. Inclui os campos `begin` e `end` para definir início e fim. Formato: `"YYYY-MM-DDTHH:mm:ss"`; exemplo: `"2024-04-11T00:00:00"`. |
+| `sum: accounted` | Como um subcampo de `aggregate`, calcula o uso total contabilizado para eventos que correspondem aos filtros e grupos da consulta. |
+| `limit` | Especifica o número máximo de resultados a serem retornados. Máximo do sistema: `10000`. |
+| `groupBy` | Especifica os campos pelos quais os resultados da consulta devem ser agrupados. Exemplo: `[clientId, metricName]`. |
+| `productId` | Identificador único do produto em uso. Neste caso, `1531930033` para Edge Functions. |
+| `metricName` | Nome da métrica calculada para análise. Exemplo: `invocations` ou `compute_time`.  |
+
+:::note
+Este exemplo recupera dados para o número total de invocações ou tempo de computação usado por Edge Functions. Os resultados são agrupados por `clientId` e `workloadId`. Para saber mais sobre os campos disponíveis, consulte a documentação dos [Campos da GraphQL API de Consumption](/pt-br/documentacao/devtools/graphql-api/recursos/campos-gql-consumption/).
+:::
+
+3. Você receberá uma resposta JSON semelhante a esta:
+
+```json
+{
+	"data": {
+		"workloadConsumptionMetrics": [
+			{
+				"clientId": "12345a",
+				"workloadId": 1234567890,
+				"productId": 1531930033,
+				"metricName": "invocations",
+				"region": "United States",
+				"Total": 816931
+			},
+			{
+				"clientId": "67890a",
+				"workloadId": 1987654321,
+				"productId": 1531930033,
+				"metricName": "invocations",
+				"region": "Europe",
+				"Total": 33134
+			},
+			{
+				"clientId": "111111b",
+				"workloadId": 1231231230,
+				"productId": 1531930033,
+				"metricName": "compute_time",
+				"region": "All Other Regions",
+				"Total": 436363.41
+			}
+		]
+	}
+}
+```
+
+Onde:
+
+| Campo | Descrição |
+|----------|----------|
+| `clientId` | Identificador único do cliente na Azion. Exemplo: `8437r.` |
+| `workloadId` | Identificador para o workload associado ao uso. Exemplo: `4829301746`. |
+| `productId` | Identificador único do produto em uso. Neste caso, `1531930033` para Edge Functions. |
+| `metricName` | Nome da métrica medida para análise. Exemplo: `invocations` ou `compute_time`.  |
+| `region` | Região geográfica onde o uso foi registrado. Exemplo: `Europe`. |
+| `total` | Este campo é o resultado de uma soma. <br/> Ao consultar `compute_time`: tempo total de execução para Edge Functions, medido em segundos. Exemplo: `436363.41`. <br/> Ao consultar `invocations`: total de invocações de funções. Exemplo: `33134`. |
+
+:::tip
+Para saber mais sobre os campos disponíveis, consulte a documentação dos [Campos da GraphQL API de Consumption](/pt-br/documentacao/devtools/graphql-api/recursos/campos-gql-consumption/).
+:::

--- a/src/content/docs/pt-br/pages/guias/graphql/query-image-processor-usage-data.mdx
+++ b/src/content/docs/pt-br/pages/guias/graphql/query-image-processor-usage-data.mdx
@@ -1,0 +1,126 @@
+---
+title: Como consultar dados de uso do Image Processor
+description: Este guia explica como consultar o conjunto de dados Consumption e verificar as imagens processadas pelo Image Processor usando o GraphiQL Playground.
+meta_tags: graphql, api, query, Image Processor, dados de uso, consumo
+namespace: docs_guides_query_image_processor_data_graphql
+permalink: /documentacao/produtos/guias/consultar-dados-de-uso-image-processor-com-graphql/
+menu_namespace: graphqlMenu
+---
+
+O conjunto de dados **workloadConsumptionMetrics** permite obter dados agregados em tempo real relacionados ao consumo e uso dos produtos Azion, incluindo o Image Processor.
+
+As informações podem ser acessadas através da API GraphQL, permitindo transferir esses dados para uma plataforma de terceiros, possibilitando uma análise e revisão mais aprofundadas. Além disso, os dados estão disponíveis por até *6 meses*.
+
+Este guia explica como consultar as imagens processadas pelo Image Processor usando o [GraphiQL Playground](/pt-br/documentacao/produtos/devtools/playground-graphql/).
+
+---
+
+## Consulte dados de uso do Image Processor
+
+Para consultar o total das imagens processadas pelo Image Processor, proceda da seguinte forma:
+
+1. Acesse o playground GraphiQL indo para o seguinte link: `https://manager.azion.com/consumption/graphql`.
+    - Você deve estar logado em sua conta Azion. Caso contrário, você receberá uma mensagem de erro.
+2. Envie uma consulta seguindo este formato:
+
+```graphql
+query {
+  workloadConsumptionMetrics(
+    filter: {
+      tsRange: { 
+        begin: "2025-02-01T00:00:00",
+        end: "2025-03-01T00:00:00",
+      }
+      productId: 1441110021
+      metricName: "images_processed"
+    }
+    aggregate: {
+      sum: accounted
+    }
+    limit: 10000
+    groupBy: [clientId, workloadId, productId, metricName]
+  ) {
+    clientId
+    workloadId
+    productId
+    metricName
+    total: sum
+  }
+}
+```
+
+Onde:
+
+| Campo | Descrição |
+|----------|----------|
+| `filter` | Define os critérios usados para filtrar os dados retornados pela consulta. |
+| `tsRange` | Um subcampo de `filter`. Especifica um intervalo de tempo para filtrar os dados. Inclui os campos `begin` e `end` para definir o início e fim. Formato: `"YYYY-MM-DDTHH:mm:ss"`; exemplo: `"2024-04-11T00:00:00"`. |
+| `sum: accounted` | Como um subcampo de `aggregate`, calcula o uso total contabilizado para eventos que correspondem aos filtros e grupos da consulta. |
+| `limit` | Especifica o número máximo de resultados a serem retornados. Máximo do sistema: `10000`. |
+| `groupBy` | Especifica os campos pelos quais os resultados da consulta devem ser agrupados. Exemplo: `[clientId, metricName]`. |
+| `productId` | Identificador único do produto em uso. Neste caso, `1441110021` para Image Processor. |
+| `metricName` | Nome da métrica calculada para análises. Neste caso, `images_processed`. |
+
+:::note
+Este exemplo recupera dados sobre o número total (*sum*) de imagens processadas pelo Image Processor. Os resultados são agrupados por `clientId` e `workloadId`. Para saber mais sobre os campos disponíveis, consulte a documentação dos [Campos da GraphQL API de Consumption](/pt-br/documentacao/devtools/graphql-api/recursos/campos-gql-consumption/).
+:::
+
+3. Você receberá uma resposta JSON semelhante a esta:
+
+```json
+{
+  "data": {
+    "workloadConsumptionMetrics": [
+      {
+        "clientId": "0000z",
+        "workloadId": 4829103746,
+        "productId": 1441110021,
+        "metricName": "images_processed",
+        "total": 32
+      },
+      {
+        "clientId": "0000z",
+        "workloadId": 1938475620,
+        "productId": 1441110021,
+        "metricName": "images_processed",
+        "total": 19478
+      },
+      {
+        "clientId": "0000z",
+        "workloadId": 7584931026,
+        "productId": 1441110021,
+        "metricName": "images_processed",
+        "total": 299612
+      },
+      {
+        "clientId": "0000z",
+        "workloadId": 6203849175,
+        "productId": 1441110021,
+        "metricName": "images_processed",
+        "total": 1432
+      },
+      {
+        "clientId": "0000z",
+        "workloadId": 3948571023,
+        "productId": 1441110021,
+        "metricName": "images_processed",
+        "total": 268675
+      }
+    ]
+  }
+}
+```
+
+Where:
+
+| Field | Description |
+|----------|----------|
+| `clientId` | Client unique identifier on Azion. Example: `8437r`. |
+| `workloadId` | Identifier for the workload associated with the usage. Example: `4829301746`. |
+| `productId` | Unique identifier of the product being used. In this case, `1441110021` for Image Processor. |
+| `metricName` | Name of the measured metric for analytics. Example: `images_processed`.  |
+| `total` | Total number of images processed by Image Processor. This field is the result of a sum. Example: `268675`. |
+
+:::tip
+Para saber mais sobre os campos disponíveis, consulte a documentação dos [Campos da GraphQL API de Consumption](/pt-br/documentacao/devtools/graphql-api/recursos/campos-gql-consumption/).
+:::

--- a/src/content/docs/pt-br/pages/guias/guides.mdx
+++ b/src/content/docs/pt-br/pages/guias/guides.mdx
@@ -210,6 +210,8 @@ permalink: /documentacao/produtos/guias/
 - [Como consultar as principais URLs impactadas por bots com a GraphQL API](/pt-br/documentacao/produtos/guias/consultar-dados-bot-manager-breakdown-com-graphql/)
 - [Como identificar os principais IPs gerando tráfego de ataque com a API GraphQL](/pt-br/documentacao/produtos/guias/consultar-top-ips-gerando-trafego-de-ataque-com-graphql/)
 - [Como identificar os principais ataques usando a API GraphQL](/pt-br/documentacao/produtos/guias/consultar-top-attacks-com-graphql/)
+- [Como consultar dados de uso de Edge Functions](/pt-br/documentacao/produtos/guias/consultar-dados-de-uso-edge-functions-com-graphql/)
+- [Como consultar dados de uso do Image Processor](/pt-br/documentacao/produtos/guias/consultar-dados-de-uso-image-processor-com-graphql/)
 
 ---
 

--- a/src/i18n/en/graphqlMenu.ts
+++ b/src/i18n/en/graphqlMenu.ts
@@ -40,7 +40,10 @@
 		{ text: 'How to query Bot Manager data', slug: '/documentation/products/guides/query-bot-manager-data-with-graphql/', key: 'guides/bot-data-graphql' },
 		{ text: 'How to query the top URLs impacted by bots', slug: '/documentation/products/guides/query-bot-manager-breakdown-data-with-graphql/', key: 'guides/bot-breakdown-data-graphql' },
 		{ text: 'How to identify the Top IPs generating attack traffic', slug: '/documentation/products/guides/query-top-ips-attack-traffic-with-graphql/', key: 'guides/top-ips-graphql' },
-		{ text: 'How to identify the top attacks', slug: '/documentation/products/guides/query-top-attacks-with-graphql/', key: 'guides/bot-top-attacks-graphql' }
+		{ text: 'How to identify the top attacks', slug: '/documentation/products/guides/query-top-attacks-with-graphql/', key: 'guides/bot-top-attacks-graphql' },
+		{ text: 'How to query usage data from Edge Functions', slug: '/documentation/products/guides/query-edge-functions-usage-data-with-graphql/', key: 'guides/edge-functions-usage-data' },
+		{ text: 'How to query usage data from Image Processor', slug: '/documentation/products/guides/query-image-processor-usage-data-with-graphql/', key: 'guides/image-processor-usage-data' }
+
 
 	] },
 

--- a/src/i18n/pt-br/graphqlMenu.ts
+++ b/src/i18n/pt-br/graphqlMenu.ts
@@ -41,7 +41,10 @@
 		{ text: 'Como consultar dados do Bot Manager', slug: '/documentacao/produtos/guias/consultar-dados-bot-manager-com-graphql/', key: 'guides/bot-data-graphql' },
 		{ text: 'Como consultar as principais URLs impactadas por bots', slug: '/documentacao/produtos/guias/consultar-dados-bot-manager-breakdown-com-graphql/', key: 'guides/bot-breakdown-data-graphql' },
 		{ text: 'Como identificar os principais IPs gerando tráfego de ataque', slug: '/documentacao/produtos/guias/consultar-top-ips-gerando-trafego-de-ataque-com-graphql/', key: 'guides/top-ips-graphql' },
-		{ text: 'Como identificar os principais ataques ', slug: '/documentacao/produtos/guias/consultar-top-attacks-com-graphql/', key: 'guides/bot-top-attacks-graphql' }
+		{ text: 'Como identificar os principais ataques', slug: '/documentacao/produtos/guias/consultar-top-attacks-com-graphql/', key: 'guides/bot-top-attacks-graphql' },
+		{ text: 'Como consultar dados de uso de Edge Functions', slug: '/documentacao/produtos/guias/consultar-dados-de-uso-edge-functions-com-graphql/', key: 'guides/edge-functions-usage-data' },
+		{ text: 'Como consultar dados de uso do Image Processor', slug: '/documentacao/produtos/guias/consultar-dados-de-uso-image-processor-com-graphql/', key: 'guides/image-processor-usage-data' }
+
 	] },
 
 


### PR DESCRIPTION
### Related issue:

[EDU-6277] [EDU-6279] 

### Changes

- Add new how-to guides to query data from the Consumption dataset: Edge Functions and Image Proccesor.
- Add link to the Guides page.
- Add label to Menu.

### Additional links

n/a.

[EDU-6277]: https://aziontech.atlassian.net/browse/EDU-6277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EDU-6279]: https://aziontech.atlassian.net/browse/EDU-6279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ