### PR TITLE
[PMK-9313] feature: add Consumption dataset to the Release Notes page

### DIFF
--- a/src/content/docs/en/pages/main-menu/release-notes/release-notes.mdx
+++ b/src/content/docs/en/pages/main-menu/release-notes/release-notes.mdx
@@ -9,6 +9,16 @@ permalink: /documentation/products/release-notes/
 ---
 import Tag from 'primevue/tag'
 
+## March 10, 2025
+
+### GraphQL API 
+
+The GraphQL API now includes the **Consumption** dataset, offering detailed insights into product usage and the metrics accounted for in the client's account.
+
+Explore more about the [GraphQL API](/en/documentation/devtools/graphql-api/overview/) and the [Consumption dataset](/en/documentation/devtools/graphql-api/features/gql-consumption-fields/)
+
+---
+
 ## February 11, 2025
 
 ### Azion Templates

--- a/src/content/docs/pt-br/pages/menu-principal/release-notes/release-notes.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/release-notes/release-notes.mdx
@@ -9,6 +9,16 @@ permalink: /documentacao/produtos/release-notes/
 ---
 import Tag from 'primevue/tag'
 
+## 10 de março, 2025
+
+### API GraphQL  
+
+A API GraphQL agora inclui o conjunto de dados **Consumption**, oferecendo insights detalhados sobre o uso de produtos e as métricas contabilizadas na conta do cliente.  
+
+Saiba mais sobre a [API GraphQL](/pt-br/documentacao/devtools/graphql-api/visao-geral/) e o [conjunto de dados Consumption](/pt-br/documentacao/devtools/graphql-api/recursos/campos-gql-consumption/).
+
+---
+
 ## 11 de fevereiro, 2025
 
 ### Azion Templates


### PR DESCRIPTION
### Related issue: 

[PMK-9313] 

### Changes

 add new item to the Release Notes page to communicate the Consumption dataset launch.

### Additional links

n/a.

[PMK-9313]: https://aziontech.atlassian.net/browse/PMK-9313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ