### PR TITLE
[EDU-6328] fix: Added valid chars to the add header section in rules engine doc

### DIFF
--- a/src/content/docs/en/pages/main-menu/reference/build/edge-application/rules-engine.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/build/edge-application/rules-engine.mdx
@@ -250,6 +250,12 @@ The field name may contain only letters (a-z, A-Z), numbers (0-9), hyphens (-), 
 | Name         | (a-z, A-Z, 0-9), (-, _ )                              |
 | Value        | (a-z, A-Z, 0-9), (\_ :;.,\/"'?!(){}[]@&lt;&gt;=-+*#$&`\|~^%) |
 
+For example, this would be a valid header:
+
+```bash
+example-field: example-value!
+```
+
 ### Bypass Cache
 <Tag severity="info" client:only="vue">Request Phase</Tag>
 [<Tag severity="info" client:only="vue">Requires Application Accelerator</Tag>](/en/documentation/products/build/edge-application/application-accelerator/)

--- a/src/content/docs/en/pages/main-menu/reference/build/edge-application/rules-engine.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/build/edge-application/rules-engine.mdx
@@ -241,6 +241,15 @@ Adds a header field to the request that will be sent to the origin or to the res
 
 The header field must be informed as an argument in the format `Field: value`.
 
+:::tip
+The field name may contain only letters (a-z, A-Z), numbers (0-9), hyphens (-), and underscores (_). Using any other characters will result in an invalid header.
+:::
+
+| Header field | Allowed Characters                                    |
+| ------------ | ----------------------------------------------------- |
+| Name         | (a-z, A-Z, 0-9), (-, _ )                              |
+| Value        | (a-z, A-Z, 0-9), (\_ :;.,\/"'?!(){}[]@&lt;&gt;=-+*#$&`\|~^%) |
+
 ### Bypass Cache
 <Tag severity="info" client:only="vue">Request Phase</Tag>
 [<Tag severity="info" client:only="vue">Requires Application Accelerator</Tag>](/en/documentation/products/build/edge-application/application-accelerator/)

--- a/src/content/docs/en/pages/main-menu/reference/build/edge-application/rules-engine.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/build/edge-application/rules-engine.mdx
@@ -242,7 +242,7 @@ Adds a header field to the request that will be sent to the origin or to the res
 The header field must be informed as an argument in the format `Field: value`.
 
 :::tip
-The field name may contain only letters (a-z, A-Z), numbers (0-9), hyphens (-), and underscores (_). Using any other characters will result in an invalid header.
+The field name may contain only letters (a-z, A-Z), numbers (0-9), hyphens (-), and/or underscores (_). Using any other characters will result in an invalid header.
 :::
 
 | Header field | Allowed Characters                                    |

--- a/src/content/docs/en/pages/main-menu/reference/build/edge-application/rules-engine.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/build/edge-application/rules-engine.mdx
@@ -245,7 +245,7 @@ The header field must be informed as an argument in the format `Field: value`.
 The `name` field may contain only letters (a-z, A-Z), numbers (0-9), hyphens (-), and/or underscores (_). Using any other characters will result in an invalid header.
 :::
 
-| Header field | Allowed Characters                                    |
+| Header field | Allowed characters                                    |
 | ------------ | ----------------------------------------------------- |
 | Name         | (a-z, A-Z, 0-9), (-, _ )                              |
 | Value        | (a-z, A-Z, 0-9), (\_ :;.,\/"'?!(){}[]@&lt;&gt;=-+*#$&`\|~^%) |

--- a/src/content/docs/en/pages/main-menu/reference/build/edge-application/rules-engine.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/build/edge-application/rules-engine.mdx
@@ -242,7 +242,7 @@ Adds a header field to the request that will be sent to the origin or to the res
 The header field must be informed as an argument in the format `Field: value`.
 
 :::tip
-The field name may contain only letters (a-z, A-Z), numbers (0-9), hyphens (-), and/or underscores (_). Using any other characters will result in an invalid header.
+The `name` field may contain only letters (a-z, A-Z), numbers (0-9), hyphens (-), and/or underscores (_). Using any other characters will result in an invalid header.
 :::
 
 | Header field | Allowed Characters                                    |

--- a/src/content/docs/pt-br/pages/menu-principal/referencia/build/edge-application/rules-engine-edge-app.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/referencia/build/edge-application/rules-engine-edge-app.mdx
@@ -243,6 +243,15 @@ Você também pode usar variáveis no lugar de valores. Por exemplo: `Path=${uri
 
 Adiciona um campo de cabeçalho na requisição que será enviada a origem ou na resposta que será enviada para o usuário. O campo de cabeçalho deve ser informado como argumento no formato `Field: value`.
 
+:::tip
+O field-name  pode conter apenas letras (a-z, A-Z), números (0-9), hífens (-) e underlines (_). O Uso de qualquer outro caractere tornará o cabeçalho inválido.
+:::
+
+| Header field | Caracteres permitidos                                 |
+| ------------ | ----------------------------------------------------- |
+| Name         | (a-z, A-Z, 0-9), (-, _ )                              |
+| Value        | (a-z, A-Z, 0-9), (\_ :;.,\/"'?!(){}[]@&lt;&gt;=-+*#$&`\|~^%) |
+
 ### Filtrar Header
 <Tag severity="info" client:only="vue">Request Phase</Tag> <Tag severity="info" client:only="vue">Response Phase</Tag>
 

--- a/src/content/docs/pt-br/pages/menu-principal/referencia/build/edge-application/rules-engine-edge-app.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/referencia/build/edge-application/rules-engine-edge-app.mdx
@@ -244,7 +244,7 @@ Você também pode usar variáveis no lugar de valores. Por exemplo: `Path=${uri
 Adiciona um campo de cabeçalho na requisição que será enviada a origem ou na resposta que será enviada para o usuário. O campo de cabeçalho deve ser informado como argumento no formato `Field: value`.
 
 :::tip
-O field-name  pode conter apenas letras (a-z, A-Z), números (0-9), hífens (-) e underlines (_). O Uso de qualquer outro caractere tornará o cabeçalho inválido.
+O field name pode conter apenas letras (a-z, A-Z), números (0-9), hífens (-) e underlines (_). O Uso de qualquer outro caractere tornará o cabeçalho inválido.
 :::
 
 | Header field | Caracteres permitidos                                 |

--- a/src/content/docs/pt-br/pages/menu-principal/referencia/build/edge-application/rules-engine-edge-app.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/referencia/build/edge-application/rules-engine-edge-app.mdx
@@ -244,7 +244,7 @@ Você também pode usar variáveis no lugar de valores. Por exemplo: `Path=${uri
 Adiciona um campo de cabeçalho na requisição que será enviada a origem ou na resposta que será enviada para o usuário. O campo de cabeçalho deve ser informado como argumento no formato `Field: value`.
 
 :::tip
-O field name pode conter apenas letras (a-z, A-Z), números (0-9), hífens (-) e underlines (_). O Uso de qualquer outro caractere tornará o cabeçalho inválido.
+O field `name` pode conter apenas letras (a-z, A-Z), números (0-9), hífens (-) e underlines (_). O uso de qualquer outro caractere tornará o cabeçalho inválido.
 :::
 
 | Campo do cabeçalho | Caracteres permitidos                                 |

--- a/src/content/docs/pt-br/pages/menu-principal/referencia/build/edge-application/rules-engine-edge-app.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/referencia/build/edge-application/rules-engine-edge-app.mdx
@@ -252,6 +252,12 @@ O field `name` pode conter apenas letras (a-z, A-Z), números (0-9), hífens (-)
 | Name         | (a-z, A-Z, 0-9), (-, _ )                              |
 | Value        | (a-z, A-Z, 0-9), (\_ :;.,\/"'?!(){}[]@&lt;&gt;=-+*#$&`\|~^%) |
 
+Por exemplo, este seria um cabeçalho válido:
+
+```
+example-field: example-value!
+```
+
 ### Filtrar Header
 <Tag severity="info" client:only="vue">Request Phase</Tag> <Tag severity="info" client:only="vue">Response Phase</Tag>
 

--- a/src/content/docs/pt-br/pages/menu-principal/referencia/build/edge-application/rules-engine-edge-app.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/referencia/build/edge-application/rules-engine-edge-app.mdx
@@ -247,7 +247,7 @@ Adiciona um campo de cabeçalho na requisição que será enviada a origem ou na
 O field name pode conter apenas letras (a-z, A-Z), números (0-9), hífens (-) e underlines (_). O Uso de qualquer outro caractere tornará o cabeçalho inválido.
 :::
 
-| Header field | Caracteres permitidos                                 |
+| Campo do cabeçalho | Caracteres permitidos                                 |
 | ------------ | ----------------------------------------------------- |
 | Name         | (a-z, A-Z, 0-9), (-, _ )                              |
 | Value        | (a-z, A-Z, 0-9), (\_ :;.,\/"'?!(){}[]@&lt;&gt;=-+*#$&`\|~^%) |


### PR DESCRIPTION
Added valid chars to the add header section in rules engine doc