### PR TITLE
[EDU-6336] fix: update URLs for the GraphiQL Playground

### DIFF
--- a/src/content/docs/en/pages/devtools/api-graphql/first-steps/first-steps.mdx
+++ b/src/content/docs/en/pages/devtools/api-graphql/first-steps/first-steps.mdx
@@ -38,7 +38,7 @@ After creating your personal token, head to the API platform you'll be using and
 
 ---
 
-## Accessing GraphQL playground
+## Accessing the GraphiQL Playground
 
 You can use Azion **GraphQL** built-in playground to write, validate, and test GraphQL queries. Using the playground can help you become more familiar with the API and the use of queries in a visual and quick manner.
 
@@ -46,11 +46,11 @@ To interact with the GraphQL playground, you first need to log in to [Azion Cons
 
 After successfully logging in to **Azion Console**, go to one of the links:
 
-- `https://manager.azion.com/metrics/graphql`
-- `https://manager.azion.com/events/graphql`
-- `https://manager.azion.com/billing/graphql`
-- `https://manager.azion.com/accounting/graphql`
-- `https://manager.azion.com/consumption/graphql`
+- `https://api.azion.com/v4/metrics/graphql`
+- `https://api.azion.com/v4/events/graphql`
+- `https://api.azion.com/v4/billing/graphql`
+- `https://api.azion.com/v4/accounting/graphql`
+- `https://api.azion.com/v4/consumption/graphql`
 
 Feel free to interact with the GraphQL API playground.
 

--- a/src/content/docs/en/pages/devtools/api-graphql/first-steps/first-steps.mdx
+++ b/src/content/docs/en/pages/devtools/api-graphql/first-steps/first-steps.mdx
@@ -42,7 +42,7 @@ After creating your personal token, head to the API platform you'll be using and
 
 You can use Azion **GraphQL** built-in playground to write, validate, and test GraphQL queries. Using the playground can help you become more familiar with the API and the use of queries in a visual and quick manner.
 
-To interact with the GraphQL playground, you first need to log in to [Azion Console](https://console.azion.com). If you haven't created an account, see the [Creating an account on Azion](/en/documentation/products/accounts/creating-account/) documentation page.
+To interact with the GraphiQL Playground, you must first log in to [Azion Console](https://console.azion.com). If you haven't created an account, check the [Creating an account on Azion](/en/documentation/products/accounts/creating-account/) documentation page.
 
 After successfully logging in to **Azion Console**, go to one of the links:
 
@@ -52,7 +52,7 @@ After successfully logging in to **Azion Console**, go to one of the links:
 - `https://api.azion.com/v4/accounting/graphql`
 - `https://api.azion.com/v4/consumption/graphql`
 
-Feel free to interact with the GraphQL API playground.
+Feel free to interact with the GraphiQL Playground.
 
 :::tip
 After you execute a query, the URL path is updated with an encoded parameter of the specific query you're using. You can copy and share the URL with other users so they can use the same query.

--- a/src/content/docs/en/pages/devtools/api-graphql/first-steps/first-steps.mdx
+++ b/src/content/docs/en/pages/devtools/api-graphql/first-steps/first-steps.mdx
@@ -30,11 +30,11 @@ When creating a personal token, you'll have to set an *expiration date*. For use
 
 After creating your personal token, head to the API platform you'll be using and include the Azion GraphQL API endpoint in your request:
 
-- To use the Real-Time Metrics API for aggregated data, include: `https://api.azionapi.net/metrics/graphql`
-- To use the Real-Time Events API for raw data, include: `https://api.azionapi.net/events/graphql`
-- To use the Billing API for financial data, include: `https://api.azionapi.net/billing/graphql`
-- To use the Accounting API for financial data, include: `https://api.azionapi.net/accounting/graphql`
-- To use the Consumption API for usage data, include: `https://api.azionapi.net/consumption/graphql`
+- To use the Real-Time Metrics API for aggregated data, include: `https://api.azion.com/v4/metrics/graphql`
+- To use the Real-Time Events API for raw data, include: `https://api.azion.com/v4/events/graphql`
+- To use the Billing API for financial data, include: `https://api.azion.com/v4/billing/graphql`
+- To use the Accounting API for financial data, include: `https://api.azion.com/v4/accounting/graphql`
+- To use the Consumption API for usage data, include: `https://api.azion.com/v4/consumption/graphql`
 
 ---
 

--- a/src/content/docs/en/pages/guides/graphql/bot-manager-breakdown-data.mdx
+++ b/src/content/docs/en/pages/guides/graphql/bot-manager-breakdown-data.mdx
@@ -23,7 +23,7 @@ To retrieve this data, you must be subscribed to Azion Bot Manager and use the [
 
 To query the top 5 URLs impacted by bot activity, proceed as follows:
 
-1. Access the GraphiQL playground in this link: `https://api.azion.com/v4/metrics/graphql`.
+1. Access the GraphiQL Playground at this link: `https://api.azion.com/v4/metrics/graphql`.
     - You must be logged in to your Azion account. Otherwise, you'll receive an error message.
 2. Send a query following this format:
 

--- a/src/content/docs/en/pages/guides/graphql/bot-manager-breakdown-data.mdx
+++ b/src/content/docs/en/pages/guides/graphql/bot-manager-breakdown-data.mdx
@@ -23,7 +23,7 @@ To retrieve this data, you must be subscribed to Azion Bot Manager and use the [
 
 To query the top 5 URLs impacted by bot activity, proceed as follows:
 
-1. Access the GraphiQL playground in this link: `https://manager.azion.com/metrics/graphql`.
+1. Access the GraphiQL playground in this link: `https://api.azion.com/v4/metrics/graphql`.
     - You must be logged in to your Azion account. Otherwise, you'll receive an error message.
 2. Send a query following this format:
 

--- a/src/content/docs/en/pages/guides/graphql/connected-users-dataset.mdx
+++ b/src/content/docs/en/pages/guides/graphql/connected-users-dataset.mdx
@@ -23,7 +23,7 @@ To retrieve this data, you must be subscribed to [Azion Live Ingest](https://www
 
 To query your data by host, proceed as follows:
 
-1. Access the GraphiQL playground going to the following link: `https://manager.azion.com/metrics/graphql`.
+1. Access the GraphiQL playground going to the following link: `https://api.azion.com/v4/metrics/graphql`.
     - You must be logged in to your Azion account. Otherwise, you'll receive an error message.
 2. Send a query following this format:
 
@@ -105,7 +105,7 @@ Where:
 
 To retrieve total values, without filtering by host, you must use the field `uniqueSessionsTotal`:
 
-1. Access the [GraphiQL playground](https://manager.azion.com/metrics/graphql)
+1. Access the GraphiQL playground by following this link: `https://api.azion.com/v4/metrics/graphql`
     - You must be logged in to your Azion account. Otherwise, you'll receive an error message.
 2. Send a query following this format:
 

--- a/src/content/docs/en/pages/guides/graphql/connected-users-dataset.mdx
+++ b/src/content/docs/en/pages/guides/graphql/connected-users-dataset.mdx
@@ -23,7 +23,7 @@ To retrieve this data, you must be subscribed to [Azion Live Ingest](https://www
 
 To query your data by host, proceed as follows:
 
-1. Access the GraphiQL playground going to the following link: `https://api.azion.com/v4/metrics/graphql`.
+1. Access the GraphiQL Playground by going to the following link: `https://api.azion.com/v4/metrics/graphql`.
     - You must be logged in to your Azion account. Otherwise, you'll receive an error message.
 2. Send a query following this format:
 
@@ -105,7 +105,7 @@ Where:
 
 To retrieve total values, without filtering by host, you must use the field `uniqueSessionsTotal`:
 
-1. Access the GraphiQL playground by following this link: `https://api.azion.com/v4/metrics/graphql`
+1. Access the GraphiQL Playground by following this link: `https://api.azion.com/v4/metrics/graphql`
     - You must be logged in to your Azion account. Otherwise, you'll receive an error message.
 2. Send a query following this format:
 

--- a/src/content/docs/en/pages/guides/graphql/query-bot-manager-data.mdx
+++ b/src/content/docs/en/pages/guides/graphql/query-bot-manager-data.mdx
@@ -23,7 +23,7 @@ To retrieve this data, you must be subscribed to Azion Bot Manager and use the [
 
 To query your data, proceed as follows:
 
-1. Access the GraphiQL playground going to the following link: `https://manager.azion.com/metrics/graphql`.
+1. Access the GraphiQL playground by going to the following link: `https://api.azion.com/v4/metrics/graphql`.
     - You must be logged in to your Azion account. Otherwise, you'll receive an error message.
 2. Send a query following this format:
 

--- a/src/content/docs/en/pages/guides/graphql/query-bot-manager-data.mdx
+++ b/src/content/docs/en/pages/guides/graphql/query-bot-manager-data.mdx
@@ -23,7 +23,7 @@ To retrieve this data, you must be subscribed to Azion Bot Manager and use the [
 
 To query your data, proceed as follows:
 
-1. Access the GraphiQL playground by going to the following link: `https://api.azion.com/v4/metrics/graphql`.
+1. Access the GraphiQL Playground at the following link: `https://api.azion.com/v4/metrics/graphql`.
     - You must be logged in to your Azion account. Otherwise, you'll receive an error message.
 2. Send a query following this format:
 

--- a/src/content/docs/en/pages/guides/graphql/query-edge-functions-usage-data.mdx
+++ b/src/content/docs/en/pages/guides/graphql/query-edge-functions-usage-data.mdx
@@ -19,7 +19,7 @@ This guide explains how to query Edge Functions' compute time and invocations me
 
 To query Edge Functions' compute time and invocations, proceed as follows:
 
-1. Access the GraphiQL playground by going to the following link: `https://api.azion.com/v4/consumption/graphql`.
+1. Access the GraphiQL Playground by going to the following link: `https://api.azion.com/v4/consumption/graphql`.
     - You must be logged in to your Azion account. Otherwise, you'll receive an error message.
 2. Send a query following this format:
 

--- a/src/content/docs/en/pages/guides/graphql/query-edge-functions-usage-data.mdx
+++ b/src/content/docs/en/pages/guides/graphql/query-edge-functions-usage-data.mdx
@@ -19,7 +19,7 @@ This guide explains how to query Edge Functions' compute time and invocations me
 
 To query Edge Functions' compute time and invocations, proceed as follows:
 
-1. Access the GraphiQL playground going to the following link: `https://manager.azion.com/consumption/graphql`.
+1. Access the GraphiQL playground by going to the following link: `https://api.azion.com/v4/consumption/graphql`.
     - You must be logged in to your Azion account. Otherwise, you'll receive an error message.
 2. Send a query following this format:
 

--- a/src/content/docs/en/pages/guides/graphql/query-image-processor-usage-data.mdx
+++ b/src/content/docs/en/pages/guides/graphql/query-image-processor-usage-data.mdx
@@ -19,7 +19,7 @@ This guide explains how to query images processed by Image Processor using the [
 
 To query the total number of images processed by Image Processor, proceed as follows:
 
-1. Access the GraphiQL playground going to the following link: `https://manager.azion.com/consumption/graphql`.
+1. Access the GraphiQL playground by going to the following link: `https://api.azion.com/v4/consumption/graphql`.
     - You must be logged in to your Azion account. Otherwise, you'll receive an error message.
 2. Send a query following this format:
 

--- a/src/content/docs/en/pages/guides/graphql/query-image-processor-usage-data.mdx
+++ b/src/content/docs/en/pages/guides/graphql/query-image-processor-usage-data.mdx
@@ -19,7 +19,7 @@ This guide explains how to query images processed by Image Processor using the [
 
 To query the total number of images processed by Image Processor, proceed as follows:
 
-1. Access the GraphiQL playground by going to the following link: `https://api.azion.com/v4/consumption/graphql`.
+1. Access the GraphiQL Playground by going to the following link: `https://api.azion.com/v4/consumption/graphql`.
     - You must be logged in to your Azion account. Otherwise, you'll receive an error message.
 2. Send a query following this format:
 

--- a/src/content/docs/en/pages/guides/graphql/query-top-attacks.mdx
+++ b/src/content/docs/en/pages/guides/graphql/query-top-attacks.mdx
@@ -15,7 +15,7 @@ You can use information from the `httpMetrics` dataset to monitor traffic patter
 
 To query the Top 5 attacks, identified by the WAF and ranked by occurrence, proceed as follows:
 
-1. Access the GraphiQL Playground at this link: `https://manager.azion.com/metrics/graphql`.
+1. Access the GraphiQL Playground at this link: `https://api.azion.com/v4/metrics/graphql`.
     - You must be logged in to your Azion account. Otherwise, you'll receive an error message.
 2. Send a query following this format:
 

--- a/src/content/docs/en/pages/guides/graphql/query-top-ips.mdx
+++ b/src/content/docs/en/pages/guides/graphql/query-top-ips.mdx
@@ -15,7 +15,7 @@ You can use information from the `httpEvents` dataset to monitor traffic pattern
 
 To query the Top 5 IPs generating attack traffic, according to the WAF, proceed as follows:
 
-1. Access the GraphiQL Playground at this link: `https://manager.azion.com/metrics/graphql`.
+1. Access the GraphiQL Playground at this link: `https://api.azion.com/v4/metrics/graphql`.
     - You must be logged in to your Azion account. Otherwise, you'll receive an error message.
 2. Send a query following this format:
 

--- a/src/content/docs/en/pages/observe-journey/real-time-events/analyze-logs/investigate-requests.mdx
+++ b/src/content/docs/en/pages/observe-journey/real-time-events/analyze-logs/investigate-requests.mdx
@@ -19,10 +19,10 @@ Change the countries in this example to the ones that best fit your application 
 
 See the steps described in this guide to investigate requests and the next steps to resolve the situation if you're being attacked.
 
-## Using GraphQL API playground for investigation
+## Using GraphiQL Playground for investigation
 
 1. Make sure you're logged in on your Azion account, via [Azion Console](https://console.azion.com).
-2. Access Real-Time Events GraphQL API Playground by going to the following link: `https://api.azion.com/v4/events/graphql`.
+2. Access Real-Time Events GraphiQL Playground by going to the following link: `https://api.azion.com/v4/events/graphql`.
   - You must be logged in to your Azion account. Otherwise, you'll receive an error message.
 3. Create a query with the filter and time range you want to use.
 
@@ -32,7 +32,7 @@ See the steps described in this guide to investigate requests and the next steps
 
 Begin your investigation with a query focused on the countries making requests.
 
-1. In Real-Time Events GraphQL API [Playground](https://api.azion.com/v4/events/graphql), add the following query:
+1. In Real-Time Events GraphiQL [Playground](https://api.azion.com/v4/events/graphql), add the following query:
 
 ```graphql
 query requestsInvestigationCountries {

--- a/src/content/docs/en/pages/observe-journey/real-time-events/analyze-logs/investigate-requests.mdx
+++ b/src/content/docs/en/pages/observe-journey/real-time-events/analyze-logs/investigate-requests.mdx
@@ -22,7 +22,7 @@ See the steps described in this guide to investigate requests and the next steps
 ## Using GraphQL API playground for investigation
 
 1. Make sure you're logged in on your Azion account, via [Azion Console](https://console.azion.com).
-2. Access Real-Time Events GraphQL API playground going to the following link: `https://api.azion.com/v4/events/graphql`.
+2. Access Real-Time Events GraphQL API Playground by going to the following link: `https://api.azion.com/v4/events/graphql`.
   - You must be logged in to your Azion account. Otherwise, you'll receive an error message.
 3. Create a query with the filter and time range you want to use.
 
@@ -32,7 +32,7 @@ See the steps described in this guide to investigate requests and the next steps
 
 Begin your investigation with a query focused on the countries making requests.
 
-1. In Real-Time Events GraphQL API [playground](https://api.azion.com/v4/events/graphql), add the following query:
+1. In Real-Time Events GraphQL API [Playground](https://api.azion.com/v4/events/graphql), add the following query:
 
 ```graphql
 query requestsInvestigationCountries {
@@ -169,7 +169,7 @@ query requestsInvestigationStatus {
 
 Next, you'll investigate the `User-Agent` header being used in the requests from the countries you've blocked, to create other rules and further improve your security.
 
-1. On [Real-Time Events GraphQL's playground](https://api.azion.com/v4/events/graphql), run the following query:
+1. On [Real-Time Events GraphQL's Playground](https://api.azion.com/v4/events/graphql), run the following query:
 
 ```graphql
 query requestsInvestigationUserAgent {

--- a/src/content/docs/en/pages/observe-journey/real-time-events/analyze-logs/investigate-requests.mdx
+++ b/src/content/docs/en/pages/observe-journey/real-time-events/analyze-logs/investigate-requests.mdx
@@ -21,8 +21,8 @@ See the steps described in this guide to investigate requests and the next steps
 
 ## Using GraphQL API playground for investigation
 
-1. Make sure you're logged in on your Azion account, via [Real-Time Manager](https://manager.azion.com/) or via [Console](https://console.azion.com).
-2. Access Real-Time Events GraphQL API playground going to the following link: `https://manager.azion.com/events/graphql`.
+1. Make sure you're logged in on your Azion account, via [Azion Console](https://console.azion.com).
+2. Access Real-Time Events GraphQL API playground going to the following link: `https://api.azion.com/v4/events/graphql`.
   - You must be logged in to your Azion account. Otherwise, you'll receive an error message.
 3. Create a query with the filter and time range you want to use.
 
@@ -32,7 +32,7 @@ See the steps described in this guide to investigate requests and the next steps
 
 Begin your investigation with a query focused on the countries making requests.
 
-1. In Real-Time Events GraphQL API [playground](https://manager.azion.com/events/graphql), add the following query:
+1. In Real-Time Events GraphQL API [playground](https://api.azion.com/v4/events/graphql), add the following query:
 
 ```graphql
 query requestsInvestigationCountries {
@@ -169,7 +169,7 @@ query requestsInvestigationStatus {
 
 Next, you'll investigate the `User-Agent` header being used in the requests from the countries you've blocked, to create other rules and further improve your security.
 
-1. On [Real-Time Events GraphQL's playground](https://manager.azion.com/events/graphql), run the following query:
+1. On [Real-Time Events GraphQL's playground](https://api.azion.com/v4/events/graphql), run the following query:
 
 ```graphql
 query requestsInvestigationUserAgent {

--- a/src/content/docs/pt-br/pages/deploy-jornada/configurar-node/vincular-service/vincular-service.mdx
+++ b/src/content/docs/pt-br/pages/deploy-jornada/configurar-node/vincular-service/vincular-service.mdx
@@ -22,7 +22,6 @@ import Tabs from '~/components/tabs/Tabs'
 Você pode criar uma relação entre um edge node e um edge service usando:
 
 - [Azion Console](/pt-br/documentacao/produtos/guias/como-acessar-o-azion-console/)
-- [Azion Real-Time Manager (RTM)](https://manager.azion.com/)
 - [Azion API](https://api.azion.com/)
 
 <Tabs client:visible>

--- a/src/content/docs/pt-br/pages/deploy-jornada/deploy-service/deploy-service.mdx
+++ b/src/content/docs/pt-br/pages/deploy-jornada/deploy-service/deploy-service.mdx
@@ -20,7 +20,7 @@ import LinkButton from 'azion-webkit/linkbutton'
 A Azion oferece duas maneiras de gerenciar edge nodes, edge services e recursos:
 
 - Via [Azion API](https://api.azion.com/#9a7daab9-63f7-43a9-9959-2bd91088fca8)
-- Via interface: [Azion Console](/pt-br/documentacao/produtos/guias/como-acessar-o-azion-console/) ou [Azion Real-Time Manager (RTM)](https://manager.azion.com/)
+- Via [Azion Console](/pt-br/documentacao/produtos/guias/como-acessar-o-azion-console/)
 
 :::note 
 A criação de um edge node acontece diretamente nos dispositivos quando o [Edge Orchestrator Agent](/pt-br/documentacao/produtos/guias/deploy/instalar-orchestrator-agent/) é instalado neles.

--- a/src/content/docs/pt-br/pages/devtools/api-graphql/primeiros-passos/primeiros-passo-gql.mdx
+++ b/src/content/docs/pt-br/pages/devtools/api-graphql/primeiros-passos/primeiros-passo-gql.mdx
@@ -44,7 +44,7 @@ Após criar o seu personal token, vá para a plataforma de API de sua escolha e 
 
 ---
 
-## Acessar o playground GraphiQL
+## Acessar o Playground GraphiQL
 
 Você pode usar o playground da **GraphQL** da Azion para escrever, validar e testar queries da GraphQL. Usar o playground também ajuda a conhecer melhor a API e o uso de queries de forma visual e rápida.
 

--- a/src/content/docs/pt-br/pages/devtools/api-graphql/primeiros-passos/primeiros-passo-gql.mdx
+++ b/src/content/docs/pt-br/pages/devtools/api-graphql/primeiros-passos/primeiros-passo-gql.mdx
@@ -44,7 +44,7 @@ Após criar o seu personal token, vá para a plataforma de API de sua escolha e 
 
 ---
 
-## Acessar o Playground GraphiQL
+## Acessar o GraphiQL Playground
 
 Você pode usar o playground da **GraphQL** da Azion para escrever, validar e testar queries da GraphQL. Usar o playground também ajuda a conhecer melhor a API e o uso de queries de forma visual e rápida.
 

--- a/src/content/docs/pt-br/pages/devtools/api-graphql/primeiros-passos/primeiros-passo-gql.mdx
+++ b/src/content/docs/pt-br/pages/devtools/api-graphql/primeiros-passos/primeiros-passo-gql.mdx
@@ -36,11 +36,11 @@ Ao criar um personal token, você deve informar uma *data de expiração*. Para 
 
 Após criar o seu personal token, vá para a plataforma de API de sua escolha e inclua o endpoint da **API GraphQL** da Azion em sua requisição:
 
-- Para usar a API Real-Time Metrics com dados agregados, inclua: `https://api.azionapi.net/metrics/graphql`
-- Para usar a API Real-Time Events com dados brutos, inclua: `https://api.azionapi.net/events/graphql`
-- Para usar a API Billing com dados financeiros, inclua: `https://api.azionapi.net/billing/graphql`
-- Para usar a API Accounting com dados financeiros, inclua: `https://api.azionapi.net/accounting/graphql`
-- Para usar a API Consumption com dados de uso dos produtos, inclua: `https://api.azionapi.net/consumption/graphql`
+- Para usar a API Real-Time Metrics com dados agregados, inclua: `https://api.azion.com/v4/metrics/graphql`
+- Para usar a API Real-Time Events com dados brutos, inclua: `https://api.azion.com/v4/events/graphql`
+- Para usar a API Billing com dados financeiros, inclua: `https://api.azion.com/v4/billing/graphql`
+- Para usar a API Accounting com dados financeiros, inclua: `https://api.azion.com/v4/accounting/graphql`
+- Para usar a API Consumption com dados de uso dos produtos, inclua: `https://api.azion.com/v4/consumption/graphql`
 
 ---
 

--- a/src/content/docs/pt-br/pages/devtools/api-graphql/primeiros-passos/primeiros-passo-gql.mdx
+++ b/src/content/docs/pt-br/pages/devtools/api-graphql/primeiros-passos/primeiros-passo-gql.mdx
@@ -44,7 +44,7 @@ Após criar o seu personal token, vá para a plataforma de API de sua escolha e 
 
 ---
 
-## Acessar o playground GraphQL
+## Acessar o playground GraphiQL
 
 Você pode usar o playground da **GraphQL** da Azion para escrever, validar e testar queries da GraphQL. Usar o playground também ajuda a conhecer melhor a API e o uso de queries de forma visual e rápida.
 
@@ -52,11 +52,11 @@ Para interagir com o playground da GraphQL, você deve estar [logado no Azion Co
 
 Após fazer login no **Console**, acesse um dos links:
 
-- `https://manager.azion.com/metrics/graphql`
-- `https://manager.azion.com/events/graphql`
-- `https://manager.azion.com/billing/graphql`
-- `https://manager.azion.com/accounting/graphql`
-- `https://manager.azion.com/consumption/graphql`
+- `https://api.azion.com/v4/metrics/graphql`
+- `https://api.azion.com/v4/events/graphql`
+- `https://api.azion.com/v4/billing/graphql`
+- `https://api.azion.com/v4/accounting/graphql`
+- `https://api.azion.com/v4/consumption/graphql`
 
 Interaja com o playground da GraphQL API livremente.
 

--- a/src/content/docs/pt-br/pages/guias/graphql/bot-manager-breakdown-data.mdx
+++ b/src/content/docs/pt-br/pages/guias/graphql/bot-manager-breakdown-data.mdx
@@ -23,7 +23,7 @@ Para recuperar esses dados, você deve estar inscrito no Azion Bot Manager e usa
 
 Para consultar as 5 principais URLs impactadas pela atividade de bots, proceda da seguinte forma:
 
-1. Acesse o GraphiQL playground nesse link: `https://api.azion.com/v4/metrics/graphql`.
+1. Acesse o GraphiQL Playground nesse link: `https://api.azion.com/v4/metrics/graphql`.
     - Você deve estar logado na sua conta Azion. Caso contrário, você receberá uma mensagem de erro.
 2. Envie uma query seguindo este formato:
 

--- a/src/content/docs/pt-br/pages/guias/graphql/bot-manager-breakdown-data.mdx
+++ b/src/content/docs/pt-br/pages/guias/graphql/bot-manager-breakdown-data.mdx
@@ -23,7 +23,7 @@ Para recuperar esses dados, você deve estar inscrito no Azion Bot Manager e usa
 
 Para consultar as 5 principais URLs impactadas pela atividade de bots, proceda da seguinte forma:
 
-1. Acesse o GraphiQL playground nesse link: `https://manager.azion.com/metrics/graphql`.
+1. Acesse o GraphiQL playground nesse link: `https://api.azion.com/v4/metrics/graphql`.
     - Você deve estar logado na sua conta Azion. Caso contrário, você receberá uma mensagem de erro.
 2. Envie uma query seguindo este formato:
 

--- a/src/content/docs/pt-br/pages/guias/graphql/connected-users-dataset.mdx
+++ b/src/content/docs/pt-br/pages/guias/graphql/connected-users-dataset.mdx
@@ -23,7 +23,7 @@ Para obter esses dados, você deve ter a subscrição do [Live Ingest da Azion](
 
 Para consultar seus dados por host, siga os seguintes passos:
 
-1. Acesse o playground GraphiQL nesse link `https://api.azion.com/v4/metrics/graphql`.
+1. Acesse o Playground GraphiQL nesse link `https://api.azion.com/v4/metrics/graphql`.
     - Você deve estar logado na sua conta Azion. Caso contrário, você receberá uma mensagem de erro.
 2. Envie uma query seguindo este formato:
 
@@ -105,7 +105,7 @@ Onde:
 
 Para consultar valores totais, sem filtrar por host, você deve usar o campo `uniqueSessionsTotal`:
 
-1. Acesse o [playground GraphiQL](https://api.azion.com/v4/metrics/graphql)
+1. Acesse o [Playground GraphiQL](https://api.azion.com/v4/metrics/graphql)
     - Você deve estar logado na sua conta Azion. Caso contrário, você receberá uma mensagem de erro.
 2. Envie uma query seguindo este formato:
 

--- a/src/content/docs/pt-br/pages/guias/graphql/connected-users-dataset.mdx
+++ b/src/content/docs/pt-br/pages/guias/graphql/connected-users-dataset.mdx
@@ -23,7 +23,7 @@ Para obter esses dados, você deve ter a subscrição do [Live Ingest da Azion](
 
 Para consultar seus dados por host, siga os seguintes passos:
 
-1. Acesse o playground GraphiQL nesse link `https://manager.azion.com/metrics/graphql`.
+1. Acesse o playground GraphiQL nesse link `https://api.azion.com/v4/metrics/graphql`.
     - Você deve estar logado na sua conta Azion. Caso contrário, você receberá uma mensagem de erro.
 2. Envie uma query seguindo este formato:
 
@@ -105,7 +105,7 @@ Onde:
 
 Para consultar valores totais, sem filtrar por host, você deve usar o campo `uniqueSessionsTotal`:
 
-1. Acesse o [playground GraphiQL](https://manager.azion.com/metrics/graphql)
+1. Acesse o [playground GraphiQL](https://api.azion.com/v4/metrics/graphql)
     - Você deve estar logado na sua conta Azion. Caso contrário, você receberá uma mensagem de erro.
 2. Envie uma query seguindo este formato:
 

--- a/src/content/docs/pt-br/pages/guias/graphql/connected-users-dataset.mdx
+++ b/src/content/docs/pt-br/pages/guias/graphql/connected-users-dataset.mdx
@@ -23,7 +23,7 @@ Para obter esses dados, você deve ter a subscrição do [Live Ingest da Azion](
 
 Para consultar seus dados por host, siga os seguintes passos:
 
-1. Acesse o Playground GraphiQL nesse link `https://api.azion.com/v4/metrics/graphql`.
+1. Acesse o GraphiQL Playground nesse link `https://api.azion.com/v4/metrics/graphql`.
     - Você deve estar logado na sua conta Azion. Caso contrário, você receberá uma mensagem de erro.
 2. Envie uma query seguindo este formato:
 
@@ -105,7 +105,7 @@ Onde:
 
 Para consultar valores totais, sem filtrar por host, você deve usar o campo `uniqueSessionsTotal`:
 
-1. Acesse o [Playground GraphiQL](https://api.azion.com/v4/metrics/graphql)
+1. Acesse o [GraphiQL Playground](https://api.azion.com/v4/metrics/graphql)
     - Você deve estar logado na sua conta Azion. Caso contrário, você receberá uma mensagem de erro.
 2. Envie uma query seguindo este formato:
 

--- a/src/content/docs/pt-br/pages/guias/graphql/query-bot-manager-data.mdx
+++ b/src/content/docs/pt-br/pages/guias/graphql/query-bot-manager-data.mdx
@@ -23,7 +23,7 @@ Para recuperar esses dados, você deve estar inscrito no Azion Bot Manager e usa
 
 Para consultar seus dados, siga os passos:
 
-1. Acesse o playground GraphiQL visitando o link `https://api.azion.com/v4/metrics/graphql`.
+1. Acesse o Playground GraphiQL visitando o link `https://api.azion.com/v4/metrics/graphql`.
     - Você deve estar logado na sua conta Azion. Caso contrário, você receberá uma mensagem de erro.
 2. Envie uma query seguindo este formato:
 

--- a/src/content/docs/pt-br/pages/guias/graphql/query-bot-manager-data.mdx
+++ b/src/content/docs/pt-br/pages/guias/graphql/query-bot-manager-data.mdx
@@ -23,7 +23,7 @@ Para recuperar esses dados, você deve estar inscrito no Azion Bot Manager e usa
 
 Para consultar seus dados, siga os passos:
 
-1. Acesse o playground GraphiQL visitando o link `https://manager.azion.com/metrics/graphql`.
+1. Acesse o playground GraphiQL visitando o link `https://api.azion.com/v4/metrics/graphql`.
     - Você deve estar logado na sua conta Azion. Caso contrário, você receberá uma mensagem de erro.
 2. Envie uma query seguindo este formato:
 

--- a/src/content/docs/pt-br/pages/guias/graphql/query-bot-manager-data.mdx
+++ b/src/content/docs/pt-br/pages/guias/graphql/query-bot-manager-data.mdx
@@ -23,7 +23,7 @@ Para recuperar esses dados, você deve estar inscrito no Azion Bot Manager e usa
 
 Para consultar seus dados, siga os passos:
 
-1. Acesse o Playground GraphiQL visitando o link `https://api.azion.com/v4/metrics/graphql`.
+1. Acesse o GraphiQL Playground visitando o link `https://api.azion.com/v4/metrics/graphql`.
     - Você deve estar logado na sua conta Azion. Caso contrário, você receberá uma mensagem de erro.
 2. Envie uma query seguindo este formato:
 

--- a/src/content/docs/pt-br/pages/guias/graphql/query-edge-functions-usage-data.mdx
+++ b/src/content/docs/pt-br/pages/guias/graphql/query-edge-functions-usage-data.mdx
@@ -19,7 +19,7 @@ Este guia explica como consultar as métricas de tempo de computação e invoca�
 
 Para consultar o tempo de computação e as invocações de Edge Functions, proceda da seguinte forma:
 
-1. Acesse o playground GraphiQL indo para o seguinte link: `https://manager.azion.com/consumption/graphql`.
+1. Acesse o playground GraphiQL indo para o seguinte link: `https://api.azion.com/v4/consumption/graphql`.
     - Você deve estar logado em sua conta Azion. Caso contrário, você receberá uma mensagem de erro.
 2. Envie uma consulta seguindo este formato:
 

--- a/src/content/docs/pt-br/pages/guias/graphql/query-edge-functions-usage-data.mdx
+++ b/src/content/docs/pt-br/pages/guias/graphql/query-edge-functions-usage-data.mdx
@@ -19,7 +19,7 @@ Este guia explica como consultar as métricas de tempo de computação e invoca�
 
 Para consultar o tempo de computação e as invocações de Edge Functions, proceda da seguinte forma:
 
-1. Acesse o Playground GraphiQL indo para o seguinte link: `https://api.azion.com/v4/consumption/graphql`.
+1. Acesse o GraphiQL Playground indo para o seguinte link: `https://api.azion.com/v4/consumption/graphql`.
     - Você deve estar logado em sua conta Azion. Caso contrário, você receberá uma mensagem de erro.
 2. Envie uma consulta seguindo este formato:
 

--- a/src/content/docs/pt-br/pages/guias/graphql/query-edge-functions-usage-data.mdx
+++ b/src/content/docs/pt-br/pages/guias/graphql/query-edge-functions-usage-data.mdx
@@ -19,7 +19,7 @@ Este guia explica como consultar as métricas de tempo de computação e invoca�
 
 Para consultar o tempo de computação e as invocações de Edge Functions, proceda da seguinte forma:
 
-1. Acesse o playground GraphiQL indo para o seguinte link: `https://api.azion.com/v4/consumption/graphql`.
+1. Acesse o Playground GraphiQL indo para o seguinte link: `https://api.azion.com/v4/consumption/graphql`.
     - Você deve estar logado em sua conta Azion. Caso contrário, você receberá uma mensagem de erro.
 2. Envie uma consulta seguindo este formato:
 

--- a/src/content/docs/pt-br/pages/guias/graphql/query-image-processor-usage-data.mdx
+++ b/src/content/docs/pt-br/pages/guias/graphql/query-image-processor-usage-data.mdx
@@ -19,7 +19,7 @@ Este guia explica como consultar as imagens processadas pelo Image Processor usa
 
 Para consultar o total das imagens processadas pelo Image Processor, proceda da seguinte forma:
 
-1. Acesse o Playground GraphiQL indo para o seguinte link: `https://api.azion.com/v4/consumption/graphql`.
+1. Acesse o GraphiQL Playground indo para o seguinte link: `https://api.azion.com/v4/consumption/graphql`.
     - Você deve estar logado em sua conta Azion. Caso contrário, você receberá uma mensagem de erro.
 2. Envie uma consulta seguindo este formato:
 

--- a/src/content/docs/pt-br/pages/guias/graphql/query-image-processor-usage-data.mdx
+++ b/src/content/docs/pt-br/pages/guias/graphql/query-image-processor-usage-data.mdx
@@ -19,7 +19,7 @@ Este guia explica como consultar as imagens processadas pelo Image Processor usa
 
 Para consultar o total das imagens processadas pelo Image Processor, proceda da seguinte forma:
 
-1. Acesse o playground GraphiQL indo para o seguinte link: `https://api.azion.com/v4/consumption/graphql`.
+1. Acesse o Playground GraphiQL indo para o seguinte link: `https://api.azion.com/v4/consumption/graphql`.
     - Você deve estar logado em sua conta Azion. Caso contrário, você receberá uma mensagem de erro.
 2. Envie uma consulta seguindo este formato:
 

--- a/src/content/docs/pt-br/pages/guias/graphql/query-image-processor-usage-data.mdx
+++ b/src/content/docs/pt-br/pages/guias/graphql/query-image-processor-usage-data.mdx
@@ -19,7 +19,7 @@ Este guia explica como consultar as imagens processadas pelo Image Processor usa
 
 Para consultar o total das imagens processadas pelo Image Processor, proceda da seguinte forma:
 
-1. Acesse o playground GraphiQL indo para o seguinte link: `https://manager.azion.com/consumption/graphql`.
+1. Acesse o playground GraphiQL indo para o seguinte link: `https://api.azion.com/v4/consumption/graphql`.
     - Você deve estar logado em sua conta Azion. Caso contrário, você receberá uma mensagem de erro.
 2. Envie uma consulta seguindo este formato:
 

--- a/src/content/docs/pt-br/pages/guias/graphql/query-top-attacks.mdx
+++ b/src/content/docs/pt-br/pages/guias/graphql/query-top-attacks.mdx
@@ -15,7 +15,7 @@ Você pode usar informações do conjunto de dados `httpMetrics` para monitorar 
 
 Para consultar os 5 principais ataques, identificados pelo WAF e classificados por ocorrência, siga os passos abaixo:
 
-1. Acesse o GraphiQL Playground neste link: `https://manager.azion.com/metrics/graphql`.
+1. Acesse o GraphiQL Playground neste link: `https://api.azion.com/v4/metrics/graphql`.
     - Você deve estar logado na sua conta Azion. Caso contrário, você receberá uma mensagem de erro.
 2. Envie uma consulta seguindo este formato:
 

--- a/src/content/docs/pt-br/pages/guias/graphql/query-top-ips.mdx
+++ b/src/content/docs/pt-br/pages/guias/graphql/query-top-ips.mdx
@@ -15,7 +15,7 @@ Você pode usar informações do conjunto de dados `httpEvents` para monitorar p
 
 Para consultar os 5 principais IPs gerando tráfego de ataque, de acordo com o WAF, siga os passos abaixo:
 
-1. Acesse o GraphiQL Playground neste link: `https://manager.azion.com/metrics/graphql`.
+1. Acesse o GraphiQL Playground neste link: `https://api.azion.com/v4/metrics/graphql`.
     - Você deve estar logado na sua conta Azion. Caso contrário, você receberá uma mensagem de erro.
 2. Envie uma consulta seguindo este formato:
 

--- a/src/content/docs/pt-br/pages/observe-jornada/real-time-events/analise-logs/investigue-requisicoes.mdx
+++ b/src/content/docs/pt-br/pages/observe-jornada/real-time-events/analise-logs/investigue-requisicoes.mdx
@@ -24,7 +24,7 @@ Veja os passos descritos neste guia para investigar requisições e os próximos
 ## Use o playground da API GraphQL para investigação
 
 1. Certifique-se de estar logado na sua conta Azion, via [Console](https://console.azion.com).
-2. Acesse o playground da API GraphQL do Real-Time Events nesse link `https://api.azion.com/v4/events/graphql`.
+2. Acesse o Playground da API GraphQL do Real-Time Events nesse link `https://api.azion.com/v4/events/graphql`.
   - Você deve estar logado na sua conta Azion. Caso contrário, você receberá uma mensagem de erro.
 3. Crie uma query com o filtro e o intervalo de tempo que deseja usar.
 
@@ -34,7 +34,7 @@ Veja os passos descritos neste guia para investigar requisições e os próximos
 
 Inicie sua investigação com uma query focada nos países que estão fazendo requisições.
 
-1. Entre no playground no link `https://api.azion.com/v4/events/graphql` da API GraphQL Real-Time Events, adicione a seguinte query:
+1. Entre no Playground no link `https://api.azion.com/v4/events/graphql` da API GraphQL Real-Time Events, adicione a seguinte query:
 
 ```graphql
 query requestsInvestigationCountries {
@@ -171,7 +171,7 @@ query requestsInvestigationStatus {
 
 A seguir, você investigará o header `User-Agent` sendo usado nas requisições dos países que você bloqueou, para criar outras regras e melhorar ainda mais sua segurança.
 
-1. No [playground da API GraphQL Real-Time Events](https://api.azion.com/v4/events/graphql), execute a seguinte query:
+1. No [Playground da API GraphQL Real-Time Events](https://api.azion.com/v4/events/graphql), execute a seguinte query:
 
 ```graphql
 query requestsInvestigationUserAgent {

--- a/src/content/docs/pt-br/pages/observe-jornada/real-time-events/analise-logs/investigue-requisicoes.mdx
+++ b/src/content/docs/pt-br/pages/observe-jornada/real-time-events/analise-logs/investigue-requisicoes.mdx
@@ -23,8 +23,8 @@ Veja os passos descritos neste guia para investigar requisições e os próximos
 
 ## Use o playground da API GraphQL para investigação
 
-1. Certifique-se de estar logado na sua conta Azion, via [Real-Time Manager](https://manager.azion.com/) ou via [Console](https://console.azion.com).
-2. Acesse o playground da API GraphQL do Real-Time Events nesse link `https://manager.azion.com/events/graphql`.
+1. Certifique-se de estar logado na sua conta Azion, via [Console](https://console.azion.com).
+2. Acesse o playground da API GraphQL do Real-Time Events nesse link `https://api.azion.com/v4/events/graphql`.
   - Você deve estar logado na sua conta Azion. Caso contrário, você receberá uma mensagem de erro.
 3. Crie uma query com o filtro e o intervalo de tempo que deseja usar.
 
@@ -34,7 +34,7 @@ Veja os passos descritos neste guia para investigar requisições e os próximos
 
 Inicie sua investigação com uma query focada nos países que estão fazendo requisições.
 
-1. Entre no playground no link `https://manager.azion.com/events/graphql` da API GraphQL Real-Time Events, adicione a seguinte query:
+1. Entre no playground no link `https://api.azion.com/v4/events/graphql` da API GraphQL Real-Time Events, adicione a seguinte query:
 
 ```graphql
 query requestsInvestigationCountries {
@@ -171,7 +171,7 @@ query requestsInvestigationStatus {
 
 A seguir, você investigará o header `User-Agent` sendo usado nas requisições dos países que você bloqueou, para criar outras regras e melhorar ainda mais sua segurança.
 
-1. No [playground da API GraphQL Real-Time Events](https://manager.azion.com/events/graphql), execute a seguinte query:
+1. No [playground da API GraphQL Real-Time Events](https://api.azion.com/v4/events/graphql), execute a seguinte query:
 
 ```graphql
 query requestsInvestigationUserAgent {


### PR DESCRIPTION
### Related issue:

[EDU-6336]

### Changes

- Update URLs for the GraphiQL Playground.
- Delete a couple of RTM mentions.

### Additional links

n/a.

[EDU-6336]: https://aziontech.atlassian.net/browse/EDU-6336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ