### PR TITLE
[NO-ISSUE] fix: removed -client from permalink

### DIFF
--- a/src/content/docs/pt-br/pages/devtools/azion-lib/usage/application.mdx
+++ b/src/content/docs/pt-br/pages/devtools/azion-lib/usage/application.mdx
@@ -2,7 +2,7 @@
 title: Módulo Application da Azion
 description: >-
   Gerencie a Edge Application usando o módulo Application.
-permalink: /documentacao/produtos/azion-lib/application-client/
+permalink: /documentacao/produtos/azion-lib/application/
 meta_tags: >-
   Azion Lib, edge computing, edge applications, Azion products
 namespace: documentation_azion_lib_application_client


### PR DESCRIPTION
The azion lib application module in pt-br had an incorrct permalink.