### PR TITLE
[EDU-6470]-fix-amend-new-link-in-bot-manager-docs

### DIFF
--- a/src/content/docs/en/pages/guides/marketplace/integrations/javascript-tag-js-tag.mdx
+++ b/src/content/docs/en/pages/guides/marketplace/integrations/javascript-tag-js-tag.mdx
@@ -25,15 +25,15 @@ Then, it creates a unique identifier containing all this information and sets it
 
 Azion provides a code sample for this JavaScript injection that you can include in your project. To do so:
 
-1. Add [this file](https://assets.azion.com/global/bot-client-fingerprint/azfp-1.0.0.min.js) to your HTML source, following this example:
+1. Add [this file](https://assets.azion.com/global/bot-manager/client-fingerprint/azfp-1.0.0.min.js) to your HTML source, following this example:
 
 ```bash
-<script src="https://assets.azion.com/global/bot-client-fingerprint/azfp-1.0.0.min.js"></script>
+<script src="https://assets.azion.com/global/bot-manager/client-fingerprint/azfp-1.0.0.min.js"></script>
 ```
 
 Alternatively, you can also:
 
-1. Copy the code in [this file](https://assets.azion.com/global/bot-client-fingerprint/azfp-1.0.0.min.js).
+1. Copy the code in [this file](https://assets.azion.com/global/bot-manager/client-fingerprint/azfp-1.0.0.min.js).
 2. Create a new JavaScript file with the code.
 3.  Include the JavaScript file in your project folder.
     1. In this example, the file name is `fingerprint-script.js`

--- a/src/content/docs/pt-br/pages/guias/marketplace/integrations/javascript-tag-js-tag.mdx
+++ b/src/content/docs/pt-br/pages/guias/marketplace/integrations/javascript-tag-js-tag.mdx
@@ -25,15 +25,15 @@ Em seguida, ele cria um identificador único contendo todas essas informações 
 
 A Azion fornece um exemplo de código para fazer a injeção de JavaScript que você pode incluir em seu projeto. Para fazer isso:
 
-1. Adicione [este arquivo](https://assets.azion.com/global/bot-client-fingerprint/azfp-1.0.0.min.js) no seu HTML fonte, seguindo o exemplo:
+1. Adicione [este arquivo](https://assets.azion.com/global/bot-manager/client-fingerprint/azfp-1.0.0.min.js) no seu HTML fonte, seguindo o exemplo:
 
 ```bash
-<script src="https://assets.azion.com/global/bot-client-fingerprint/azfp-1.0.0.min.js"></script>
+<script src="https://assets.azion.com/global/bot-manager/client-fingerprint/azfp-1.0.0.min.js"></script>
 ```
 
 Alternativamente, você também pode:
 
-1. Copiar o código neste [arquivo](https://assets.azion.com/global/bot-client-fingerprint/azfp-1.0.0.min.js).
+1. Copiar o código neste [arquivo](https://assets.azion.com/global/bot-manager/client-fingerprint/azfp-1.0.0.min.js).
 2. Criar um novo arquivo JavaScript com o código.
 3. Incluir o arquivo JavaScript na pasta do seu projeto.
   - Neste exemplo, o nome do arquivo é `fingerprint-script.js`.


### PR DESCRIPTION
Guys, as per Artur`s request, I updated the link where needed:
_O link para o client fingerprint do Bot Manager mudou para [https://assets.azion.com/global/bot-manager/client-fingerprint/azfp-1.0.0.min.js](https://www.google.com/url?q=https%3A%2F%2Fassets.azion.com%2Fglobal%2Fbot-manager%2Fclient-fingerprint%2Fazfp-1.0.0.min.js&sa=D) 
Preciso que sejam atualizadas as docs que referenciam o arquivo azfp-1.0.0.min.js para que apontem para este novo link._