### PR TITLE
feat/form-builder-documentation

### DIFF
--- a/src/content/docs/en/pages/devtools/form-builder/form-builder.mdx
+++ b/src/content/docs/en/pages/devtools/form-builder/form-builder.mdx
@@ -1,0 +1,228 @@
+---
+title: Form Builder
+description: Build visual, schema-driven forms to configure Azion Functions arguments in Applications and Firewalls.
+meta_tags: 'form builder, json schema, azion functions, devtools, ui, arguments'
+namespace: documentation_devtools_form_builder
+menu_namespace: devtoolsMenu
+permalink: /documentation/devtools/form-builder/
+---
+
+## Overview
+
+Form Builder is a declarative compiler for efficiently building form-based web user interfaces (UIs). These UIs are targeted at entering, modifying, and viewing data and are typically embedded within [Functions](/en/documentation/products/build/applications/functions/) used in [Applications](/en/documentation/products/build/applications/) and [Firewalls](/en/documentation/products/secure/firewall/).
+
+---
+
+## How it works
+
+Form Builder is built on top of [JsonForms](https://jsonforms.io/docs/) and uses a schema-driven approach: the UI is generated from JSON Schemas.
+
+- **Data/JSON Schema**: Defines the underlying data structure to be displayed in the UI, including objects, properties, and their types.
+
+### Example schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "name": { "type": "string" },
+    "description": { "type": "string" },
+    "done": { "type": "boolean" },
+    "rating": { "type": "integer" }
+  },
+  "required": ["name"]
+}
+```
+
+---
+
+## Why use Form Builder
+
+- Visual interface for Azion Functions arguments through a form-based mode.
+- User-friendly for non-technical users who need to edit argument values.
+- Flexible management to add, edit, or remove visual form elements as needed.
+- Automatic rendering based on the JSON Schema configuration.
+
+---
+
+## Getting started
+
+### Create a Function with Form Builder
+
+1. Go to [**Functions**](/en/documentation/products/build/applications/functions/) → **+ Function**.
+2. Open the **Arguments** tab and select the **JSON/Form Builder** options.
+3. Click **+ Form Builder** to load an example configuration and see how the visual form is generated.
+
+### Use Function Instances with Form Builder
+
+Application and Firewall [Functions Instances](/en/documentation/products/build/applications/functions-instances/) render using the configured Form Builder from the created function.
+
+When a Form Builder is configured during function creation/editing, the visual form loads with a `Form/JSON` selector panel when loading instances in [Applications](/en/documentation/products/build/applications/) or Firewalls.
+
+- Fill function arguments by entering values in the input fields.
+
+:::note
+When Form Builder is configured, manual JSON argument editing is disabled.
+:::
+
+---
+
+## Editing Form Builder schema
+
+You can modify the form schema directly:
+
+1. Below the form, select the option to edit the schema to add or adjust inputs.
+2. Switch back to the visual form to render the updated schema.
+
+:::note
+Editing the schema in production environments isn’t recommended. Use this for experimentation and prototyping.
+:::
+
+---
+
+## Feature support
+
+### JSON Schema renderer compatibility
+
+| Feature | Input Type | Supported |
+| :---: | :---: | :---: |
+| **Boolean** | Checkbox | ✅ |
+| **Integer** | Number | ✅ |
+| **String** | Text | ✅ |
+| **String** | Textarea | 🔄 |
+| **String** | Enum Combo | 🔄 |
+| **oneOf (const/title)** | Combo | ✅ |
+| **Date format** | Date field | 🔄 |
+| **Time format** | Time field | 🔄 |
+| **Datetime format** | Datetime field | 🔄 |
+| **Array of primitives** | List | ✅ |
+| Array of objects | List | ✅ |
+
+Legend:
+
+- ✅ True: Fully supported
+- 🔄 True / TODO: Partially implemented, under review/implementation
+
+---
+
+## Advanced example
+
+The following example demonstrates a variety of configuration possibilities. It includes validation constraints, defaults, patterns, and arrays of objects.
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "checkboxInput": {
+      "type": "boolean",
+      "title": "Boolean",
+      "description": "Name of the cookie used to store the A/B test variation"
+    },
+    "cookie_name": {
+      "type": "string",
+      "title": "Cookie Name",
+      "description": "Name of the cookie used to store the A/B test variation",
+      "minLength": 1,
+      "maxLength": 64,
+      "pattern": "^[a-zA-Z0-9_+-]+$"
+    },
+    "domain": {
+      "type": "string",
+      "title": "Domain",
+      "description": "Domain where the cookie will be valid (use '.' at the beginning for subdomains)",
+      "default": ".azion.com",
+      "pattern": "^[.]?[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]*\\.[a-zA-Z]{2,}$"
+    },
+    "max_age": {
+      "type": "integer",
+      "title": "Max Age (seconds)",
+      "description": "Lifetime of the cookie in seconds",
+      "default": 180,
+      "minimum": 1,
+      "maximum": 31536000
+    },
+    "path": {
+      "type": "string",
+      "title": "Path",
+      "description": "Path where the cookie will be valid"
+    },
+    "values": {
+      "type": "array",
+      "title": "Test Variations",
+      "description": "List of A/B test variations with their respective weights",
+      "minItems": 2,
+      "maxItems": 10,
+      "items": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string",
+            "title": "Variation Value",
+            "description": "Unique identifier of the variation",
+            "minLength": 1,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9_-]+$"
+          },
+          "weight": {
+            "type": "integer",
+            "title": "Weight",
+            "description": "Variation weight (higher weight = higher probability)",
+            "minimum": 1,
+            "maximum": 100
+          }
+        },
+        "required": ["value", "weight"]
+      }
+    }
+  },
+  "required": ["cookie_name", "domain", "max_age", "values"]
+}
+```
+
+### Supported schema properties
+
+The following JSON Schema properties are supported:
+
+- `type`: Data type specification
+- `title`: Display label for the field
+- `description`: Help text for the field
+- `default`: Default value
+- `minimum` / `maximum`: Numeric constraints
+- `minLength` / `maxLength`: String length constraints
+- `minItems` / `maxItems`: Number of min/max items
+- `pattern`: Regular expression validation
+- `required`: Required field specifications
+
+---
+
+### Future considerations
+
+- Custom renderers for specialized form elements.
+- Complete input type coverage.
+- Enhanced components:
+  - Advanced select components
+  - Rich text inputs
+  - Custom checkbox styles
+  - Specialized input blocks
+- Dynamic response-based selection: select options based on API responses.
+
+---
+
+## Best practices
+
+1. Keep schemas simple and well-structured for better user experience.
+2. Use validation constraints (min/max, patterns) to ensure data integrity.
+3. Provide clear titles and descriptions for all fields.
+
+---
+
+## Troubleshooting
+
+### Common issues
+
+- Form not rendering: verify JSON Schema syntax and structure.
+- Validation errors: check that required fields are properly defined.
+- Display issues: ensure field types are supported (see the compatibility table).
+
+For technical support, consult Azion documentation or contact the [support team](https://tickets.azion.com/en/support/login).
+

--- a/src/content/docs/pt-br/pages/devtools/form-builder/form-builder.mdx
+++ b/src/content/docs/pt-br/pages/devtools/form-builder/form-builder.mdx
@@ -1,0 +1,238 @@
+---
+title: Form Builder
+description: Construa formulários visuais orientados por schema para configurar argumentos de Azion Functions em Aplicações e Firewalls.
+meta_tags: 'form builder, json schema, azion functions, devtools, ui, argumentos'
+namespace: documentation_devtools_form_builder
+menu_namespace: devtoolsMenu
+permalink: /documentacao/devtools/form-builder/
+---
+
+## Visão geral
+
+O Form Builder é um compilador declarativo para construir interfaces web baseadas em formulários (UIs) de forma eficiente. Essas UIs são voltadas para inserir, modificar e visualizar dados e, normalmente, são incorporadas em [Functions](/pt-br/documentacao/produtos/build/applications/functions/) usadas em [Applications](/pt-br/documentacao/produtos/build/applications/) e Firewalls.
+
+---
+
+## Como funciona
+
+O Form Builder é construído sobre o [JsonForms](https://jsonforms.io/docs/) e usa uma abordagem orientada por schema: a UI é gerada a partir de JSON Schemas.
+
+- **Data/JSON Schema**: define a estrutura de dados subjacente a ser exibida na UI, incluindo objetos, propriedades e seus tipos.
+
+### Exemplo de schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "name": { "type": "string" },
+    "description": { "type": "string" },
+    "done": { "type": "boolean" },
+    "rating": { "type": "integer" }
+  },
+  "required": ["name"]
+}
+```
+
+---
+
+## Por que usar o Form Builder
+
+- Interface visual para os argumentos de [Azion Functions](/pt-br/documentacao/produtos/build/applications/functions/) por meio de um modo baseado em formulário.
+- Amigável para usuários não técnicos que precisam editar valores de argumentos.
+- Gestão flexível para adicionar, editar ou remover elementos do formulário conforme necessário.
+- Renderização automática com base na configuração do JSON Schema.
+
+---
+
+## Primeiros passos
+
+### Criar uma Function com Form Builder
+
+1. Acesse [**Functions**](/pt-br/documentacao/produtos/build/applications/functions/) → **+ Function**.
+2. Abra a aba **Arguments** e selecione as opções **JSON/Form Builder**.
+3. Clique em **+ Form Builder** para carregar um exemplo de configuração e ver como o formulário visual é gerado.
+
+### Usar Instâncias de Função com Form Builder
+
+As [Functions Instances](/pt-br/documentacao/produtos/build/applications/functions-instances/) de [Applications](/pt-br/documentacao/produtos/build/applications/) e Firewalls renderizam usando o Form Builder configurado na função criada.
+
+Quando um Form Builder é configurado durante a criação/edição da função, o formulário visual é carregado com um seletor `Form/JSON` ao carregar instâncias em [Applications](/pt-br/documentacao/produtos/build/applications/) ou Firewalls.
+
+- Preencha os argumentos da função inserindo valores nos campos de entrada.
+
+:::note
+Quando o Form Builder está configurado, a edição manual do JSON dos argumentos é desabilitada.
+:::
+
+---
+
+## Editando o schema do Form Builder
+
+Você pode modificar o schema do formulário diretamente:
+
+1. Abaixo do formulário, selecione a opção para editar o schema a fim de adicionar ou ajustar entradas.
+2. Volte para o formulário visual para renderizar o schema atualizado.
+
+:::note
+Editar o schema em ambientes de produção não é recomendado. Utilize para experimentação e prototipagem.
+:::
+
+---
+
+## Suporte de recursos
+
+### Compatibilidade do renderizador de JSON Schema
+
+| Recurso | Tipo de entrada | Suporte |
+| :---: | :---: | :---: |
+| **Boolean** | Checkbox | ✅ |
+| **Integer** | Number | ✅ |
+| **String** | Text | ✅ |
+| **String** | Textarea | 🔄 |
+| **String** | Enum Combo | 🔄 |
+| **oneOf (const/title)** | Combo | ✅ |
+| **Date format** | Date field | 🔄 |
+| **Time format** | Time field | 🔄 |
+| **Datetime format** | Datetime field | 🔄 |
+| **Array of primitives** | List | ✅ |
+| Array of objects | List | ✅ |
+
+Legenda:
+
+- ✅ Verdadeiro: totalmente suportado
+- 🔄 Verdadeiro / TODO: parcialmente implementado, em revisão/implementação
+
+---
+
+## Exemplo avançado
+
+O exemplo a seguir demonstra várias possibilidades de configuração. Ele inclui restrições de validação, valores padrão, padrões (regex) e arrays de objetos.
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "checkboxInput": {
+      "type": "boolean",
+      "title": "Boolean",
+      "description": "Nome do cookie usado para armazenar a variação do teste A/B"
+    },
+    "cookie_name": {
+      "type": "string",
+      "title": "Cookie Name",
+      "description": "Nome do cookie usado para armazenar a variação do teste A/B",
+      "minLength": 1,
+      "maxLength": 64,
+      "pattern": "^[a-zA-Z0-9_+-]+$"
+    },
+    "domain": {
+      "type": "string",
+      "title": "Domain",
+      "description": "Domínio onde o cookie será válido (use '.' no início para subdomínios)",
+      "default": ".azion.com",
+      "pattern": "^[.]?[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]*\\.[a-zA-Z]{2,}$"
+    },
+    "max_age": {
+      "type": "integer",
+      "title": "Max Age (seconds)",
+      "description": "Tempo de vida do cookie em segundos",
+      "default": 180,
+      "minimum": 1,
+      "maximum": 31536000
+    },
+    "path": {
+      "type": "string",
+      "title": "Path",
+      "description": "Caminho no qual o cookie será válido"
+    },
+    "values": {
+      "type": "array",
+      "title": "Test Variations",
+      "description": "Lista de variações do teste A/B com seus respectivos pesos",
+      "minItems": 2,
+      "maxItems": 10,
+      "items": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string",
+            "title": "Variation Value",
+            "description": "Identificador único da variação",
+            "minLength": 1,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9_-]+$"
+          },
+          "weight": {
+            "type": "integer",
+            "title": "Weight",
+            "description": "Peso da variação (peso maior = maior probabilidade)",
+            "minimum": 1,
+            "maximum": 100
+          }
+        },
+        "required": ["value", "weight"]
+      }
+    }
+  },
+  "required": ["cookie_name", "domain", "max_age", "values"]
+}
+```
+
+### Propriedades de schema suportadas
+
+As seguintes propriedades do JSON Schema são suportadas:
+
+- `type`: especificação do tipo de dado
+- `title`: rótulo exibido para o campo
+- `description`: texto de ajuda para o campo
+- `default`: valor padrão
+- `minimum` / `maximum`: restrições numéricas
+- `minLength` / `maxLength`: restrições de tamanho de string
+- `minItems` / `maxItems`: quantidade mínima/máxima de itens
+- `pattern`: validação por expressão regular
+- `required`: especificação de campos obrigatórios
+
+---
+
+### Considerações futuras
+
+- Renderizadores customizados para elementos de formulário especializados.
+- Cobertura completa de tipos de entrada.
+- Componentes aprimorados:
+  - Componentes de seleção avançados
+  - Entradas de rich text
+  - Estilos personalizados de checkbox
+  - Blocos de entrada especializados
+- Seleção dinâmica baseada em resposta: opções de seleção com base em respostas de API.
+
+### Considerações futuras
+
+- Renderizadores customizados para elementos de formulário especializados.
+- Cobertura completa de tipos de entrada.
+- Componentes aprimorados:
+  - Componentes de seleção avançados
+  - Entradas de rich text
+  - Estilos personalizados de checkbox
+  - Blocos de entrada especializados
+- Seleção dinâmica baseada em resposta: opções de seleção com base em respostas de API.
+
+---
+
+## Boas práticas
+
+1. Mantenha os schemas simples e bem estruturados para melhor experiência do usuário.
+2. Utilize restrições de validação (min/max, padrões) para garantir a integridade dos dados.
+3. Forneça títulos e descrições claros para todos os campos.
+
+---
+
+## Solução de problemas
+
+### Problemas comuns
+
+- Formulário não renderiza: verifique a sintaxe e a estrutura do JSON Schema.
+- Erros de validação: confira se os campos obrigatórios foram definidos corretamente.
+- Problemas de exibição: confirme se os tipos de campo são suportados (consulte a tabela de compatibilidade).
+
+Para suporte técnico, consulte a documentação da Azion ou entre em contato com a [equipe de suporte](https://tickets.azion.com/en/support/login).


### PR DESCRIPTION
Changes
Add EN Form Builder doc

Created 
src/content/docs/en/pages/devtools/form-builder/form-builder.mdx

Added front matter aligned with DevTools conventions (namespace, menu_namespace, permalink)
Wrote Overview, How it works (JsonForms-based), Getting started, Feature support table, Advanced JSON schema example, Supported schema properties, Best practices, Troubleshooting

Ensured JSON examples are valid and consistent (e.g., cookie_name included in properties and required)
Add PT-BR Form Builder doc

Created 
src/content/docs/pt-br/pages/devtools/form-builder/form-builder.mdx

Mirrored EN structure and content with localized front matter and text

Cross-links and navigation improvements (EN)
Linked to Functions, Applications, and Functions Instances

Added link to Firewalls in Overview
Cross-links and navigation improvements (PT-BR)
Linked to Functions, Applications, and Functions Instances