### PR TITLE
[ENG-37181]: chore: add Makefile for developer helper

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -85,6 +85,36 @@ If you want to propose a new page:
 
 You can branch out from main or commit the changes directly once you're pleased with them. We use the basics of the **Conventional Commits** standard to title commits and PRs.
 
+### :test_tube: Local testing (optional)
+
+> **Optional helper:** A `Makefile` is available to simplify running common development commands. It's a convenience tool — you can also use npm commands directly as shown in `package.json`.
+
+Before submitting your PR, you can test your changes locally to ensure everything works correctly. Run `make help` to see all available commands:
+
+| Command | Description |
+|---------|-------------|
+| `make install` | Install dependencies |
+| `make dev` | Start dev server with hot reload at http://localhost:4321 |
+| `make build-local` | Build locally and run frontmatter tests |
+| `make preview` | Preview the production build locally |
+| `make check` | Run Astro type checking |
+| `make lint` | Run ESLint |
+| `make format` | Format code with Prettier |
+| `make validate` | Run all validations (check + lint + build) |
+| `make clean` | Remove build artifacts |
+
+**Language routing:** The site uses URL-based language routing. Access the desired language by navigating to:
+- **English:** `http://localhost:4321/en/`
+- **Portuguese:** `http://localhost:4321/pt-br/`
+
+**Recommended workflow before submitting a PR:**
+
+1. Run `make dev` to start the development server and preview your changes.
+2. Navigate to the correct language URL (e.g., `/en/` or `/pt-br/`).
+3. Make your changes and verify they look correct in the browser (hot reload enabled).
+4. Run `make validate` to ensure your changes pass all checks.
+5. Commit and push your changes.
+
 ### :speech_balloon: Create a Pull Request
 
 When you're finished with the changes, create a pull request (PR).

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,90 @@
+# Azion Docs - Makefile for contributors
+# Based on CONTRIBUTING.md guidelines
+
+.PHONY: help install dev build build-local preview check lint format test clean
+
+# Default target
+help:
+	@echo "Azion Docs - Contributor Commands"
+	@echo "================================="
+	@echo ""
+	@echo "Setup:"
+	@echo "  make install        - Install dependencies"
+	@echo ""
+	@echo "Development:"
+	@echo "  make dev            - Start dev server with hot reload (http://localhost:4321)"
+	@echo "  make preview        - Preview production build locally"
+	@echo ""
+	@echo "Build:"
+	@echo "  make build          - Production build"
+	@echo "  make build-local    - Local build with frontmatter tests"
+	@echo ""
+	@echo "Quality:"
+	@echo "  make check          - Run Astro type checking"
+	@echo "  make lint           - Run ESLint"
+	@echo "  make format         - Format code with Prettier"
+	@echo "  make test           - Run all tests (frontmatter validation)"
+	@echo ""
+	@echo "All-in-one:"
+	@echo "  make validate       - Run check, lint, and build-local"
+	@echo ""
+	@echo "Clean:"
+	@echo "  make clean          - Remove build artifacts"
+	@echo ""
+
+# Setup
+install:
+	@echo "Installing dependencies..."
+	npm install
+
+# Development
+dev:
+	@echo "Starting dev server..."
+	npm run dev
+
+preview:
+	@echo "Starting preview server..."
+	npm run preview
+
+# Build
+build:
+	@echo "Running production build..."
+	npm run build
+
+build-local:
+	@echo "Running local build with frontmatter tests..."
+	npm run build:local
+
+# Quality
+check:
+	@echo "Running Astro type check..."
+	npm run check
+
+lint:
+	@echo "Running ESLint..."
+	npm run lint:eslint
+
+format:
+	@echo "Formatting code with Prettier..."
+	npm run format
+
+test:
+	@echo "Running frontmatter tests..."
+	npm run test:frontmatter
+
+# All-in-one validation
+validate: check lint build-local
+	@echo "✓ All validations passed!"
+
+# Clean
+clean:
+	@echo "Cleaning build artifacts..."
+	rm -rf dist/
+	rm -rf .astro/
+	rm -rf node_modules/.vite/
+	@echo "✓ Clean complete!"
+
+# Memory-expanded build (for large builds)
+build-memory:
+	@echo "Running build with expanded memory..."
+	NODE_OPTIONS='--max-old-space-size=8192' npm run build:local


### PR DESCRIPTION
## Summary

Added a `Makefile` to simplify common development commands for contributors, following the guidelines in [CONTRIBUTING.md](.github/CONTRIBUTING.md).

## Why
Improves contributor experience by providing a standardized interface for:
- Setting up the development environment
- Running local development server with hot reload
- Building and previewing changes
- Running linting and type checks
- Validating changes before submitting PRs

## Available Commands

| Command | Description |
|---------|-------------|
| `make help` | Show all available commands |
| `make install` | Install dependencies |
| `make dev` | Start dev server (http://localhost:4321) |
| `make build-local` | Local build with frontmatter tests |
| `make preview` | Preview production build |
| `make check` | Run Astro type checking |
| `make lint` | Run ESLint |
| `make format` | Format code with Prettier |
| `make validate` | Run all validations (check + lint + build) |
| `make clean` | Remove build artifacts |

## Testing
- [x] `make help` displays all commands
- [x] Commands match existing npm scripts in package.json
