### PR TITLE
docs(cli): update azion cli commands documentation for waf support

### DIFF
--- a/src/content/docs/en/pages/devtools/cli/azion-cli/commands/delete/delete.mdx
+++ b/src/content/docs/en/pages/devtools/cli/azion-cli/commands/delete/delete.mdx
@@ -15,8 +15,8 @@ menu_namespace: cliMenuAlpha
 With the `azion delete [resource]` command you can delete:
 
 - [Applications](#applications).
-    - [Functions](#functions). 
-    - [Rules engine](#rules-engine). 
+    - [Functions](#functions).
+    - [Rules engine](#rules-engine).
     - [Cache settings](#cache-settings).
     - [Workloads](#workloads).
     - [Connectors](#Connectors).
@@ -24,6 +24,8 @@ With the `azion delete [resource]` command you can delete:
     - [Personal tokens](#personal-tokens).
     - [Object Storage bucket](#object-storage-object).
     - [Object Storage object](#object-storage-object).
+    - [WAF](#waf).
+    - [WAF exceptions](#waf-exceptions).
 
 :::note 
 In case one or more required fields aren't informed through the specific flags, an interactive message prompts and asks for the missing information.
@@ -286,3 +288,55 @@ The `--object-key` flag specifies the key of the object in the Object Storage bu
 ##### help
 
 The `-h` or `--help` option displays more information about the `azion delete edge-storage object` command.
+
+---
+
+## WAF
+
+Deletes a WAF (Web Application Firewall).
+
+#### Usage
+
+```bash
+azion delete waf --waf-id <waf-id>
+```
+
+#### Required flags
+
+##### waf-id
+
+The `--waf-id` flag specifies the unique identifier of the WAF to be deleted.
+
+#### Optional flags
+
+##### help
+
+The `--help` flag displays more information about the `azion delete waf` command.
+
+---
+
+## WAF exceptions
+
+Deletes a WAF exception.
+
+#### Usage
+
+```bash
+azion delete waf-exceptions --exception-id <exception-id> --waf-id <waf-id>
+```
+
+#### Required flags
+
+##### exception-id
+
+The `--exception-id` flag specifies the unique identifier of the WAF exception to be deleted.
+
+##### waf-id
+
+The `--waf-id` flag specifies the unique identifier of the WAF associated with the exception.
+
+#### Optional flags
+
+##### help
+
+The `--help` flag displays more information about the `azion delete waf-exceptions` command.

--- a/src/content/docs/en/pages/devtools/cli/azion-cli/commands/describe/describe.mdx
+++ b/src/content/docs/en/pages/devtools/cli/azion-cli/commands/describe/describe.mdx
@@ -14,13 +14,15 @@ menu_namespace: cliMenuAlpha
 With the `azion describe [resource]` command you can describe:
 
 - [Applications](#applications).
-    - [Functions](#functions). 
-    - [Rules engine](#rules-engine). 
+    - [Functions](#functions).
+    - [Rules engine](#rules-engine).
     - [Cache settings](#cache-settings).
     - [Workloads](#workloads).
     - [Connectors](#connectors).
     - [Variables](#variables).
     - [Object Storage object](#edge-storage-object).
+    - [WAF](#waf).
+    - [WAF exceptions](#waf-exceptions).
 
 :::note 
 In case one or more required fields aren't informed through the specific flags, an interactive message prompts and asks for the missing information.
@@ -310,3 +312,71 @@ The `--format` option allows you to specify the format in which the command outp
 ##### out
 
 The `--out` option lets you specify a path where the output of the command will be stored. For example, './tmp/test.json'.
+
+---
+
+## WAF
+
+Describes a WAF (Web Application Firewall).
+
+#### Usage
+
+```bash
+azion describe waf --waf-id <waf-id> [flags]
+```
+
+#### Required flags
+
+##### waf-id
+
+The `--waf-id` flag specifies the unique identifier of the WAF.
+
+#### Optional flags
+
+##### format
+
+The `--format` flag changes the output format. Pass `json` to get JSON output.
+
+##### out
+
+The `--out` flag exports the output to the given file path.
+
+##### help
+
+The `--help` flag displays more information about the `azion describe waf` command.
+
+---
+
+## WAF exceptions
+
+Describes a WAF exception.
+
+#### Usage
+
+```bash
+azion describe waf-exceptions --exception-id <exception-id> --waf-id <waf-id> [flags]
+```
+
+#### Required flags
+
+##### exception-id
+
+The `--exception-id` flag specifies the unique identifier of the WAF exception.
+
+##### waf-id
+
+The `--waf-id` flag specifies the unique identifier of the WAF.
+
+#### Optional flags
+
+##### format
+
+The `--format` flag changes the output format. Pass `json` to get JSON output.
+
+##### out
+
+The `--out` flag exports the output to the given file path.
+
+##### help
+
+The `--help` flag displays more information about the `azion describe waf-exceptions` command.

--- a/src/content/docs/en/pages/devtools/cli/azion-cli/commands/list/list.mdx
+++ b/src/content/docs/en/pages/devtools/cli/azion-cli/commands/list/list.mdx
@@ -12,8 +12,8 @@ permalink: /documentation/devtools/cli/list/
 With the `azion list [resource]` command you can list your:
 
 - [Applications](#applications).
-    - [Functions](#functions). 
-    - [Rules engine](#rules-engine). 
+    - [Functions](#functions).
+    - [Rules engine](#rules-engine).
     - [Cache settings](#cache-settings).
     - [Workloads](#workloads).
     - [Connectors](#origins).
@@ -21,6 +21,8 @@ With the `azion list [resource]` command you can list your:
     - [Personal tokens](#personal-tokens).
     - [Object Storage bucket](#object-storage-bucket).
     - [Object Storage object](#object-storage-object).
+    - [WAF](#waf).
+    - [WAF exceptions](#waf-exceptions).
 
 :::note 
 In case one or more required fields aren't informed through the specific flags, an interactive message prompts and asks for the missing information.
@@ -377,5 +379,95 @@ The `-h` or `--help` option displays more detailed information about the `azion 
 ##### page-size
 
 The `--page-size` option defines how many items should be returned per page. The default value is `50`.
+
+---
+
+## WAF
+
+Lists all WAFs (Web Application Firewalls).
+
+#### Usage
+
+```bash
+azion list waf [flags]
+```
+
+#### Optional flags
+
+##### details
+
+The `--details` flag displays all relevant fields when listing.
+
+##### filter
+
+The `--filter` flag filters items by their name.
+
+##### order-by
+
+The `--order-by` flag sorts the output based on the selected field.
+
+##### page
+
+The `--page` flag returns a specific page of the list according to its number. By default, it's `1`.
+
+##### page-size
+
+The `--page-size` flag defines how many items should be returned per page. By default, it's `10`.
+
+##### sort
+
+The `--sort` flag defines the order of the items on the list. The value should be either `asc` or `desc`.
+
+##### help
+
+The `--help` flag displays more information about the `azion list waf` command.
+
+---
+
+## WAF exceptions
+
+Lists all WAF exceptions for a given WAF.
+
+#### Usage
+
+```bash
+azion list waf-exceptions --waf-id <waf-id> [flags]
+```
+
+#### Required flags
+
+##### waf-id
+
+The `--waf-id` flag specifies the unique identifier of the WAF.
+
+#### Optional flags
+
+##### details
+
+The `--details` flag displays all relevant fields when listing.
+
+##### filter
+
+The `--filter` flag filters items by their name.
+
+##### order-by
+
+The `--order-by` flag sorts the output based on the selected field.
+
+##### page
+
+The `--page` flag returns a specific page of the list according to its number. By default, it's `1`.
+
+##### page-size
+
+The `--page-size` flag defines how many items should be returned per page. By default, it's `10`.
+
+##### sort
+
+The `--sort` flag defines the order of the items on the list. The value should be either `asc` or `desc`.
+
+##### help
+
+The `--help` flag displays more information about the `azion list waf-exceptions` command.
 
 

--- a/src/content/docs/en/pages/devtools/cli/azion-cli/commands/update/update.mdx
+++ b/src/content/docs/en/pages/devtools/cli/azion-cli/commands/update/update.mdx
@@ -12,14 +12,16 @@ permalink: /documentation/devtools/cli/update/
 With the `azion update [resource]` command you can update:
 
 - [Applications](#applications).
-    - [Functions](#functions-1). 
-    - [Rules engine](#rules-engine). 
+    - [Functions](#functions-1).
+    - [Rules engine](#rules-engine).
     - [Cache settings](#cache-settings).
     - [Workloads](#workloads).
     - [Connectors](#connectors).
     - [Variables](#variables).
     - [Object Storage object](#object-storage-bucket).
     - [Object Storage object](#object-storage-object).
+    - [WAF](#waf).
+    - [WAF exceptions](#waf-exceptions).
 
 :::note 
 In case one or more required fields aren't informed through the specific flags, an interactive message prompts and asks for the missing information.
@@ -645,4 +647,72 @@ Attributes inside a `JSON` file:
 ##### help
 
 The `-h` or `--help` option provides more information about the `azion update edge-storage object` command.
+
+---
+
+## WAF
+
+Updates a WAF (Web Application Firewall).
+
+#### Usage
+
+```bash
+azion update waf --waf-id <waf-id> [flags]
+```
+
+#### Required flags
+
+##### waf-id
+
+The `--waf-id` flag specifies the unique identifier of the WAF to be updated.
+
+#### Optional flags
+
+##### name
+
+The `--name` flag sets the new name for the WAF.
+
+##### mode
+
+The `--mode` flag sets the WAF mode. Possible values: `learning` or `blocking`.
+
+##### file
+
+The `--file` flag specifies the path to a JSON file containing the attributes of the WAF. You can use `-` for reading from stdin.
+
+##### help
+
+The `--help` flag displays more information about the `azion update waf` command.
+
+---
+
+## WAF exceptions
+
+Updates a WAF exception.
+
+#### Usage
+
+```bash
+azion update waf-exceptions --exception-id <exception-id> --waf-id <waf-id> [flags]
+```
+
+#### Required flags
+
+##### exception-id
+
+The `--exception-id` flag specifies the unique identifier of the WAF exception to be updated.
+
+##### waf-id
+
+The `--waf-id` flag specifies the unique identifier of the WAF associated with the exception.
+
+#### Optional flags
+
+##### file
+
+The `--file` flag specifies the path to a JSON file containing the attributes of the WAF exception. You can use `-` for reading from stdin.
+
+##### help
+
+The `--help` flag displays more information about the `azion update waf-exceptions` command.
 

--- a/src/content/docs/en/pages/main-menu/reference/observe/data-stream/data-stream.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/observe/data-stream/data-stream.mdx
@@ -114,6 +114,7 @@ The **Activity History** data source displays the data for [logs activity](/en/d
 | Variable | Description | Example |
 | --- | --- | --- |
 | $account_id | Azion account identifier. | "8437" |
+| $created_at | Date and time when the resource was created. Enables filtering and ordering by creation time. | "2026-03-30T14:25:00Z" |
 | $author_email | Email address of the Azion Console user who performed the action. | "myemail@gmail.com" |
 | $author_name | Name of the Azion Console user who performed the action. | "Gabriel Alves" |
 | $client | Unique Azion customer identifier. | "4529r" |

--- a/src/content/docs/pt-br/pages/devtools/cli/azion-cli/comandos/delete/delete.mdx
+++ b/src/content/docs/pt-br/pages/devtools/cli/azion-cli/comandos/delete/delete.mdx
@@ -14,15 +14,17 @@ menu_namespace: cliMenuAlpha
 Com o comando `azion delete [recurso]` você pode remover:
 
 - [Applications](#applications).
-    - [Functions](#functions). 
-    - [Rules engine](#rules-engine). 
+    - [Functions](#functions).
+    - [Rules engine](#rules-engine).
     - [Cache settings](#cache-settings).
     - [Workload](#workloads).
-    - [Connectors](#connectors). 
+    - [Connectors](#connectors).
     - [Variables](#variables).
     - [Personal tokens](#personal-tokens).
     - [Object Storage bucket](#object-storage-bucket).
     - [Object Storage object](#object-storage-object).
+    - [WAF](#waf).
+    - [WAF exceptions](#waf-exceptions).
 
 :::note
 No caso de um ou mais campos obrigatórios não serem informados através das flags específicas, uma mensagem interativa será exibida, solicitando essas informações.
@@ -276,3 +278,55 @@ A flag `--object-key` especifica a chave do objeto no bucket no Object Storage q
 ##### help
 
 A opção `-h` ou `--help` exibe mais informações sobre o comando `azion delete edge-storage object`.
+
+---
+
+## WAF
+
+Exclui um WAF (Web Application Firewall).
+
+#### Uso
+
+```bash
+azion delete waf --waf-id <waf-id>
+```
+
+#### Flags obrigatórias
+
+##### waf-id
+
+A flag `--waf-id` especifica o identificador único do WAF a ser excluído.
+
+#### Flags opcionais
+
+##### help
+
+A flag `--help` exibe mais informações sobre o comando `azion delete waf`.
+
+---
+
+## WAF exceptions
+
+Exclui uma exceção de WAF.
+
+#### Uso
+
+```bash
+azion delete waf-exceptions --exception-id <exception-id> --waf-id <waf-id>
+```
+
+#### Flags obrigatórias
+
+##### exception-id
+
+A flag `--exception-id` especifica o identificador único da exceção de WAF a ser excluída.
+
+##### waf-id
+
+A flag `--waf-id` especifica o identificador único do WAF associado à exceção.
+
+#### Flags opcionais
+
+##### help
+
+A flag `--help` exibe mais informações sobre o comando `azion delete waf-exceptions`.

--- a/src/content/docs/pt-br/pages/devtools/cli/azion-cli/comandos/describe/describe.mdx
+++ b/src/content/docs/pt-br/pages/devtools/cli/azion-cli/comandos/describe/describe.mdx
@@ -15,13 +15,15 @@ menu_namespace: cliMenuAlpha
 Com o comando `azion describe [recurso]` você pode acessar informações de suas:
 
 - [Applications](#applications).
-    - [Functions](#functions). 
-    - [Rules engine](#rules-engine). 
+    - [Functions](#functions).
+    - [Rules engine](#rules-engine).
     - [Cache settings](#cache-settings).
     - [Workloads](#workloads).
-    - [Connectors](#edge-connectors). 
+    - [Connectors](#edge-connectors).
     - [Variables](#variables).
     - [Object Storage object](#edge-storage-object).
+    - [WAF](#waf).
+    - [WAF exceptions](#waf-exceptions).
 
 :::note
 No caso de um ou mais campos obrigatórios não serem informados através das flags específicas, uma mensagem interativa será exibida, solicitando essas informações.
@@ -270,3 +272,71 @@ A opção `--format` permite que você especifique o formato em que a saída do 
 ##### out
 
 A opção `--out` permite que você especifique um caminho onde a saída do comando será armazenada. Por exemplo, './tmp/test.json'.
+
+---
+
+## WAF
+
+Descreve um WAF (Web Application Firewall).
+
+#### Uso
+
+```bash
+azion describe waf --waf-id <waf-id> [flags]
+```
+
+#### Flags obrigatórias
+
+##### waf-id
+
+A flag `--waf-id` especifica o identificador único do WAF.
+
+#### Flags opcionais
+
+##### format
+
+A flag `--format` altera o formato de saída. Passe `json` para obter saída em JSON.
+
+##### out
+
+A flag `--out` exporta a saída para o caminho de arquivo fornecido.
+
+##### help
+
+A flag `--help` exibe mais informações sobre o comando `azion describe waf`.
+
+---
+
+## WAF exceptions
+
+Descreve uma exceção de WAF.
+
+#### Uso
+
+```bash
+azion describe waf-exceptions --exception-id <exception-id> --waf-id <waf-id> [flags]
+```
+
+#### Flags obrigatórias
+
+##### exception-id
+
+A flag `--exception-id` especifica o identificador único da exceção de WAF.
+
+##### waf-id
+
+A flag `--waf-id` especifica o identificador único do WAF.
+
+#### Flags opcionais
+
+##### format
+
+A flag `--format` altera o formato de saída. Passe `json` para obter saída em JSON.
+
+##### out
+
+A flag `--out` exporta a saída para o caminho de arquivo fornecido.
+
+##### help
+
+A flag `--help` exibe mais informações sobre o comando `azion describe waf-exceptions`.

--- a/src/content/docs/pt-br/pages/devtools/cli/azion-cli/comandos/list/list.mdx
+++ b/src/content/docs/pt-br/pages/devtools/cli/azion-cli/comandos/list/list.mdx
@@ -14,15 +14,17 @@ menu_namespace: cliMenuAlpha
 Com o comando `azion list [recurso]` você pode listar:
 
 - [Applications](#applications).
-    - [Functions](#functions). 
-    - [Rules engine](#rules-engine). 
+    - [Functions](#functions).
+    - [Rules engine](#rules-engine).
     - [Cache settings](#cache-settings).
     - [Workloads](#workloads).
-    - [Edge Connectors](#connectors). 
+    - [Edge Connectors](#connectors).
     - [Variables](#variables).
     - [Personal tokens](#personal-tokens).
-    - [Object Storage bucket](#object-storage-bucket). 
+    - [Object Storage bucket](#object-storage-bucket).
     - [Object Storage object](#object-storage-object).
+    - [WAF](#waf).
+    - [WAF exceptions](#waf-exceptions).
 
 
 :::note
@@ -374,3 +376,93 @@ A opção `-h` ou `--help` exibe informações mais detalhadas sobre o comando `
 ##### page-size
 
 A opção `--page-size` define quantos itens devem ser retornados por página. O valor padrão é `50`.
+
+---
+
+## WAF
+
+Lista todos os WAFs (Web Application Firewalls).
+
+#### Uso
+
+```bash
+azion list waf [flags]
+```
+
+#### Flags opcionais
+
+##### details
+
+A flag `--details` exibe todos os campos relevantes ao listar.
+
+##### filter
+
+A flag `--filter` filtra itens pelo nome.
+
+##### order-by
+
+A flag `--order-by` ordena a saída com base no campo selecionado.
+
+##### page
+
+A flag `--page` retorna uma página específica da lista de acordo com seu número. Por padrão, é `1`.
+
+##### page-size
+
+A flag `--page-size` define quantos itens devem ser retornados por página. Por padrão, é `10`.
+
+##### sort
+
+A flag `--sort` define a ordem dos itens na lista. O valor deve ser `asc` ou `desc`.
+
+##### help
+
+A flag `--help` exibe mais informações sobre o comando `azion list waf`.
+
+---
+
+## WAF exceptions
+
+Lista todas as exceções de WAF para um determinado WAF.
+
+#### Uso
+
+```bash
+azion list waf-exceptions --waf-id <waf-id> [flags]
+```
+
+#### Flags obrigatórias
+
+##### waf-id
+
+A flag `--waf-id` especifica o identificador único do WAF.
+
+#### Flags opcionais
+
+##### details
+
+A flag `--details` exibe todos os campos relevantes ao listar.
+
+##### filter
+
+A flag `--filter` filtra itens pelo nome.
+
+##### order-by
+
+A flag `--order-by` ordena a saída com base no campo selecionado.
+
+##### page
+
+A flag `--page` retorna uma página específica da lista de acordo com seu número. Por padrão, é `1`.
+
+##### page-size
+
+A flag `--page-size` define quantos itens devem ser retornados por página. Por padrão, é `10`.
+
+##### sort
+
+A flag `--sort` define a ordem dos itens na lista. O valor deve ser `asc` ou `desc`.
+
+##### help
+
+A flag `--help` exibe mais informações sobre o comando `azion list waf-exceptions`.

--- a/src/content/docs/pt-br/pages/devtools/cli/azion-cli/comandos/update/update.mdx
+++ b/src/content/docs/pt-br/pages/devtools/cli/azion-cli/comandos/update/update.mdx
@@ -15,14 +15,16 @@ menu_namespace: cliMenuAlpha
 Com o comando `azion update [recurso]` você pode atualizar:
 
 - [Applications](#applications).
-    - [Functions](#functions). 
-    - [Rules engine](#rules-engine). 
+    - [Functions](#functions).
+    - [Rules engine](#rules-engine).
     - [Cache settings](#cache-settings).
     - [Workloads](#workloads).
-    - [Connectors](#connectors). 
+    - [Connectors](#connectors).
     - [Variables](#variables).
     - [Object Storage bucket](#object-storage-bucket).
     - [Object Storage object](#object-storage-object).
+    - [WAF](#waf).
+    - [WAF exceptions](#waf-exceptions).
 
 :::note
 No caso de um ou mais campos obrigatórios não serem informados através das flags específicas, uma mensagem interativa será exibida, solicitando essas informações.
@@ -610,3 +612,71 @@ A opção `--file` refere-se ao caminho para um arquivo JSON contendo os atribut
 ##### help
 
 A opção `-h` ou `--help` fornece mais informações sobre o comando `azion update edge-storage object`.
+
+---
+
+## WAF
+
+Atualiza um WAF (Web Application Firewall).
+
+#### Uso
+
+```bash
+azion update waf --waf-id <waf-id> [flags]
+```
+
+#### Flags obrigatórias
+
+##### waf-id
+
+A flag `--waf-id` especifica o identificador único do WAF a ser atualizado.
+
+#### Flags opcionais
+
+##### name
+
+A flag `--name` define o novo nome para o WAF.
+
+##### mode
+
+A flag `--mode` define o modo do WAF. Valores possíveis: `learning` ou `blocking`.
+
+##### file
+
+A flag `--file` especifica o caminho para um arquivo JSON contendo os atributos do WAF. Você pode usar `-` para ler do stdin.
+
+##### help
+
+A flag `--help` exibe mais informações sobre o comando `azion update waf`.
+
+---
+
+## WAF exceptions
+
+Atualiza uma exceção de WAF.
+
+#### Uso
+
+```bash
+azion update waf-exceptions --exception-id <exception-id> --waf-id <waf-id> [flags]
+```
+
+#### Flags obrigatórias
+
+##### exception-id
+
+A flag `--exception-id` especifica o identificador único da exceção de WAF a ser atualizada.
+
+##### waf-id
+
+A flag `--waf-id` especifica o identificador único do WAF associado à exceção.
+
+#### Flags opcionais
+
+##### file
+
+A flag `--file` especifica o caminho para um arquivo JSON contendo os atributos da exceção de WAF. Você pode usar `-` para ler do stdin.
+
+##### help
+
+A flag `--help` exibe mais informações sobre o comando `azion update waf-exceptions`.

--- a/src/content/docs/pt-br/pages/menu-principal/referencia/observe/data-streaming/data-streaming.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/referencia/observe/data-streaming/data-streaming.mdx
@@ -116,6 +116,7 @@ O data source **Activity History** exibe os dados referentes aos [registros de a
 | Variável | Descrição | Exemplo |
 | --- | --- | --- |
 | $account_id | Identificador da conta Azion. | "8437" |
+| $created_at | Data e hora em que o recurso foi criado. Permite filtragem e ordenação por tempo de criação. | "2026-03-30T14:25:00Z" |
 | $author_email | Email do usuário do Azion Console que executou a atividade. | "myemail@gmail.com" |
 | $author_name | Nome do usuário do Azion Console que executou a atividade. | "Gabriel Alves" |
 | $client | Identificador único de cliente Azion. | "4529r" |


### PR DESCRIPTION
Add comprehensive documentation for WAF and WAF exceptions in delete, describe, list, and update commands, including usage examples, required and optional flags, and help options. Update both English and Portuguese versions. Additionally, enhance Data Stream reference to include the new created_at variable for activity history filtering and ordering.