### PR TITLE
docs: add release notes for April 9 and 10, 2026

### DIFF
--- a/src/content/docs/en/pages/main-menu/release-notes/release-notes.mdx
+++ b/src/content/docs/en/pages/main-menu/release-notes/release-notes.mdx
@@ -10,6 +10,46 @@ permalink: /documentation/products/release-notes/
 import Tag from 'primevue/tag'
 
 ---
+## April 10, 2026
+
+### API v4 (Preview)
+
+Updates deployed to the GraphQL API at `api.azion.com/v4/*/graphql`:
+
+#### Features
+
+- **activityHistoryEvents dataset**: Added two new event types:
+  - `User Login`
+  - `User Lockout Policy`
+
+---
+## April 9, 2026
+
+### Azion Console
+
+**Version 1.56.0**
+
+#### Features
+
+- **New Console Home**: Redesigned home page with metrics, product listings, and resource overview
+  - Metrics section with four KPI cards: Total Data Transferred, Requests Per Second, Bandwidth Saving, and Data Transfer Offload, each with percentage change indicators
+  - Resources table listing workloads with domain, status, and last modified date
+  - Last Activities feed showing recent operations with resource type, resource name, parent info, and author email
+  - Right sidebar with Monthly Usage summary and Marketplace Trends
+  - Prominent Invite User button and team name greeting
+
+#### Improvements
+
+- **Server-Sent Events (SSE)**: Introduced SSE to improve data freshness and responsiveness across the platform
+  - Cache is automatically invalidated whenever updates occur
+  - Fresh data is proactively prefetched to keep the UI in sync
+- **Activity History**: Improved information display in activity tracking
+- **Cache Governance**: Implemented governance architecture to ensure cache performance
+- **Page Loading**: Added skeleton loading states on edit pages
+- **Azion Webkit**: Externalized input components to Azion Webkit
+
+
+---
 ## April 2, 2026
 
 ### API

--- a/src/content/docs/pt-br/pages/menu-principal/release-notes/release-notes.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/release-notes/release-notes.mdx
@@ -10,6 +10,46 @@ permalink: /documentacao/produtos/release-notes/
 import Tag from 'primevue/tag'
 
 ---
+## 10 de abril, 2026
+
+### API v4 (Preview)
+
+Atualizações implantadas na API GraphQL em `api.azion.com/v4/*/graphql`:
+
+#### Recursos
+
+- **Dataset activityHistoryEvents**: Adicionados dois novos tipos de evento:
+  - `User Login`
+  - `User Lockout Policy`
+
+---
+## 9 de abril, 2026
+
+### Azion Console
+
+**Versão 1.56.0**
+
+#### Recursos
+
+- **Nova Home do Console**: Página inicial reformulada com métricas, listagem de produtos e visão geral de recursos
+  - Seção de métricas com quatro cards de KPI: Total de Dados Transferidos, Requisições Por Segundo, Economia de Banda e Offload de Transferência de Dados, cada um com indicadores de variação percentual
+  - Tabela de recursos listando workloads com domínio, status e última data de modificação
+  - Feed de Últimas Atividades exibindo operações recentes com tipo de recurso, nome do recurso, informações do pai e email do autor
+  - Barra lateral direita com resumo de Uso Mensal e Tendências do Marketplace
+  - Botão de Convidar Usuário em destaque e saudação personalizada com nome do time
+
+#### Melhorias
+
+- **Server-Sent Events (SSE)**: Introduzido SSE para melhorar a atualização de dados e responsividade em toda a plataforma
+  - Cache é automaticamente invalidado sempre que ocorrem atualizações
+  - Dados atualizados são prefetchados proativamente para manter a UI sincronizada
+- **Activity History**: Melhoria na exibição de informações no rastreamento de atividades
+- **Governança de Cache**: Implementada arquitetura de governança para garantir performance de cache
+- **Carregamento de Páginas**: Adicionados estados de skeleton loading nas páginas de edição
+- **Azion Webkit**: Externalizados componentes de input para o Azion Webkit
+
+
+---
 ## 2 de abril, 2026
 
 ### API


### PR DESCRIPTION
Adds documentation for new features and improvements in Azion Console v1.56.0 and API v4 updates, including redesigned console home, SSE implementation, and new activity history events.