### PR TITLE
docs(release-notes): update documentation for API v4 and Terraform v2

### DIFF
--- a/src/content/docs/en/pages/main-menu/release-notes/release-notes.mdx
+++ b/src/content/docs/en/pages/main-menu/release-notes/release-notes.mdx
@@ -10,6 +10,65 @@ permalink: /documentation/products/release-notes/
 import Tag from 'primevue/tag'
 
 ---
+## April 17, 2026
+
+### API v4 (Preview)
+
+Updates deployed to the GraphQL API at `api.azion.com/v4/*/graphql`:
+
+#### Improvements
+
+- **Datasource aliases**: Added aliases for datasources. Current names continue to work:
+  - `cellsConsoleEvents` → `functionConsoleEvents`
+  - `edgeFunctionEvents` → `functionEvents`
+  - `httpEvents` → `workloadEvents`
+- **Field aliases**: Added aliases for fields. Current names continue to work:
+  - `edgeFunctionsInstanceIdList` → `functionsInstanceIdList`
+  - `edgeFunctionsInitiatorTypeList` → `functionsInitiatorTypeList`
+  - `edgeFunctionsList` → `functionsList`
+  - `edgeFunctionsSolutionId` → `functionsSolutionId`
+  - `edgeFunctionsTime` → `functionsTime`
+
+---
+## April 16, 2026
+
+### Terraform Provider
+
+**Version 2.0.0**
+
+<Tag severity="warning" client:only="vue">Breaking Changes</Tag>
+
+This major release migrates the Azion Terraform Provider to API v4, bringing improved performance, new features, and a more consistent resource management experience.
+
+#### API Version Migration
+
+- **Version 2.0.0+**: Supports Azion API v4 only
+- **Version 1.41.0 and earlier**: Supports Azion API v3
+
+If you are currently using API v3, you must remain on version 1.41.0 or earlier, or update your configurations to be compatible with API v4.
+
+#### Removed Resources and Data Sources
+
+Resources and data sources that no longer exist in API v4 have been removed, such as origins and domains.
+
+#### Features
+
+- Migrated to Azion API v4 for improved performance and reliability
+- Added new APIs that were missing from Terraform, providing a full suite of Azion products in the provider
+
+#### Improvements
+
+- Updated SDK dependencies to latest versions
+- Removed legacy API client configurations
+- Streamlined provider configuration
+
+#### Documentation Updates
+
+- Added API Version Notice section to README.md
+- Removed documentation files for deprecated resources
+- Updated example configurations to remove deprecated resources
+
+---
 ## April 13, 2026
 
 ### Azion Console

--- a/src/content/docs/pt-br/pages/menu-principal/release-notes/release-notes.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/release-notes/release-notes.mdx
@@ -10,6 +10,65 @@ permalink: /documentacao/produtos/release-notes/
 import Tag from 'primevue/tag'
 
 ---
+## 17 de abril, 2026
+
+### API v4 (Preview)
+
+Atualizações implantadas na API GraphQL em `api.azion.com/v4/*/graphql`:
+
+#### Melhorias
+
+- **Aliases de datasource**: Adicionados aliases para datasources. Os nomes atuais continuam funcionando:
+  - `cellsConsoleEvents` → `functionConsoleEvents`
+  - `edgeFunctionEvents` → `functionEvents`
+  - `httpEvents` → `workloadEvents`
+- **Aliases de campo**: Adicionados aliases para campos. Os nomes atuais continuam funcionando:
+  - `edgeFunctionsInstanceIdList` → `functionsInstanceIdList`
+  - `edgeFunctionsInitiatorTypeList` → `functionsInitiatorTypeList`
+  - `edgeFunctionsList` → `functionsList`
+  - `edgeFunctionsSolutionId` → `functionsSolutionId`
+  - `edgeFunctionsTime` → `functionsTime`
+
+---
+## 16 de abril, 2026
+
+### Terraform Provider
+
+**Versão 2.0.0**
+
+<Tag severity="warning" client:only="vue">Breaking Changes</Tag>
+
+Esta versão principal migra o Azion Terraform Provider para a API v4, trazendo melhorias de performance, novos recursos e uma experiência mais consistente de gerenciamento de recursos.
+
+#### Migração de Versão da API
+
+- **Versão 2.0.0+**: Suporta apenas Azion API v4
+- **Versão 1.41.0 e anteriores**: Suporta Azion API v3
+
+Se você está utilizando API v3, deve permanecer na versão 1.41.0 ou anterior, ou atualizar suas configurações para serem compatíveis com a API v4.
+
+#### Recursos e Data Sources Removidos
+
+Recursos e data sources que não existem mais na API v4 foram removidos, como origins e domains.
+
+#### Recursos
+
+- Migração para Azion API v4 para melhor performance e confiabilidade
+- Adicionadas novas APIs que estavam ausentes no Terraform, fornecendo um conjunto completo de produtos Azion no provider
+
+#### Melhorias
+
+- Atualizadas dependências do SDK para as versões mais recentes
+- Removidas configurações legadas do cliente API
+- Simplificada a configuração do provider
+
+#### Atualizações de Documentação
+
+- Adicionada seção de Aviso de Versão da API no README.md
+- Removidos arquivos de documentação de recursos depreciados
+- Atualizadas configurações de exemplo para remover recursos depreciados
+
+---
 ## 13 de abril, 2026
 
 ### Azion Console


### PR DESCRIPTION
Add release notes for April 16 and 17, 2026, covering:
- API v4 (Preview) improvements including datasource and field aliases.
- Terraform Provider v2.0.0 major release, including breaking changes regarding API v4 migration and removed resources.

