### PR TITLE
Fix no slug de Data Stream na página de Pricing PT-BR

### DIFF
--- a/src/components/Table/TablePricing.astro
+++ b/src/components/Table/TablePricing.astro
@@ -91,6 +91,7 @@ const i18n = {
 		'Over 5,000 million images processed/month': 'Acima de 5.000 milhões de imagens processadas / mês',
 
 		'First 100,000 requests / month': 'Primeiras 100.000 requisições / mês',
+		'First 1 million requests / month': 'Primeiro 1 milhão de requisições / mês',
 		'Next 999,900,000 requests / month': 'Próximas 999.900.000 requisições / mês',
 		'First 1 billion requests /month': 'Primeiro 1 bilhão de requisições / mês', 
 		'First 1 billion requests/month': 'Primeiro 1 bilhão de requisições / mês',


### PR DESCRIPTION
<!--
Thank you for contributing to Azion Docs! Please fill out the information below.
Use the conventional commits standard to categorize the type of change in the PR title. We recommend:
- feat: adding new content
- refactor: making minor changes
- fix: fixing errors

Don't forget to add the Jira issue code to the PR title or the GitHub issue hash.
For example: 
- [EDU-3000] refactor: modify origins page to include load balancer
- [#34] feat: add new application CLI commands
- [NO-ISSUE] fix: fix broken link in Orch doc
-->

### Related issue: Fix no slug "First 1 million requests / month" para "Primeiro 1 milhão requisições / mês" versão PT-BR em TablePricing.astro para a página de Princing

[EDU-3000]: https://aziontech.atlassian.net/browse/EDU-3000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ