### PR TITLE
EDU-6935-changes-on-30-06-26

### DIFF
--- a/src/content/docs/en/pages/main-menu/pricing/pricing.mdx
+++ b/src/content/docs/en/pages/main-menu/pricing/pricing.mdx
@@ -31,7 +31,7 @@ Our On-Demand billing model utilizes monthly tiered pricing. You only pay for wh
 
 ## Workloads
 
-Workloads are billed based on two metrics: Workloads and Data Transfer.
+Workloads are billed based on three metrics: Workloads, Data Transfer and Requests.
 
 
 <TablePricing
@@ -43,10 +43,11 @@ Workloads are billed based on two metrics: Workloads and Data Transfer.
   metric_slug="workload_workloads"
 />
 
+
 <TablePricing
   lang="en"
   coin="dolar"
-  metric='Requests (per 10,000)'
+  metric='Data Transfer (per GB)'
   billing={[
     'United States',
     'Canada',
@@ -59,16 +60,6 @@ Workloads are billed based on two metrics: Workloads and Data Transfer.
   metric_slug="workload_data_transfer"
 />
 
-<LinkButton link="/en/documentation/products/secure/workloads/" label="View product documentation" severity="secondary" />
-
----
-
-## Build
-
-### Applications
-
-Applications are billed based on two metrics: Requests and Rules.
-
 
 <TablePricing
   lang="en"
@@ -82,9 +73,22 @@ Applications are billed based on two metrics: Requests and Rules.
     'Latam',
     'Other regions'
   ]}
-  product_slug="application"
-  metric_slug="application_requests"
+  product_slug="workload"
+  metric_slug="workload_requests"
 />
+
+
+
+<LinkButton link="/en/documentation/products/secure/workloads/" label="View product documentation" severity="secondary" />
+
+---
+
+## Build
+
+### Applications
+
+Applications are billed based on the following metric: Rules.
+
 
 <TablePricing
   lang="en"
@@ -638,7 +642,7 @@ Included with the platform, no additional charge.
 
 ## Support
 
-### Developer Service Plan
+### Developer Support
 
 Included in the service package, no additional charge.
 <LinkButton link="https://www.azion.com/en/professional-services/" label="Compare support levels" />
@@ -673,7 +677,7 @@ Included in the service package, no additional charge.
 
 <LinkButton link="https://www.azion.com/en/professional-services/" label="Compare support levels" />
 
-### Mission Critical Support
+### Mission-Critical Support
 
 | Support Fee |
 | :--- |

--- a/src/content/docs/en/pages/main-menu/pricing/pricing.mdx
+++ b/src/content/docs/en/pages/main-menu/pricing/pricing.mdx
@@ -46,7 +46,7 @@ Workloads are billed based on two metrics: Workloads and Data Transfer.
 <TablePricing
   lang="en"
   coin="dolar"
-  metric='Data Transfer (per GB)'
+  metric='Requests (per 10,000)'
   billing={[
     'United States',
     'Canada',
@@ -636,16 +636,16 @@ Included with the platform, no additional charge.
 ---
 
 
-## Service Plans
+## Support
 
 ### Developer Service Plan
 
 Included in the service package, no additional charge.
-<LinkButton link="https://www.azion.com/en/professional-services/" label="Compare plans" />
+<LinkButton link="https://www.azion.com/en/professional-services/" label="Compare support levels" />
 
-### Business Service Plan
+### Business Support
 
-| Service Fee | 
+| Support Fee | 
 | :--- |
 | Minimum of $100 per month |  
 | - or, if higher than the minimum - |   
@@ -657,11 +657,11 @@ Included in the service package, no additional charge.
 
 
 
-<LinkButton link="https://www.azion.com/en/professional-services/" label="Compare plans" />
+<LinkButton link="https://www.azion.com/en/professional-services/" label="Compare support levels" />
 
-### Enterprise Service Plan
+### Enterprise Support
 
-| Service Fee |
+| Support Fee |
 | :--- |
 | Minimum of $3,500 per month |
 | - or, if higher than the minimum - |
@@ -671,11 +671,11 @@ Included in the service package, no additional charge.
 | 3% of monthly product charges over $360,000  |
 
 
-<LinkButton link="https://www.azion.com/en/professional-services/" label="Compare plans" />
+<LinkButton link="https://www.azion.com/en/professional-services/" label="Compare support levels" />
 
-### Mission Critical Service Plan
+### Mission Critical Support
 
-| Service Fee |
+| Support Fee |
 | :--- |
 | Minimum of $14,000 per month |
 | - or, if higher than the minimum - |
@@ -684,9 +684,9 @@ Included in the service package, no additional charge.
 | 5% of monthly product charges from $500,000 to $1,000,000 |
 | 3% of monthly product charges over $1,000,000  |
 
-<LinkButton link="https://www.azion.com/en/professional-services/" label="Compare plans" />
+<LinkButton link="https://www.azion.com/en/professional-services/" label="Compare support levels" />
 
-### Professional Services: Add-ons
+### Professional Services
 
 | Integration Services| Price |
 | :--- | :--- |

--- a/src/content/docs/pt-br/pages/menu-principal/pricing/pricing.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/pricing/pricing.mdx
@@ -52,7 +52,7 @@ Workloads é cobrado com base em duas métricas: Workloads e Data Transfer.
 <TablePricing
   lang="pt-br"
   coin="dolar"
-  metric='Data Transfer (por GB)'
+  metric='Requests (Por 10.000)'
   billing={[
     'EUA',
     'Canadá',
@@ -642,16 +642,16 @@ Incluído na plataforma, sem cobrança adicional.
 ---
 
 
-## Service Plans
+## Support
 
-### Developer Service Plan
+### Developer Support
 
 Incluído no pacote de serviços, sem cobrança adicional.
-<LinkButton link="https://www.azion.com/pt-br/servicos-profissionais/" label="Comparar planos" />
+<LinkButton link="https://www.azion.com/pt-br/servicos-profissionais/" label="Comparar níveis de suporte" />
 
-### Business Service Plan
+### Business Support
 
-| Service Fee | 
+| Support Fee | 
 | :--- |
 | Mínimo de 100 USD por mês |  
 | - ou, se maior que o mínimo - |   
@@ -664,11 +664,11 @@ Incluído no pacote de serviços, sem cobrança adicional.
 
 
 
-<LinkButton link="https://www.azion.com/pt-br/servicos-profissionais/" label="Comparar planos" />
+<LinkButton link="https://www.azion.com/pt-br/servicos-profissionais/" label="Comparar níveis de suporte" />
 
-### Enterprise Service Plan
+### Enterprise Support
 
-| Service Fee | 
+| Support Fee | 
 | :--- |
 | Mínimo de 3.500 USD por mês |  
 | - ou, se maior que o mínimo - |   
@@ -678,11 +678,11 @@ Incluído no pacote de serviços, sem cobrança adicional.
 | 3% sobre o valor mensal dos produtos acima de 360.000 USD  |  
 
 
-<LinkButton link="https://www.azion.com/pt-br/servicos-profissionais/" label="Comparar planos" />
+<LinkButton link="https://www.azion.com/pt-br/servicos-profissionais/" label="Comparar níveis de suporte" />
 
-### Mission Critical Service Plan
+### Mission Critical Support
 
-| Service Fee | 
+| Support Fee | 
 | :--- |
 | Mínimo de 14.000 USD por mês |  
 | - ou, se maior que o mínimo - |   
@@ -691,9 +691,9 @@ Incluído no pacote de serviços, sem cobrança adicional.
 | 5% sobre o valor mensal dos produtos de 500.000 até 1.000.000 USD |  
 | 3% sobre o valor mensal dos produtos acima de 1.000.000 USD  |  
 
-<LinkButton link="https://www.azion.com/pt-br/servicos-profissionais/" label="Comparar planos" />
+<LinkButton link="https://www.azion.com/pt-br/servicos-profissionais/" label="Comparar níveis de suporte" />
 
-### Serviços Profissionais: Add-ons
+### Serviços Profissionais
 
 | Integration Services| Preço por pacote |
 | :--- | :--- |
@@ -758,7 +758,7 @@ Workloads é cobrado com base em duas métricas: Workloads e Data Transfer.
 <TablePricing
   lang="pt-br"
   coin="real"
-  metric='Data Transfer (por GB)'
+  metric='Requests (Por 10.000)'
   billing={[
     'EUA',
     'Canadá',
@@ -1358,16 +1358,16 @@ Incluído na plataforma, sem cobrança adicional.
 ---
 
 
-##  Service Plans
+##  Support
 
-### Developer Service Plan
+### Developer Support
 
 Incluído no pacote de serviços, sem cobrança adicional.
-<LinkButton link="https://www.azion.com/pt-br/servicos-profissionais/" label="Comparar planos" />
+<LinkButton link="https://www.azion.com/pt-br/servicos-profissionais/" label="Comparar níveis de suporte" />
 
-### Business Service Plan
+### Business Support
 
-| Service Fee | 
+| Support Fee | 
 | :--- |
 | Mínimo de R$ 500,00  por mês |  
 | - ou, se maior que o mínimo - |   
@@ -1376,11 +1376,11 @@ Incluído no pacote de serviços, sem cobrança adicional.
 | 5% sobre o valor mensal dos produtos de R$ 320.000,01 até R$ 1.000.000,00  |  
 | 3% sobre o valor mensal dos produtos acima de R$ 1.000.000,00  |  
 
-<LinkButton link="https://www.azion.com/pt-br/servicos-profissionais/" label="Comparar planos" />
+<LinkButton link="https://www.azion.com/pt-br/servicos-profissionais/" label="Comparar níveis de suporte" />
 
 
-### Enterprise Service Plan
-| Service Fee | 
+### Enterprise Support
+| Support Fee | 
 | :--- |
 | Mínimo de R$ 14.000,00 por mês |  
 | - ou, se maior que o mínimo - |   
@@ -1390,11 +1390,11 @@ Incluído no pacote de serviços, sem cobrança adicional.
 | 3% sobre o valor mensal dos produtos acima de R$ 1.440.000,00  |  
 
 
-<LinkButton link="https://www.azion.com/pt-br/servicos-profissionais/" label="Comparar planos" />
+<LinkButton link="https://www.azion.com/pt-br/servicos-profissionais/" label="Comparar níveis de suporte" />
 
 
-### Mission Critical Service Plan
-| Service Fee | 
+### Mission Critical Support
+| Support Fee | 
 | :--- |
 | Mínimo de R$ 56.000,00 por mês |  
 | - ou, se maior que o mínimo - |   
@@ -1404,11 +1404,11 @@ Incluído no pacote de serviços, sem cobrança adicional.
 | 3% sobre o valor mensal dos produtos acima de R$ 4.000.000,00  |  
 
 
-<LinkButton link="https://www.azion.com/pt-br/servicos-profissionais/" label="Comparar planos" />
+<LinkButton link="https://www.azion.com/pt-br/servicos-profissionais/" label="Comparar níveis de suporte" />
 
 
 
-### Serviços Profissionais: Add-ons
+### Serviços Profissionais
 
 | Integration Services| Preço por pacote |
 | :--- | :--- |

--- a/src/content/docs/pt-br/pages/menu-principal/pricing/pricing.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/pricing/pricing.mdx
@@ -37,7 +37,7 @@ Todos os preços estão em dólares americanos (USD).
 
 ## Workloads
 
-Workloads é cobrado com base em duas métricas: Workloads e Data Transfer.
+Workloads é cobrado com base em três métricas: Workloads, Data Transfer e Requests.
 
 
 <TablePricing
@@ -52,7 +52,7 @@ Workloads é cobrado com base em duas métricas: Workloads e Data Transfer.
 <TablePricing
   lang="pt-br"
   coin="dolar"
-  metric='Requests (Por 10.000)'
+  metric='Data Transfer (por GB)'
   billing={[
     'EUA',
     'Canadá',
@@ -64,16 +64,6 @@ Workloads é cobrado com base em duas métricas: Workloads e Data Transfer.
   product_slug="workload"
   metric_slug="workload_data_transfer"
 />
-
-<LinkButton link="/pt-br/documentacao/produtos/secure/workloads/" label="Ver doc do produto" severity="secondary" />
-
----
-
-## Construir
-
-### Applications
-
-O Applications é cobrado com base em duas métricas: Requests e Rules.
 
 
 <TablePricing
@@ -88,9 +78,20 @@ O Applications é cobrado com base em duas métricas: Requests e Rules.
     'Latam',
     'Outras regiões'
   ]}
-  product_slug="application"
-  metric_slug="application_requests"
+  product_slug="workload"
+  metric_slug="workload_requests"
 />
+
+<LinkButton link="/pt-br/documentacao/produtos/secure/workloads/" label="Ver doc do produto" severity="secondary" />
+
+---
+
+## Construir
+
+### Applications
+
+O Applications é cobrado com base na seguinte métrica: Rules.
+
 
 <TablePricing
   lang="pt-br"
@@ -680,7 +681,7 @@ Incluído no pacote de serviços, sem cobrança adicional.
 
 <LinkButton link="https://www.azion.com/pt-br/servicos-profissionais/" label="Comparar níveis de suporte" />
 
-### Mission Critical Support
+### Mission-Critical Support
 
 | Support Fee | 
 | :--- |
@@ -744,7 +745,7 @@ Todos os preços estão em reais (BRL). A cobrança em reais está disponível p
 ## Workloads
 {/* <span style="font-size:1.6em;">Workloads</span> */}
 
-Workloads é cobrado com base em duas métricas: Workloads e Data Transfer.
+Workloads é cobrado com base em três métricas: Workloads, Data Transfer e Requests.
 
 <TablePricing
   lang="pt-br"
@@ -758,7 +759,7 @@ Workloads é cobrado com base em duas métricas: Workloads e Data Transfer.
 <TablePricing
   lang="pt-br"
   coin="real"
-  metric='Requests (Por 10.000)'
+  metric='Data Transfer (por GB)'
   billing={[
     'EUA',
     'Canadá',
@@ -771,15 +772,6 @@ Workloads é cobrado com base em duas métricas: Workloads e Data Transfer.
   metric_slug="workload_data_transfer"
 />
 
-<LinkButton link="/pt-br/documentacao/produtos/secure/workloads/" label="Ver doc do produto" severity="secondary" />
-
-
-## Construir
-
-### Applications
-
-O Applications é cobrado com base em duas métricas: Requests e Rules.
-
 <TablePricing
   lang="pt-br"
   coin="real"
@@ -790,11 +782,20 @@ O Applications é cobrado com base em duas métricas: Requests e Rules.
     'Europa',
     'Brasil',
     'Latam',
-    'Outras Regiões'
+    'Outras regiões'
   ]}
-  product_slug="application"
-  metric_slug="application_requests"
+  product_slug="workload"
+  metric_slug="workload_requests"
 />
+
+<LinkButton link="/pt-br/documentacao/produtos/secure/workloads/" label="Ver doc do produto" severity="secondary" />
+
+
+## Construir
+
+### Applications
+
+O Applications é cobrado com base na seguinte métrica: Rules.
 
 <TablePricing
   lang="pt-br"
@@ -808,6 +809,7 @@ O Applications é cobrado com base em duas métricas: Requests e Rules.
 />
 
 <LinkButton link="/pt-br/documentacao/produtos/build/applications/" label="Ver doc do produto" severity="secondary" />
+
 
 ### Functions
 
@@ -1393,7 +1395,7 @@ Incluído no pacote de serviços, sem cobrança adicional.
 <LinkButton link="https://www.azion.com/pt-br/servicos-profissionais/" label="Comparar níveis de suporte" />
 
 
-### Mission Critical Support
+### Mission-Critical Support
 | Support Fee | 
 | :--- |
 | Mínimo de R$ 56.000,00 por mês |  


### PR DESCRIPTION
<!--
Thank you for contributing to Azion Docs! Please fill out the information below.
Use the conventional commits standard to categorize the type of change in the PR title. We recommend:
- feat: adding new content
- refactor: making minor changes
- fix: fixing errors

Don't forget to add the Jira issue code to the PR title or the GitHub issue hash.
For example: 
- [EDU-3000] refactor: modify origins page to include load balancer
- [#34] feat: add new application CLI commands
- [NO-ISSUE] fix: fix broken link in Orch doc
-->

### Related issue: EDU-6935 em 30-04-2026. Mudanças que precisamos fazer no Pricing para o lançamento dos plans e das novas métricas.
- Workloads: a métrica Requests do Applications vai mudar "as is" para o Workloads.
- Service Plans: trocar por Support. A seção vira Support,  o nome dos pacotes vira Developer Support, Business Support, Enterprise Support e Mission-Critical Support. A metrica que era Service Fee vira Support Fee.
- Professional Services: remover "Add-ons" do header e manter apenas como Professional Services


[EDU-3000]: https://aziontech.atlassian.net/browse/EDU-3000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ