### PR TITLE
EDU-6667 API v4

### DIFF
--- a/src/content/docs/pt-br/pages/guias/edge-application/ea-request-lets-encrypt-certificates-via-api.mdx
+++ b/src/content/docs/pt-br/pages/guias/edge-application/ea-request-lets-encrypt-certificates-via-api.mdx
@@ -1,27 +1,116 @@
 ---
-title: Como gerar um certificado Let's Encrypt usando desafio HTTP-01 para sua aplicação via API
+title: Como gerar um certificado Let's Encrypt para sua aplicação via API
 description: >-
-  Descubra como você pode gerar um certificado TLS gratuito assinado pela Let's Encrypt e gerenciado automaticamente pela Azion para garantir segurança para sua aplicação.
+  Descubra como você pode gerar um certificado TLS gratuito assinado pela Let's
+  Encrypt e gerenciado automaticamente pela Azion para garantir segurança para
+  sua aplicação.
 meta_tags: "certificate, ssl, tls, let's encrypt, API"
 namespace: documentation_guides_lets_encrypt_via_api
 permalink: /documentacao/produtos/guias/como-gerar-um-certificado-lets-encrypt-via-api/
 ---
 
+import Tabs from '~/components/tabs/Tabs'
+import Code from '~/components/Code/Code.astro'
+
 As aplicações que utilizam o protocolo HTTPS requerem um [Digital Certificate](/pt-br/documentacao/produtos/build/applications/certificate-manager/). Ao direcionar seu tráfego para a Azion, você tem a opção de gerar um certificado *Let's Encrypt*™, que é uma maneira gratuita e segura de criptografar dados para sua application. A Azion automatiza a emissão, renovação e desativação deste certificado TLS através de uma solução interna de gerenciamento de certificados.
 
-## Desafio HTTP-01 do Let's Encrypt via API
+## Certificados Let's Encrypt via API
 
-A Azion agora oferece emissão e renovação de [certificados Let's Encrypt](/pt-br/documentacao/produtos/secure/firewall/certificate-manager/) via API usando o desafio HTTP-01, oferecendo um processo simplificado sem a necessidade de registros TXT no DNS. Isso oferece uma solução de integração fácil e conveniente, especialmente benéfica para clientes que gerenciam diversos domínios e nomes de host.
+A API V4 da Azion oferece emissão e renovação de [certificados Let's Encrypt](/pt-br/documentacao/produtos/secure/firewall/certificate-manager/) utilizando dois métodos de validação:
 
-Os certificados são renovados automaticamente antes de expirar, eliminando janelas de manutenção e mantendo as cotas, faturamento e permissões existentes. Perfeito para plataformas de e-commerce e provedores de hospedagem, esse aprimoramento permite um onboarding mais rápido e garante segurança aos sites dos clientes em minutos, sem alterações no DNS.
+- **DNS-01**: Validação através de um registro TXT no DNS do domínio. Este método é recomendado para domínios wildcard (`*`) ou quando você não tem controle direto sobre o servidor web.
+- **HTTP-01**: Validação através de um arquivo disponibilizado no servidor web. Este método é mais simples para domínios que já apontam para a infraestrutura da Azion, sem necessidade de alterações no DNS.
+
+Os certificados são renovados automaticamente antes de expirar, eliminando janelas de manutenção e mantendo as cotas, faturamento e permissões existentes.
 
 Para mais informações sobre essas atualizações visite a documentação de [Certificate Manager](/pt-br/documentacao/produtos/secure/firewall/certificate-manager/).
 
 ---
 
-### Como emitir um certificado Let's Encrypt via challenge HTTP-01
- 
-1. Defina o hostname que será usado no certificado digital (por exemplo, meusite.azion.com) como common_name;
+## Como emitir um certificado Let's Encrypt via API
+
+<Tabs client:visible>
+<Fragment slot="tab.dns01">Challenge DNS-01</Fragment>
+<Fragment slot="tab.http01">Challenge HTTP-01</Fragment>
+
+<Fragment slot="panel.dns01">
+
+### Emitir certificado via DNS-01
+
+O desafio DNS-01 requer a adição de um registro TXT no DNS do domínio para comprovar a propriedade. Este método é ideal para domínios wildcard ou quando você prefere gerenciar a validação via DNS.
+
+1. Defina o hostname que será usado no certificado digital (por exemplo, `meusite.azion.com`) como `common_name`.
+
+2. Configure o registro CNAME `_acme-challenge` no seu provedor de DNS conforme descrito no guia [Como gerar um certificado Let's Encrypt para o seu domínio](/pt-br/documentacao/produtos/guias/como-gerar-um-certificado-lets-encrypt/#opcao-2-preparar-a-entrada-de-dns-com-um-provedor-de-dns-externo).
+
+3. Crie ou use um Token existente de API (ver [Primeiros passos com a API da Azion](https://www.azion.com/pt-br/documentacao/produtos/devtools/primeiros-passos-api/)).
+
+4. Faça uma chamada para requisitar um novo certificado com o desafio `"dns"` no endpoint `https://api.azion.com/v4/digital_certificates/certificates/request`.
+
+Por exemplo:
+
+<Code lang="bash" code={`curl --request POST \\
+  --url https://api.azion.com/v4/digital_certificates/certificates/request \\
+  --header 'Accept: application/json' \\
+  --header 'Authorization: Bearer {seutoken}' \\
+  --header 'Content-Type: application/json' \\
+  --data '{
+  "name": "Meu certificado",
+  "challenge": "dns",
+  "authority": "lets_encrypt",
+  "common_name": "meusite.azion.com",
+  "alternative_names": []
+}'`}/>
+
+5. A resposta será semelhante à abaixo:
+
+```json
+{
+  "state": "executed",
+  "data": {
+    "id": 127013,
+    "name": "Meu certificado",
+    "certificate": null,
+    "issuer": null,
+    "subject_name": [
+      "meusite.azion.com"
+    ],
+    "validity": null,
+    "status": "Pending",
+    "type": "edge_certificate",
+    "managed": true,
+    "status_detail": "",
+    "csr": null,
+    "challenge": "dns",
+    "authority": "lets_encrypt",
+    "key_algorithm": "",
+    "active": true,
+    "product_version": "2.0",
+    "last_editor": "{seu_usuario@azion.com}",
+    "last_modified": "2025-06-25T21:32:21.016402Z"
+  }
+}
+```
+
+6. Se o status resultante for **Pending**, o agendamento foi concluído com sucesso.
+
+7. Monitore o status da emissão consultando os detalhes do certificado pelo endpoint `https://api.azion.com/v4/digital_certificates/certificates/{id}`, substituindo o `{id}` pelo identificador respondido anteriormente.
+
+   a. Em caso de falha, será exibida uma mensagem de erro na propriedade **status_detail**, como por exemplo: `"status_detail": "An error has occurred while issuing the requested certificate. Please verify the following domains CNAME: meusite.azion.com"`
+
+8. Se o processo ocorreu com sucesso, o certificado será emitido e o status será **Active**.
+
+9. Agora basta associar seu certificado ao workload desejado e ajustar as propriedades TLS/HTTPS de sua preferência.
+
+</Fragment>
+
+<Fragment slot="panel.http01">
+
+### Emitir certificado via HTTP-01
+
+O desafio HTTP-01 oferece um processo simplificado sem a necessidade de registros TXT no DNS. Isso oferece uma solução de integração fácil e conveniente, especialmente benéfica para clientes que gerenciam diversos domínios e nomes de host.
+
+1. Defina o hostname que será usado no certificado digital (por exemplo, `meusite.azion.com`) como `common_name`.
 
 2. Garanta que o DNS para tal hostname esteja apontado para Azion (ver [Como apontar seu domínio para a Azion](/pt-br/documentacao/produtos/guias/apontar-dominio-para-a-azion/)). Isso deve ser feito no seu serviço provedor de DNS.
 
@@ -29,24 +118,22 @@ Para mais informações sobre essas atualizações visite a documentação de [C
 
 3. Uma vez que o DNS responda corretamente, crie ou use um Token existente de API (ver [Primeiros passos com a API da Azion](https://www.azion.com/pt-br/documentacao/produtos/devtools/primeiros-passos-api/)).
 
-4. Fazer uma chamada para requisitar um novo certificado com o desafio "http" no endpoint https://api.azion.com/v4/digital_certificates/certificates/request.
+4. Faça uma chamada para requisitar um novo certificado com o desafio `"http"` no endpoint `https://api.azion.com/v4/digital_certificates/certificates/request`.
 
 Por exemplo:
 
-```shell
-curl --request POST \
-  --url https://api.azion.com/v4/digital_certificates/certificates/request \
-  --header 'Accept: application/json' \
-  --header 'Authorization: Bearer {seutoken}' \
-  --header 'Content-Type: application/json' \
+<Code lang="bash" code={`curl --request POST \\
+  --url https://api.azion.com/v4/digital_certificates/certificates/request \\
+  --header 'Accept: application/json' \\
+  --header 'Authorization: Bearer {seutoken}' \\
+  --header 'Content-Type: application/json' \\
   --data '{
   "name": "Meu certificado",
   "challenge": "http",
   "authority": "lets_encrypt",
   "common_name": "meusite.azion.com",
   "alternative_names": []
-}'
-```
+}'`}/>
 
 5. A resposta será semelhante à abaixo:
 
@@ -78,16 +165,19 @@ curl --request POST \
 }
 ```
 
-6. Se o status resultante for **Pending**, o agendamento foi concluído com sucesso. 
+6. Se o status resultante for **Pending**, o agendamento foi concluído com sucesso.
 
 7. A plataforma Azion irá agendar a emissão do certificado automaticamente mesmo que você não tenha um Workload com o hostname relativo publicado e ativo na Azion.
 
    a. A própria Azion sobe um serviço que responde o desafio Let's Encrypt HTTP-01 e o finaliza assim que a emissão é concluída.
 
-8. Monitore o status da emissão pela consulta dos detalhes do certificado pelo endpoint `https://api.azion.com/v4/digital_certificates/certificates/{id}` substituindo o `{id}` pelo identificador respondido anteriormente, como no exemplo "id": 127013.
+8. Monitore o status da emissão pela consulta dos detalhes do certificado pelo endpoint `https://api.azion.com/v4/digital_certificates/certificates/{id}` substituindo o `{id}` pelo identificador respondido anteriormente, como no exemplo `"id": 127013`.
 
-   a. Em caso de falha, será exibida uma mensagem de erro na propriedade **status_detail**, como por exemplo "status_detail": "An error has occurred while issuing the requested certificate. Please verify the following domains CNAME: meusite.azion.com"
+   a. Em caso de falha, será exibida uma mensagem de erro na propriedade **status_detail**, como por exemplo: `"status_detail": "An error has occurred while issuing the requested certificate. Please verify the following domains CNAME: meusite.azion.com"`
 
-9. Se o processo ocorreu com sucesso, o certificado será emitido e o status será **active**.
+9. Se o processo ocorreu com sucesso, o certificado será emitido e o status será **Active**.
 
 10. Agora basta associar seu certificado ao workload desejado e ajustar as propriedades TLS/HTTPS de sua preferência.
+
+</Fragment>
+</Tabs>

--- a/src/content/docs/pt-br/pages/guias/edge-application/ea-request-lets-encrypt-certificates-via-api.mdx
+++ b/src/content/docs/pt-br/pages/guias/edge-application/ea-request-lets-encrypt-certificates-via-api.mdx
@@ -1,9 +1,6 @@
 ---
 title: Como gerar um certificado Let's Encrypt para sua aplicação via API
-description: >-
-  Descubra como você pode gerar um certificado TLS gratuito assinado pela Let's
-  Encrypt e gerenciado automaticamente pela Azion para garantir segurança para
-  sua aplicação.
+description: Descubra como você pode gerar um certificado TLS gratuito assinado pela Let's Encrypt e gerenciado automaticamente pela Azion para garantir segurança para sua aplicação.
 meta_tags: "certificate, ssl, tls, let's encrypt, API"
 namespace: documentation_guides_lets_encrypt_via_api
 permalink: /documentacao/produtos/guias/como-gerar-um-certificado-lets-encrypt-via-api/
@@ -18,10 +15,10 @@ As aplicações que utilizam o protocolo HTTPS requerem um [Digital Certificate]
 
 A API V4 da Azion oferece emissão e renovação de [certificados Let's Encrypt](/pt-br/documentacao/produtos/secure/firewall/certificate-manager/) utilizando dois métodos de validação:
 
-- **DNS-01**: Validação através de um registro TXT no DNS do domínio. Este método é recomendado para domínios wildcard (`*`) ou quando você não tem controle direto sobre o servidor web.
-- **HTTP-01**: Validação através de um arquivo disponibilizado no servidor web. Este método é mais simples para domínios que já apontam para a infraestrutura da Azion, sem necessidade de alterações no DNS.
+- **DNS-01**: Validação através de um registro TXT no DNS do domínio. Este método é recomendado quando você tem controle sobre os registros DNS do domínio, sendo ideal para domínios wildcard (`*`) ou quando você não tem acesso direto ao servidor web.
+- **HTTP-01**: Validação através de um arquivo disponibilizado no servidor web. Este método é recomendado quando você não tem controle sobre os registros DNS, sendo mais simples para domínios que já apontam para a infraestrutura da Azion.
 
-Os certificados são renovados automaticamente antes de expirar, eliminando janelas de manutenção e mantendo as cotas, faturamento e permissões existentes.
+Os certificados são renovados automaticamente antes de expirar, desde que as configurações de validação estejam válidas e atualizadas, eliminando janelas de manutenção e mantendo as cotas, faturamento e permissões existentes.
 
 Para mais informações sobre essas atualizações visite a documentação de [Certificate Manager](/pt-br/documentacao/produtos/secure/firewall/certificate-manager/).
 

--- a/src/content/docs/pt-br/pages/guias/edge-application/ea-requet-lets-encrypt-certificates.mdx
+++ b/src/content/docs/pt-br/pages/guias/edge-application/ea-requet-lets-encrypt-certificates.mdx
@@ -84,7 +84,7 @@ Para permitir que o desafio DNS-01 ocorra:
 
 1. Acesse o site do seu provedor de DNS.
 2. Navegue até a área de gerenciamento de DNS.
-3.Crie um **registro CNAME** para cada domínio que você deseja usar com o certificado. Certifique-se de que esse **registro CNAME** corresponda ao valor que você vai inserir no campo **CNAME** ao criar seu domínio na Azion. Por exemplo: `www.seudominio.org`.
+3. Crie um **registro CNAME** para cada domínio que você deseja usar com o certificado. Certifique-se de que esse **registro CNAME** corresponda ao valor que você vai inserir no campo **CNAME** ao criar seu domínio na Azion. Por exemplo: `www.seudominio.org`.
 4. Adicione um novo registro ao seu domínio da seguinte forma:
 
 | Nome | Valor | Tipo |
@@ -120,10 +120,11 @@ Para criar um **Workload**, você deve primeiro ter uma application. Se você ai
 4. Nos campos **Subdomain** e **Domain**, adicione o FQDN do domínio que você criou nas seções anteriores. Exemplo: `www.yourdomain.org`.
 5. Em **Applications**, selecione a aplicação que você criou.
 6. Em **Digital Certificate**, selecione a opção **Let's Encrypt**.
-7. Escolha o método de validação:
-    - DNS-01: Adicione um registro TXT no DNS do domínio. Este método é recomendado para domínios wildcard (*) ou quando você não tem controle direto sobre o servidor web.
-    - HTTP-01: Valide o domínio através de um arquivo disponibilizado no servidor web. Este método é mais simples para domínios que já apontam para a infraestrutura da Azion.
-8. Clique no botão **Save**.
+7. Clique no botão **Save**.
+
+:::note
+O certificado será emitido utilizando o método de validação **DNS-01**. Para domínios hospedados no Edge DNS, a validação é automática. Para domínios em provedores DNS externos, certifique-se de que o registro CNAME `_acme-challenge` está configurado corretamente.
+:::
 
 </Fragment>
 
@@ -139,10 +140,11 @@ Depois de ter uma application, você precisa [criar um domínio](/pt-br/document
 4. Em **Applications**, selecione a aplicação que você criou.
 5. Em **CNAME**, adicione o FQDN do domínio que você criou nas seções anteriores. Exemplo: `www.seudominio.org`
 6. Em **Digital Certificate**, selecione a opção **Let's Encrypt**.
-7. Escolha o método de validação:
-    - DNS-01: Adicione um registro TXT no DNS do domínio. Este método é recomendado para domínios wildcard (*) ou quando você não tem controle direto sobre o servidor web.
-    - HTTP-01: Valide o domínio através de um arquivo disponibilizado no servidor web. Este método é mais simples para domínios que já apontam para a infraestrutura da Azion.
-8. Clique no botão **Save**.
+7. Clique no botão **Save**.
+
+:::note
+O certificado será emitido utilizando o método de validação **DNS-01**. Para domínios hospedados no Edge DNS, a validação é automática. Para domínios em provedores DNS externos, certifique-se de que o registro CNAME `_acme-challenge` está configurado corretamente.
+:::
 
 </Fragment>
 </Tabs>


### PR DESCRIPTION
<!--
Thank you for contributing to Azion Docs! Please fill out the information below.
Use the conventional commits standard to categorize the type of change in the PR title. We recommend:
- feat: adding new content
- refactor: making minor changes
- fix: fixing errors

Don't forget to add the Jira issue code to the PR title or the GitHub issue hash.
For example: 
- [EDU-3000] refactor: modify origins page to include load balancer
- [#34] feat: add new application CLI commands
- [NO-ISSUE] fix: fix broken link in Orch doc
-->

### Related issue: EDU-6667 
[API v4] Briefing Digital Certificates
This PR aims to align and clarify the current behavior of Let’s Encrypt certificate issuance across the available flows.
At the moment, the console issuance flow follows the same behavior as API v3: certificate issuance is possible during the creation of a Workload, by selecting the Let’s Encrypt option to generate a certificate using the DNS-01 challenge.
The API v4, in turn, officially supports Let’s Encrypt certificate issuance using the following challenges:
- DNS-01
- HTTP-01
Therefore, this PR reflects the current state of the feature, highlighting the difference between the flow available in the console and the support already available in API v4.


[EDU-3000]: https://aziontech.atlassian.net/browse/EDU-3000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ