### PR TITLE
docs: add reference documentation sections to migration guide

### DIFF
--- a/src/content/docs/en/pages/guides/cloudflare-to-azion/cf-to-azion-comprehensive-guide.mdx
+++ b/src/content/docs/en/pages/guides/cloudflare-to-azion/cf-to-azion-comprehensive-guide.mdx
@@ -151,6 +151,13 @@ Validate the deployment:
 curl https://xxxxxxxxxx.map.azionedge.net/
 ```
 
+#### Reference documentation
+
+* [Applications](https://www.azion.com/en/documentation/products/build/applications/)
+* [Applications first steps](https://www.azion.com/en/documentation/products/build/applications/first-steps/)
+* [Azion CLI overview](https://www.azion.com/en/documentation/products/azion-cli/overview/)
+* [Import an existing project from GitHub](https://www.azion.com/en/documentation/products/guides/import-an-existing-project-from-github/)
+
 ### 2. Converting Build Configuration
 
 A migration can appear successful when the build passes but fail later when runtime behavior differs. Review build and deployment configuration carefully instead of treating it as a mechanical command replacement.
@@ -173,6 +180,12 @@ During migration, answer these questions:
 * Are runtime variables accessed through correct Azion APIs?
 * Are any Cloudflare-specific assumptions still embedded in code?
 * Can the team run local development and deploy flows consistently?
+
+#### Reference documentation
+
+* [Azion CLI overview](https://www.azion.com/en/documentation/products/azion-cli/overview/)
+* [azion.config.js reference](https://www.azion.com/en/documentation/devtools/cli/configs/azion-config-js/)
+* [azion deploy command](https://www.azion.com/en/documentation/devtools/cli/deploy/)
 
 ### 3. Moving Environment Variables
 
@@ -232,6 +245,12 @@ const apiKey = Azion.env.get('API_KEY');
 Avoid copying secrets into local notes, tickets, chat messages, or temporary documents. Keep secrets in approved systems and limit access to processes that need them.
 :::
 
+#### Reference documentation
+
+* [Environment Variables](https://www.azion.com/en/documentation/products/build/develop-with-azion/environment-variables/)
+* [Working with variables](https://www.azion.com/en/documentation/products/guides/deploy/work-with-variables/)
+* [Azion runtime environment variables reference](https://www.azion.com/en/documentation/products/functions/environment-variables/)
+
 ### 4. Rewriting and Redirecting URLs
 
 Redirects protect years of SEO value, campaign links, backlinks, bookmarks, and user expectations. When redirects break, the impact shows up as lost traffic, lower rankings, and poor user experience.
@@ -278,6 +297,12 @@ curl -I https://yourdomain.com/old-blog/post
 For SEO-sensitive migrations: prioritize permanent redirects where appropriate, avoid unnecessary redirect chains, confirm canonical paths remain consistent, and test both trailing slash versions when relevant.
 :::
 
+#### Reference documentation
+
+* [Rules Engine for Applications](https://www.azion.com/en/documentation/products/build/applications/rules-engine/)
+* [Rules Engine variables and operators](https://www.azion.com/en/documentation/products/build/applications/rules-engine/#variables)
+* [Applications reference](https://www.azion.com/en/documentation/products/build/applications/)
+
 ### 5. Migrating Custom Headers
 
 HTTP headers control caching, security, and browser behavior. Azion gives teams a more flexible model through `azion.config.js` and Rules Engine, allowing rules that respond to request characteristics.
@@ -314,6 +339,12 @@ const config: AzionConfig = {
 
 export default config;
 ```
+
+#### Reference documentation
+
+* [Rules Engine for Applications](https://www.azion.com/en/documentation/products/build/applications/rules-engine/)
+* [azion.config.js reference](https://www.azion.com/en/documentation/devtools/cli/configs/azion-config-js/)
+* [Applications main settings](https://www.azion.com/en/documentation/products/build/applications/main-settings/)
 
 ### 6. Migrating Workers to Functions
 
@@ -366,6 +397,13 @@ import { Database } from 'azion:sql';
 const db = new Database('my-database');
 const result = await db.prepare('SELECT * FROM users').all();
 ```
+
+#### Reference documentation
+
+* [Functions](https://www.azion.com/en/documentation/products/build/applications/functions/)
+* [Functions Instances](https://www.azion.com/en/documentation/products/build/applications/functions-instances/)
+* [Runtime APIs](https://www.azion.com/en/documentation/products/build/develop-with-azion/runtime-apis/)
+* [JavaScript Runtime APIs reference](https://www.azion.com/en/documentation/runtime-apis/javascript/)
 
 ### 7. Migrating Load Balancing
 
@@ -446,6 +484,12 @@ curl -X POST 'https://api.azionapi.net/v4/load_balancers' \
   "healthy_threshold": 2    // Mark healthy after 2 successes
 }
 ```
+
+#### Reference documentation
+
+* [Load Balancer](https://www.azion.com/en/documentation/products/secure/connectors/load-balancer/)
+* [Connectors](https://www.azion.com/en/documentation/products/secure/connectors/)
+* [Origins](https://www.azion.com/en/documentation/products/build/applications/origins/)
 
 ### 8. Migrating Cache Configuration
 
@@ -528,6 +572,14 @@ curl -X POST 'https://api.azionapi.net/v4/applications/{id}/cache/purge' \
   --header 'Authorization: Token YOUR_TOKEN' \
   --data '{"urls": ["https://example.com/image.jpg"]}'
 ```
+
+#### Reference documentation
+
+* [Cache](https://www.azion.com/en/documentation/products/build/applications/cache/)
+* [Cache Settings](https://www.azion.com/en/documentation/products/build/applications/cache-settings/)
+* [Tiered Cache](https://www.azion.com/en/documentation/products/build/applications/cache/tiered-cache/)
+* [Real-Time Purge](https://www.azion.com/en/documentation/products/build/applications/real-time-purge/)
+* [Application Accelerator](https://www.azion.com/en/documentation/products/build/applications/application-accelerator/)
 
 ### 9. Migrating Image Optimization
 
@@ -622,6 +674,12 @@ https://example.com/photos/landscape.jpg?ims=400x300:fill
 Azion Image Processor automatically optimizes image format based on the client's `Accept` header, serving WebP or AVIF to supported browsers.
 :::
 
+#### Reference documentation
+
+* [Image Processor](https://www.azion.com/en/documentation/products/build/applications/image-processor/)
+* [How to process images](https://www.azion.com/en/documentation/products/guides/build/process-images/)
+* [Object Storage](https://www.azion.com/en/documentation/products/store/object-storage/)
+
 ### 10. Migrating AI Workloads (Workers AI to AI Inference)
 
 AI inference at the edge enables low-latency AI-powered features in applications. Azion AI Inference provides GPU-backed inference for machine learning models.
@@ -680,6 +738,12 @@ Use the AI Inference Starter Kit template:
 # Deploy via CLI
 azion deploy --template ai-inference-starter-kit
 ```
+
+#### Reference documentation
+
+* [AI Inference](https://www.azion.com/en/documentation/products/ai/ai-inference/)
+* [AI Inference models](https://www.azion.com/en/documentation/products/ai/ai-inference/models/)
+* [AI Inference Starter Kit](https://www.azion.com/en/documentation/products/guides/ai-inference-starter-kit/)
 
 ## Secure
 
@@ -744,6 +808,13 @@ dig www.yourdomain.com CNAME +short
 :::caution[warning]
 Before switching production traffic, confirm: certificate is active, domain is associated with correct workload, DNS records are ready, critical routes have been tested, redirects behave as expected, and monitoring is configured for post-cutover validation.
 :::
+
+#### Reference documentation
+
+* [Workloads](https://www.azion.com/en/documentation/products/secure/workloads/)
+* [Create an Azion custom domain](https://www.azion.com/en/documentation/products/guides/create-azion-custom-domain/)
+* [Edge DNS](https://www.azion.com/en/documentation/products/secure/edge-dns/)
+* [Certificate Manager](https://www.azion.com/en/documentation/products/build/applications/certificate-manager/)
 
 ### 2. Migrating DNS to Edge DNS
 
@@ -835,6 +906,13 @@ dig www.example.com A +short
 dig @ns1.aziondns.net example.com A
 ```
 
+#### Reference documentation
+
+* [Edge DNS](https://www.azion.com/en/documentation/products/secure/edge-dns/)
+* [DNSSEC compatibility](https://www.azion.com/en/documentation/products/secure/edge-dns/dnssec-compatibility/)
+* [Run the dig command](https://www.azion.com/en/documentation/products/guides/run-the-dig-command/)
+* [Run the traceroute command](https://www.azion.com/en/documentation/products/guides/run-the-traceroute-command/)
+
 ### 3. Migrating SSL/TLS to Certificate Manager
 
 SSL/TLS certificates ensure secure communication between clients and your application. Azion provides automatic certificate provisioning and supports custom certificates.
@@ -924,6 +1002,13 @@ For mutual TLS authentication:
 3. Configure your workload to require client certificates.
 4. See the [mTLS configuration guide](/en/documentation/products/guides/mtls/) for detailed steps.
 
+#### Reference documentation
+
+* [Certificate Manager](https://www.azion.com/en/documentation/products/build/applications/certificate-manager/)
+* [Firewall Certificate Manager](https://www.azion.com/en/documentation/products/secure/firewall/certificate-manager/)
+* [Create a digital certificate](https://www.azion.com/en/documentation/products/guides/create-a-digital-certificate/)
+* [mTLS](https://www.azion.com/en/documentation/products/secure/firewall/mtls/)
+
 ### 4. Migrating WAF to Web Application Firewall
 
 Web Application Firewall protects applications from malicious traffic, SQL injection, cross-site scripting (XSS), and other application-layer attacks. Migrating WAF rules requires careful mapping of rule logic and understanding differences in rule construction.
@@ -1000,6 +1085,12 @@ Argument: 10.0.0.0/8
 Azion WAF operates in Learning mode by default, analyzing traffic patterns before active blocking. Use this mode to validate rule behavior before switching to Blocking mode.
 :::
 
+#### Reference documentation
+
+* [Web Application Firewall](https://www.azion.com/en/documentation/products/secure/firewall/web-application-firewall/)
+* [Rules Engine for Firewall](https://www.azion.com/en/documentation/products/secure/firewall/rules-engine/)
+* [Functions for Firewall](https://www.azion.com/en/documentation/products/secure/firewall/functions/)
+
 ### 5. Migrating DDoS Protection
 
 DDoS protection guards against volumetric attacks, protocol attacks, and application layer attacks. Azion provides automatic DDoS mitigation with no configuration required for most attack types.
@@ -1064,6 +1155,12 @@ For network-layer protection, use Azion Network Shield:
 * Works with Edge DNS for traffic filtering
 * Integrates with Firewall for unified security
 
+#### Reference documentation
+
+* [DDoS Protection](https://www.azion.com/en/documentation/products/secure/firewall/ddos-protection/)
+* [DDoS Mitigation](https://www.azion.com/en/documentation/products/secure/firewall/ddos-protection/ddos-mitigation/)
+* [Network Shield](https://www.azion.com/en/documentation/products/secure/firewall/network-shield/)
+
 ### 6. Migrating Bot Management
 
 Bot management protects applications from automated threats while allowing legitimate bots. Azion Bot Manager provides detection, challenge, and mitigation capabilities.
@@ -1126,6 +1223,13 @@ curl -A "BadBot/1.0" https://yourdomain.com/
 curl -A "Mozilla/5.0" https://yourdomain.com/
 # Expected: Normal response
 ```
+
+#### Reference documentation
+
+* [Bot Manager](https://www.azion.com/en/documentation/products/secure/firewall/bot-manager/)
+* [Bot Manager Lite](https://www.azion.com/en/documentation/products/secure/firewall/bot-manager-lite/)
+* [Bot Manager Lite integration kit](https://www.azion.com/en/documentation/products/guides/bot-manager-lite-integration-kit/)
+* [Radware Bot Manager](https://www.azion.com/en/documentation/products/guides/radware-bot-manager/)
 
 ### 7. Migrating Rate Limiting
 
@@ -1200,6 +1304,12 @@ export default {
 };
 ```
 
+#### Reference documentation
+
+* [Rules Engine for Firewall](https://www.azion.com/en/documentation/products/secure/firewall/rules-engine/)
+* [Functions for Firewall](https://www.azion.com/en/documentation/products/secure/firewall/functions/)
+* [Functions Instances for Firewall](https://www.azion.com/en/documentation/products/secure/firewall/functions-instances/)
+
 ## Store
 
 The Store category covers data services. Migrate key-value, object, and SQL data with attention to consistency, access patterns, and application compatibility.
@@ -1232,6 +1342,12 @@ Export existing KV data through Cloudflare's API. Before importing, review:
 * Value formats and serialized object structure
 * Missing-key and default value behavior
 
+#### Reference documentation
+
+* [KV Store (azion:kv module)](https://www.azion.com/en/documentation/products/azion-lib/kv/)
+* [Functions](https://www.azion.com/en/documentation/products/build/applications/functions/)
+* [Runtime APIs](https://www.azion.com/en/documentation/products/build/develop-with-azion/runtime-apis/)
+
 ### 2. Replacing R2 with Object Storage
 
 Object storage powers files that matter to users and business operations: images, documents, static assets, media files, uploads, and generated content.
@@ -1262,6 +1378,15 @@ const client = new S3Client({
 :::note
 Migrate data using familiar tools such as rclone or AWS CLI. Before migration, map buckets, object prefixes, public/private assets, access patterns, and signed URL logic.
 :::
+
+#### Reference documentation
+
+* [Object Storage](https://www.azion.com/en/documentation/products/store/object-storage/)
+* [S3 protocol for Object Storage](https://www.azion.com/en/documentation/products/store/storage/s3-protocol-for-object-storage/)
+* [Create and modify a bucket](https://www.azion.com/en/documentation/products/guides/create-and-modify-bucket/)
+* [Upload and download objects](https://www.azion.com/en/documentation/products/guides/upload-and-download-objects-from-bucket/)
+* [Use a bucket as origin](https://www.azion.com/en/documentation/products/store/storage/use-bucket-as-origin/)
+* [Storage library reference](https://www.azion.com/en/documentation/products/azion-lib/storage/)
 
 ### 3. Replacing D1 with SQL Database
 
@@ -1302,6 +1427,15 @@ wrangler d1 export my-db --output=dump.sql
 
 # Import to Azion (via EdgeSQL CLI or migration workflow)
 ```
+
+#### Reference documentation
+
+* [SQL Database](https://www.azion.com/en/documentation/products/store/sql-database/)
+* [Vector Search](https://www.azion.com/en/documentation/products/store/sql-database/vector-search/)
+* [Create a database](https://www.azion.com/en/documentation/products/store/sql/create-database/)
+* [Install Edge SQL Shell](https://www.azion.com/en/documentation/products/store/sql/install-edge-sql-shell/)
+* [SQL Database Shell commands](https://www.azion.com/en/documentation/products/store/sql/sql-database-shell-commands/)
+* [Import data into SQL Database](https://www.azion.com/en/documentation/products/guides/import-data-sql-database/)
 
 ## Observe
 
@@ -1365,6 +1499,16 @@ Azion provides a Grafana plugin for custom dashboards:
 2. Configure your Azion API credentials.
 3. Build custom dashboards using Azion data sources.
 4. See the [Grafana integration guide](/en/documentation/products/guides/azion-plugin-grafana-custom-dash/) for details.
+
+#### Reference documentation
+
+* [Real-Time Metrics](https://www.azion.com/en/documentation/products/observe/real-time-metrics/)
+* [Real-Time Metrics first steps](https://www.azion.com/en/documentation/products/observe/real-time-metrics/first-steps/)
+* [Historical Real-Time Metrics](https://www.azion.com/en/documentation/products/observe/historical-real-time-metrics/)
+* [Analyze metrics](https://www.azion.com/en/documentation/products/guides/observe/analyze-metrics/)
+* [Grafana plugin custom dashboards](https://www.azion.com/en/documentation/products/guides/azion-plugin-grafana-custom-dash/)
+* [Grafana plugin pre-built dashboards](https://www.azion.com/en/documentation/products/guides/azion-plugin-grafana-pre-built-dash/)
+* [Edge Pulse](https://www.azion.com/en/documentation/products/observe/edge-pulse/)
 
 ### 2. Migrating Logs to Real-Time Events and Data Stream
 
@@ -1468,6 +1612,17 @@ Data Stream supports 15+ destinations:
 * **Monitoring**: Datadog, Splunk, Elasticsearch, New Relic, Azure Monitor
 * **Streaming**: Amazon Kinesis, Apache Kafka
 * **Custom**: HTTP Webhook, Generic HTTP POST
+
+#### Reference documentation
+
+* [Real-Time Events](https://www.azion.com/en/documentation/products/observe/real-time-events/)
+* [Real-Time Events first steps](https://www.azion.com/en/documentation/products/observe/real-time-events/first-steps/)
+* [Data Stream](https://www.azion.com/en/documentation/products/observe/data-stream/)
+* [Data Stream first steps](https://www.azion.com/en/documentation/products/observe/data-stream/first-steps/)
+* [Use Data Stream](https://www.azion.com/en/documentation/products/guides/use-data-stream/)
+* [Investigate requests with the GraphQL API](https://www.azion.com/en/documentation/products/guides/observe/investigate-requests-graphql-api/)
+* [Configure sampling](https://www.azion.com/en/documentation/products/guides/observe/configure-sampling/)
+* Connectors: [Amazon S3](https://www.azion.com/en/documentation/products/guides/endpoint-amazon-s3/), [Azion Object Storage](https://www.azion.com/en/documentation/products/guides/connector-azion-object-storage/), [Datadog](https://www.azion.com/en/documentation/products/guides/endpoint-datadog/), [Splunk](https://www.azion.com/en/documentation/products/guides/endpoint-splunk/), [Elasticsearch](https://www.azion.com/en/documentation/products/guides/endpoint-elasticsearch/), [Kinesis](https://www.azion.com/en/documentation/products/guides/endpoint-amazon-kinesis/), [BigQuery](https://www.azion.com/en/documentation/products/guides/endpoint-google-bigquery/)
 
 ## Troubleshooting
 


### PR DESCRIPTION
### Related issue
[NO-ISSUE]

### Changes

Added "Reference documentation" sections throughout the Cloudflare to Azion comprehensive migration guide. Each section now includes curated links to relevant Azion documentation for the specific migration topic being covered.

The additions include reference links for:
- Applications and deployment (1. Getting Started)
- Build configuration and CLI (2. Converting Build Configuration)
- Environment variables (3. Moving Environment Variables)
- URL rewriting and redirects (4. Rewriting and Redirecting URLs)
- Custom headers (5. Migrating Custom Headers)
- Functions (6. Migrating Workers to Functions)
- Load balancing (7. Migrating Load Balancing)
- Cache configuration (8. Migrating Cache Configuration)
- Image optimization (9. Migrating Image Optimization)
- AI workloads (10. Migrating AI Workloads)
- Domains and certificates (Secure 1. Migrating Domains and Certificates)
- DNS (Secure 2. Migrating DNS to Edge DNS)
- SSL/TLS certificates (Secure 3. Migrating SSL/TLS to Certificate Manager)
- WAF rules (Secure 4. Migrating WAF to Web Application Firewall)
- DDoS protection (Secure 5. Migrating DDoS Protection)
- Bot management (Secure 6. Migrating Bot Management)
- Rate limiting (Secure 7. Migrating Rate Limiting)
- KV store (Store 1. Replacing KV with KV Store)
- Object storage (Store 2. Replacing R2 with Object Storage)
- SQL database (Store 3. Replacing D1 with SQL Database)
- Metrics and observability (Observe 1. Migrating Metrics to Real-Time Metrics)
- Logs and data streaming (Observe 2. Migrating Logs to Real-Time Events and Data Stream)

### Additional links

This improves the guide's usability by providing readers with direct access to detailed product documentation for each migration topic, reducing friction in the learning process.

https://claude.ai/code/session_01F62jpG5SEQ19F7wkqyEU3Q