### PR TITLE
EDU-6970 New features and updates Azion CLI 4.21.0

### DIFF
--- a/src/content/docs/en/pages/devtools/cli/azion-cli/commands/deploy/deploy.mdx
+++ b/src/content/docs/en/pages/devtools/cli/azion-cli/commands/deploy/deploy.mdx
@@ -78,6 +78,64 @@ The `--debug` option allows you to see the logs of the deploying process directl
 
 The `--writable-bucket` option, when sent, creates the project bucket with read-write access.
 
+#### workers
+
+The `--workers` option allows you to manually configure the number of workers for the upload process. By default, the CLI automatically calculates the optimal number of workers based on your CPU cores (maximum of 20).
+
+```bash
+azion deploy --workers 5
+```
+
 :::note 
 Once the deployment is triggered, Azion will open the browser and take you to a page on Azion Console where the deployment logs and process can be monitored. If it doesn't open automatically, just click on the provided link. Using the `--debug` flag will open the browser and display logs in the terminal as well.
-::: 
+:::
+
+---
+
+## Performance
+
+The Azion CLI uses an optimized S3 upload engine for static file deployments, providing significant performance improvements:
+
+- **Parallel uploads**: Files are uploaded concurrently using configurable workers.
+- **Automatic worker calculation**: The CLI automatically determines the optimal number of workers based on CPU cores (max 20).
+- **Improved upload times**: Medium-sized projects that previously took ~1m45s now deploy in approximately ~8 seconds.
+
+You can fine-tune the upload performance using the `--workers` flag to match your specific environment and project needs.
+
+---
+
+## Credentials Management
+
+The Azion CLI automatically manages S3 credentials for static application deployments. Credentials are stored securely in:
+
+```
+~/.azion/<PROFILE_NAME>/credentials.toml
+```
+
+No manual intervention is required. The CLI handles credential retrieval, storage, and rotation automatically during the deployment process.
+
+---
+
+## Observability
+
+### Deploy Timing Summary
+
+When running `azion deploy`, you'll receive a detailed timing report in the terminal showing the **Deploy Timing Summary**. This report includes:
+
+| Phase | Description |
+|-------|-------------|
+| Upload | Time spent uploading static files to Object Storage |
+| Bucket Creation | Time to create or configure the storage bucket |
+| Manifest Apply | Time to apply the deployment manifest |
+| Total | Overall deployment duration |
+
+### Bundler Telemetry Report
+
+The Azion Bundler generates detailed telemetry reports for build performance analysis. After building, you can find:
+
+| File | Format | Description |
+|------|--------|-------------|
+| `.edge/telemetry-report.json` | JSON | Machine-readable telemetry data |
+| `.edge/telemetry-report.html` | HTML | Visual timeline of build stages |
+
+These reports help you identify bottlenecks and optimize your build configuration for faster deployments. 

--- a/src/content/docs/pt-br/pages/devtools/cli/azion-cli/comandos/deploy/deploy.mdx
+++ b/src/content/docs/pt-br/pages/devtools/cli/azion-cli/comandos/deploy/deploy.mdx
@@ -79,6 +79,64 @@ A opção `--debug` permite que você veja os logs do processo de deploy diretam
 
 A opção `--writable-bucket`, quando enviada, cria o bucket do projeto com acesso de leitura e escrita.
 
+#### workers
+
+A opção `--workers` permite configurar manualmente o número de workers para o processo de upload. Por padrão, a CLI calcula automaticamente o número ideal de workers com base nos núcleos de CPU do seu sistema (máximo de 20).
+
+```bash
+azion deploy --workers 5
+```
+
 :::note 
 Uma vez que o deployment é iniciado, a Azion abrirá o navegador e levará o usuário a uma página no Azion Console onde os logs e o processo de implantação podem ser monitorados. Se não abrir automaticamente, basta clicar no link fornecido. Usar a flag `--debug` abrirá o navegador e exibirá logs no terminal também.
-::: 
+:::
+
+---
+
+## Performance
+
+A Azion CLI utiliza um motor de upload S3 otimizado para deployments de arquivos estáticos, proporcionando melhorias significativas de performance:
+
+- **Uploads paralelos**: Arquivos são enviados simultaneamente usando workers configuráveis.
+- **Cálculo automático de workers**: A CLI determina automaticamente o número ideal de workers com base nos núcleos de CPU (máximo de 20).
+- **Tempos de upload aprimorados**: Projetos de médio porte que anteriormente levavam ~1m45s agora são implantados em aproximadamente ~8 segundos.
+
+Você pode ajustar a performance de upload usando a flag `--workers` para atender às necessidades específicas do seu ambiente e projeto.
+
+---
+
+## Gestão de Credenciais
+
+A Azion CLI gerencia automaticamente as credenciais S3 para deployments de aplicações estáticas. As credenciais são armazenadas de forma segura em:
+
+```
+~/.azion/<NOME_DO_PERFIL>/credentials.toml
+```
+
+Nenhuma intervenção manual é necessária. A CLI gerencia a obtenção, armazenamento e rotação de credenciais automaticamente durante o processo de deployment.
+
+---
+
+## Observabilidade
+
+### Deploy Timing Summary
+
+Ao executar `azion deploy`, você receberá um relatório detalhado de tempo no terminal exibindo o **Deploy Timing Summary**. Este relatório inclui:
+
+| Fase | Descrição |
+|------|-----------|
+| Upload | Tempo gasto no upload de arquivos estáticos para o Object Storage |
+| Bucket Creation | Tempo para criar ou configurar o bucket de armazenamento |
+| Manifest Apply | Tempo para aplicar o manifesto de deployment |
+| Total | Duração total do deployment |
+
+### Relatório de Telemetria do Bundler
+
+O Azion Bundler gera relatórios detalhados de telemetria para análise de performance do build. Após o build, você encontra:
+
+| Arquivo | Formato | Descrição |
+|---------|---------|-----------|
+| `.edge/telemetry-report.json` | JSON | Dados de telemetria legíveis por máquina |
+| `.edge/telemetry-report.html` | HTML | Timeline visual das etapas do build |
+
+Esses relatórios ajudam a identificar gargalos e otimizar sua configuração de build para deployments mais rápidos. 


### PR DESCRIPTION
<!--
Thank you for contributing to Azion Docs! Please fill out the information below.
Use the conventional commits standard to categorize the type of change in the PR title. We recommend:
- feat: adding new content
- refactor: making minor changes
- fix: fixing errors

Don't forget to add the Jira issue code to the PR title or the GitHub issue hash.
For example: 
- [EDU-3000] refactor: modify origins page to include load balancer
- [#34] feat: add new application CLI commands
- [NO-ISSUE] fix: fix broken link in Orch doc
-->

### Related issue: EDU-6970 New features and updates Azion CLI 4.21.0

New Features

Use S3 to upload static files during deploy command (this is making the deploy process MUCH MUCH faster):

Before: In a project with 180 static files, it took between 1m.35s and 1m.45s to upload the static files (using 5 workers)

Now: In the same project, it's taking between 3.5s and 8.5s. YES, seconds! In comparison, the same project takes 9s to 10s in Cloudflare.

Explanation:

We are now calculating the number of available CPU cores and allocating a variable number of workers based on that.

Add --workers flag to allow custom worker configuration

This allows the user to, instead of using the calculated number of workers, inform a number they want to use.

Create a file to store S3 credentials per profile

Add deploy report after remote deploy

Refactor

Improve workers logic (auto-detect CPU cores, max 20 workers)

Change stage bundler

Update bundler call (use aziontech namespace)

Update dependencies


[EDU-3000]: https://aziontech.atlassian.net/browse/EDU-3000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ