### PR TITLE
EDU-6953 update Activity History changes on docs

### DIFF
--- a/src/content/docs/en/pages/devtools/api-graphql/features/events-fields.mdx
+++ b/src/content/docs/en/pages/devtools/api-graphql/features/events-fields.mdx
@@ -25,6 +25,7 @@ See each available field and their descriptions below.
 | accountId | Account's identifier on Azion. Example: `8437` |
 | authorEmail | Email address of the Azion Console user who performed the action. Example: `myemail@gmail.com` |
 | authorName | Name of the Azion Console user who performed the action. Example: `Hannah` |
+| clientId | Unique Azion client identifier. Example: `8437r` |
 | comment | Editable space available for users to add comments when performing changes. Example: `Action performed during investigation` |
 | parentResourceId | Unique identifier of the parent resource, if it exists. Example: `8190` |
 | parentResourceType | Identifier of the parent resource type, if it exists. Example: `Application` |
@@ -129,8 +130,9 @@ See each available field and their descriptions below.
 | streamName | ID set through virtual host configuration based on location directive. Set on virtual host configuration file. Example: `company_sector.sdp` |
 | tcpinfoRtt | Round-Trip Time (RTT) in microseconds measured by the edge for the user. Available on systems that support the TCP_INFO socket option. Example: `72052` |
 | ts | Timestamp of when the event was created. Example: `2022-10-20T10:10:10` |
-| upstreamAddr | Client’s IP address and port. Can also store multiple servers or server groups. Example: `192.168.1.1:80`. When the response is `127.0.0.1:1666`, the upstream is [Azion Cells Runtime](/en/documentation/runtime/overview/). |
+| upstreamAddr | Client's IP address and port. Can also store multiple servers or server groups. Example: `192.168.1.1:80`. When the response is `127.0.0.1:1666`, the upstream is [Azion Cells Runtime](/en/documentation/runtime/overview/). |
 | upstreamAddrStr | List with all `upstreamAddr` responses. |
+| upstreamLocalAddr | Local IP address used by the edge to establish the connection with the origin server. It represents the outgoing (source) IP used when communicating with the upstream. Example: `10.0.12.34` |
 | upstreamBytesReceived | Number of bytes received by the origin’s edge if the content isn’t cached. Example: `8304` |
 | upstreamBytesReceivedStr | List with all `upstreamBytesReceived` responses. |
 | upstreamBytesSent | Number of bytes sent to the origin. Example: `2733` |

--- a/src/content/docs/pt-br/pages/devtools/api-graphql/recursos/events-campos.mdx
+++ b/src/content/docs/pt-br/pages/devtools/api-graphql/recursos/events-campos.mdx
@@ -24,6 +24,7 @@ Veja cada campo disponível e suas descrições abaixo.
 | accountId | Identificador da conta Azion. Exemplo: `8437` |
 | authorEmail | Email do usuário do Azion Console que executou a ação. Exemplo: `myemail@gmail.com` |
 | authorName | Nome do usuário do Azion Console que executou a ação. Exemplo: `Hannah` |
+| clientId | Identificador único de cliente Azion. Exemplo: `8437r` |
 | comment | Campo editável disponível para que usuários possam adicionar comentários ao realizarem mudanças. Exemplo: `Ação realizada durante investigação` |
 | parentResourceId | Identificador único do recurso pai, se houver. Exemplo: `8190` |
 | parentResourceType | Identificador do tipo de recurso pai, se houver. Exemplo: `Application` |
@@ -134,6 +135,7 @@ Veja cada campo disponível e suas descrições abaixo.
 | ts | Data e hora de quando o evento foi criado. Exemplo: `2022-10-20T10:10:10` |
 | upstreamAddr | Endereço IP e porta do cliente. Também pode armazenar múltiplos servidores ou grupos de servidores. Exemplo: `192.168.1.1:80`. Quando a resposta é `127.0.0.1:1666`, o upstream é o [Azion Cells Runtime](/pt-br/documentacao/runtime/visao-geral/). |
 | upstreamAddrStr | Lista com todas as respostas `upstreamAddr`. |
+| upstreamLocalAddr | Endereço IP local utilizado pelo edge para estabelecer a conexão com o servidor de origem. Representa o IP de saída (source IP) usado na comunicação com o upstream. Exemplo: `10.0.12.34` |
 | upstreamBytesReceived | Número de bytes recebidos pelo edge da origem, se o conteúdo não estiver em cache. Exemplo: `8304` |
 | upstreamBytesReceivedStr | Lista com todas as respostas `upstreamBytesReceived`. |
 | upstreamBytesSent | Número de bytes enviados para a origem. Exemplo: `2733` |


### PR DESCRIPTION
<!--
Thank you for contributing to Azion Docs! Please fill out the information below.
Use the conventional commits standard to categorize the type of change in the PR title. We recommend:
- feat: adding new content
- refactor: making minor changes
- fix: fixing errors

Don't forget to add the Jira issue code to the PR title or the GitHub issue hash.
For example: 
- [EDU-3000] refactor: modify origins page to include load balancer
- [#34] feat: add new application CLI commands
- [NO-ISSUE] fix: fix broken link in Orch doc
-->

### Related issue: EDU-6953 update Activity History changes on docs

# Activity History Documentation Update

## Changes Made

### 1. Added `clientId` field to activityHistoryEvents (GraphQL API)

**Files updated:**
- [`events-fields.mdx`](src/content/docs/en/pages/devtools/api-graphql/features/events-fields.mdx:28) (EN)
- [`events-campos.mdx`](src/content/docs/pt-br/pages/devtools/api-graphql/recursos/events-campos.mdx:27) (PT-BR)

**Added field:**
```
| clientId | Unique Azion client identifier. Example: `8437r` |
```


### 2. Added `upstreamLocalAddr` field to workloadEvents (GraphQL API)

**Files updated:**
- [`events-fields.mdx`](src/content/docs/en/pages/devtools/api-graphql/features/events-fields.mdx:135) (EN)
- [`events-campos.mdx`](src/content/docs/pt-br/pages/devtools/api-graphql/recursos/events-campos.mdx:138) (PT-BR)

**Added field:**
```
| upstreamLocalAddr | Local IP address used by the edge to establish the connection with the origin server. It represents the outgoing (source) IP used when communicating with the upstream. Example: `10.0.12.34` |
```


[EDU-3000]: https://aziontech.atlassian.net/browse/EDU-3000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ