### PR TITLE
chore: add Context7 integration configuration

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/aziontech/docs",
+  "public_key": "pk_k7y2QfIyVLG1Bw7fGoykN"
+}


### PR DESCRIPTION
### Related issue

[NO-ISSUE]

### Changes

This PR adds a Context7 configuration file (`context7.json`) to enable Context7 integration for the documentation repository.

- Adds `context7.json` with integration URL and public key

### Additional links

- [Context7](https://context7.com)