### PR TITLE
fix: correct WAF Rule Sets link in Akamai to Azion migration guide

### DIFF
--- a/src/content/docs/pt-br/pages/guias/akamai-to-azion/akamai-to-azion-comprehensive-guide.mdx
+++ b/src/content/docs/pt-br/pages/guias/akamai-to-azion/akamai-to-azion-comprehensive-guide.mdx
@@ -533,7 +533,7 @@ App & API Protector protege aplicações e APIs contra tráfego malicioso, vulne
 #### Documentação de referência
 
 * [Web Application Firewall](https://www.azion.com/pt-br/documentacao/produtos/secure/firewall/web-application-firewall/)
-* [WAF Rule Sets](https://www.azion.com/pt-br/documentacao/produtos/secure/firewall/web-application-firewall/rules-set/)
+* [WAF Rule Sets](https://www.azion.com/pt-br/documentacao/produtos/secure/firewall/web-application-firewall/rule-sets/) 
 * [Rules Engine para Firewall](https://www.azion.com/pt-br/documentacao/produtos/secure/firewall/rules-engine/)
 * [Functions para Firewall](https://www.azion.com/pt-br/documentacao/produtos/secure/firewall/functions/)
 


### PR DESCRIPTION
fix: correct WAF Rule Sets link in Akamai to Azion migration guide