### PR TITLE
fix: update documentation links and remove trailing whitespace

### DIFF
--- a/src/content/docs/pt-br/pages/changelog/anos-passados/anos-passados-changelog.mdx
+++ b/src/content/docs/pt-br/pages/changelog/anos-passados/anos-passados-changelog.mdx
@@ -482,8 +482,8 @@ Acompanhe as atualizações de anos anteriores a seguir.
 
 * Bugfix no produto Edge DNS.
 * [Lançamento da nova versão do Origin Shield](https://www.azion.com/pt-br/blog/origin-shield-disponivel-rtm-api/), com suporte à consulta da Network List via Real-Time Manager e API.
-* Adicionada a funcionalidade de envio de notificação por email quando houver mudanças na Network List do produto [Origin Shield.](/pt-br/documentacao/produtos/edge-firewall/network-layer-protection#origin-shield)
-* Adicionada a funcionalidade de visualizar as mudanças que ocorreram na Network List do produto [Origin Shield](/pt-br/documentacao/produtos/edge-firewall/network-layer-protection#origin-shield) por meio do *History* do RTM.
+* Adicionada a funcionalidade de envio de notificação por email quando houver mudanças na Network List do produto [Origin Shield.](/pt-br/documentacao/produtos/secure/firewall/network-shield/#origin-shield)
+* Adicionada a funcionalidade de visualizar as mudanças que ocorreram na Network List do produto [Origin Shield](/pt-br/documentacao/produtos/secure/firewall/network-shield/#origin-shield) por meio do *History* do RTM.
 * Bugfix no produto Digital Certificate.
 * Lançamento do Single Sign-On.
 
@@ -978,5 +978,3 @@ Nota: Assim como a interface foi atualizada para requerer o tipo de purge, a [AP
 * Atualização da interface do [Edge Firewall](/pt-br/documentacao/produtos/secure/edge-firewall/) para suporte a reuso de rule sets.
 * Atualização da interface de Custom Headers para suporte a reuso de configurações.
 * Lançamento de aba para configuração de Device Groups e atualização na aba Rules Engine para integração do produto Adaptive Delivery.
-
-

--- a/src/includes/docs_help_center/en/real-time-metrics/edge-applications/data-transferred/edge-caching/index.md
+++ b/src/includes/docs_help_center/en/real-time-metrics/edge-applications/data-transferred/edge-caching/index.md
@@ -16,7 +16,7 @@ It provides a first layer of caching to the client content on Azion edges. The g
 >
 > ORIGIN -> EDGE -> END USER
 
-To use Cache and analyze data on it, you must activate it in your account. See the [Cache documentation](https://www.azion.com/en/documentation/products/edge-application/edge-caching/) for more information.
+To use Cache and analyze data on it, you must activate it in your account. See the [Cache documentation](https://www.azion.com/en/documentation/products/build/applications/cache/) for more information.
 
 > **In what unit does data appear on graphs?**
 >


### PR DESCRIPTION
### Related issue
[NO-ISSUE]

### Changes

This PR updates broken documentation links and performs minor cleanup:

1. **Updated Origin Shield documentation links** in the Portuguese changelog:
   - Changed links from `/pt-br/documentacao/produtos/edge-firewall/network-layer-protection#origin-shield` to `/pt-br/documentacao/produtos/secure/firewall/network-shield/#origin-shield`
   - Affects two changelog entries related to Origin Shield Network List notifications and history features

2. **Updated Edge Caching documentation link** in the English real-time metrics help center:
   - Changed link from `/en/documentation/products/edge-application/edge-caching/` to `/en/documentation/products/build/applications/cache/`
   - Reflects the updated documentation structure

3. **Removed trailing whitespace** from the Portuguese changelog file
