### PR TITLE
Normalize duplicate slashes in docs URLs

### DIFF
--- a/src/components/HeadSEO.astro
+++ b/src/components/HeadSEO.astro
@@ -18,7 +18,7 @@ export interface Props {
 import { OPEN_GRAPH } from '~/config';
 import { normalizeLangTag } from '~/i18n/bcp-normalize';
 import { useTranslations } from '~/i18n/util';
-import { getLanguageFromURL } from '~/util';
+import { getLanguageFromURL, normalizePathSlashes, removeLeadingSlash, removeTrailingSlash } from '~/util';
 import ogImage from '~/util/ogImage';
 
 const {  content, canonicalURL, translatedPages } = Astro.props;
@@ -29,6 +29,11 @@ const t = useTranslations(Astro);
 const lang = getLanguageFromURL(canonicalURL?.pathname || '/');
 const bcpLang = normalizeLangTag(lang);
 const ogLocale = bcpLang.replace(/-/g, '_');
+
+const getAlternateHref = (lang: string, slug: string) => {
+  const normalizedPermalink = removeTrailingSlash(removeLeadingSlash(normalizePathSlashes(`${lang}/${slug}`)));
+  return `${SITE_URL}/${normalizedPermalink}/`;
+};
 ---
 
 <link rel="canonical" href={canonicalURL} />
@@ -36,15 +41,15 @@ const ogLocale = bcpLang.replace(/-/g, '_');
 {
   translatedPages ?
     translatedPages.flatMap(({ slug, lang }) => [
-      <link rel="alternate" href={`${SITE_URL}/${lang}/${slug}/`} hreflang={lang} />,
-      ...(lang === "pt-br" ? [<link rel="alternate" href={`${SITE_URL}/${lang}/${slug}/`} hreflang="pt" />] : [])
+      <link rel="alternate" href={getAlternateHref(lang, slug)} hreflang={lang} />,
+      ...(lang === "pt-br" ? [<link rel="alternate" href={getAlternateHref(lang, slug)} hreflang="pt" />] : [])
     ])
   : null
 }
 
 {
   defaultPage ? (
-    <link rel="alternate" href={`${SITE_URL}/${defaultPage.lang}/${defaultPage.slug}/`} hreflang="x-default" />
+    <link rel="alternate" href={getAlternateHref(defaultPage.lang, defaultPage.slug)} hreflang="x-default" />
   ) : null
 }
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -22,7 +22,7 @@ import SystemStatus from 'azion-webkit/systemstatus';
 import SelectLang from 'azion-webkit/selectlang';
 import ThemeSwitcher from 'azion-webkit/dropdownthemeswitcher';
 
-import { getLanguageFromURL, removeLeadingSlash } from '~/util';
+import { getLanguageFromURL, normalizePathSlashes, removeLeadingSlash } from '~/util';
 // import { getPageCategory } from '~/util/getPageCategory';
 import { getTranslatedPagesByNamespace } from '~/util/getPageTranslations';
 import { getHeaderMenuStrings, getFooterMenuStrings } from '~/i18n/translations';
@@ -79,8 +79,9 @@ const formatTitle = (content: { title?: string }) => {
     ? `${content.title.trim()} - ${t('site.title')}`
     : t('site.title');
 };
-// Ensures the canonicalURL always has a trailing slash.
-const canonicalURL = new URL(Astro.url.pathname.replace(/([^/])$/, '$1/'), Astro.site);
+// Ensures the canonicalURL uses collapsed slashes and always has a trailing slash.
+const normalizedPathname = normalizePathSlashes(Astro.url.pathname);
+const canonicalURL = new URL(normalizedPathname.replace(/([^/])$/, '$1/'), Astro.site);
 if (isFallback) canonicalURL.pathname = canonicalURL.pathname.replace(`/${lang}/`, '/en/');
 
 const translatedPages = await (async (c) => {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,16 @@
+import { defineMiddleware } from 'astro/middleware';
+
+import { normalizePathSlashes } from '~/util';
+
+export const onRequest = defineMiddleware((context, next) => {
+	const normalizedPathname = normalizePathSlashes(context.url.pathname);
+
+	if (normalizedPathname !== context.url.pathname) {
+		const redirectURL = new URL(context.url);
+		redirectURL.pathname = normalizedPathname;
+
+		return context.redirect(`${redirectURL.pathname}${redirectURL.search}`, 301);
+	}
+
+	return next();
+});

--- a/src/util.ts
+++ b/src/util.ts
@@ -17,6 +17,12 @@ export function removeTrailingSlash(path: string | undefined) {
 	return `${path}`
 }
 
+/** Collapse repeated forward slashes in URL path segments. */
+export function normalizePathSlashes(path: string | undefined) {
+	if (typeof path === 'string') return path.replace(/\/{2,}/g, '/');
+	return `${path}`
+}
+
 /** Get a page’s slug, without the language prefix (e.g. `'en/migrate'` => `'migrate'`). */
 export const stripLangFromSlug = (slug: CollectionEntry<'docs'>['slug']) => slug.split('/').slice(1).join('/');
 

--- a/src/util/getPageTranslations.ts
+++ b/src/util/getPageTranslations.ts
@@ -1,4 +1,4 @@
-import { getLangFromSlug, removeLeadingSlash, removeTrailingSlash } from '~/util'
+import { getLangFromSlug, normalizePathSlashes, removeLeadingSlash, removeTrailingSlash } from '~/util'
 import { getCollection } from 'astro:content';
 
 interface LanguageSelector {
@@ -11,7 +11,7 @@ export const getTranslatedPagesByNamespace = async (namespace: string): Promise<
 
 	const mappedPageData =  translatePageData
 		.filter(page => page.data.permalink)
-		.map(page => ({ slug: removeTrailingSlash(removeLeadingSlash(page.data.permalink)), lang: getLangFromSlug(page.slug) }));
+		.map(page => ({ slug: removeTrailingSlash(removeLeadingSlash(normalizePathSlashes(page.data.permalink))), lang: getLangFromSlug(page.slug) }));
 
 	return mappedPageData.length > 0 ? mappedPageData : undefined
 }


### PR DESCRIPTION
### Motivation
- Prevent duplicate-slash paths from creating duplicate content and ensure all documentation URLs canonicalize to a single trailing slash form for SEO and consistent routing.
- Ensure alternate/hreflang links and translated permalinks are generated from normalized permalinks so `HeadSEO` always emits canonical URLs.

### Description
- Added `normalizePathSlashes(path)` to `src/util.ts` to collapse repeated forward slashes in a path.
- Use the normalized pathname when building the canonical URL in `src/layouts/BaseLayout.astro` so canonical links always use collapsed slashes and a trailing slash.
- Normalize translated permalinks in `src/util/getPageTranslations.ts` so `HeadSEO` receives normalized slugs for alternate link generation.
- Update `src/components/HeadSEO.astro` to generate `rel="alternate"` hrefs from normalized permalinks via a `getAlternateHref` helper.
- Add `src/middleware.ts` middleware that issues a permanent `301` redirect when an incoming request pathname contains repeated slashes, preserving the query string.

### Testing
- Ran a local dev server with `npm run dev -- --host 127.0.0.1` and verified with curl that duplicate-slash requests are redirected: `curl -I /pt-br/...//` returned `301` with `Location: /pt-br/.../` and the canonical path returned `200 OK`.
- Ran `git diff --check` which reported no whitespace/patch issues for these changes (passed).
- Ran `npm run check` which failed due to pre-existing, project-wide TypeScript/ASTRO type errors unrelated to this change (reported as failing and not caused by this PR).
- Attempted `npm run build` and `NODE_OPTIONS='--max-old-space-size=8120' npm run build`; builds progressed but the environment hit heap and external DNS resolution limits (fetch to an external map.azionedge.net failed), so full production build verification could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19cecd0328832f88915e281907816d)