### PR TITLE
fix: update example URLs in image processor documentation to use asterisks for emphasis

### DIFF
--- a/src/content/docs/en/pages/main-menu/reference/build/edge-application/image-processor.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/build/edge-application/image-processor.mdx
@@ -49,9 +49,9 @@ This module supports an array of image formats, including:
 :::caution
 To ensure proper processing of images, the `ims=` query string parameter must be the last parameter in the URL. If any additional query string parameters are included after `ims=`, the request may return a **504** error.
 
-Example of a **valid** URL: https://example.com/image.jpeg?ts=1234&ims=1000x1000
+Example of a **valid** URL:*example.com/image.jpeg?ts=1234&ims=1000x1000*
 
-Example of an **invalid** URL (causes error 504): https://example.com/image.jpeg?ims=1000x1000&ts=1234
+Example of an **invalid** URL (causes error 504): *example.com/image.jpeg?ims=1000x1000&ts=1234*
 :::
 
 ## Resize images

--- a/src/content/docs/pt-br/pages/menu-principal/referencia/build/edge-application/image-processor-primeiros-passos.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/referencia/build/edge-application/image-processor-primeiros-passos.mdx
@@ -28,9 +28,9 @@ Para imagens, a Azion recomenda que você escolha valores maiores de time-to-liv
 :::caution
 Para garantir o processamento adequado das imagens, o parâmetro de query string `ims=` deve ser o último parâmetro na URL. Se quaisquer parâmetros de query string adicionais forem incluídos após `ims=`, a requisição pode retornar um erro **504**.
 
-Exemplo de uma URL **válida**: https://example.com/image.jpeg?ts=1234&ims=1000x1000
+Exemplo de uma URL **válida**: *example.com/image.jpeg?ts=1234&ims=1000x1000*
 
-Exemplo de uma URL **inválida** (causa erro 504): https://example.com/image.jpeg?ims=1000x1000&ts=1234
+Exemplo de uma URL **inválida** (causa erro 504): *example.com/image.jpeg?ims=1000x1000&ts=1234*
 :::
 
 6. Edite as configurações restantes conforme necessário e clique no botão **Save**.

--- a/src/content/docs/pt-br/pages/menu-principal/referencia/build/edge-application/image-processor.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/referencia/build/edge-application/image-processor.mdx
@@ -49,9 +49,9 @@ Esse módulo oferece suporte aos seguintes formatos de imagem:
 :::caution
 Para garantir o processamento adequado das imagens, o parâmetro de query string `ims=` deve ser o último parâmetro na URL. Se quaisquer parâmetros de query string adicionais forem incluídos após `ims=`, a requisição pode retornar um erro **504**.
 
-Exemplo de uma URL **válida**: https://example.com/image.jpeg?ts=1234&ims=1000x1000
+Exemplo de uma URL **válida**: *example.com/image.jpeg?ts=1234&ims=1000x1000*
 
-Exemplo de uma URL **inválida** (causa erro 504): https://example.com/image.jpeg?ims=1000x1000&ts=1234
+Exemplo de uma URL **inválida** (causa erro 504): *example.com/image.jpeg?ims=1000x1000&ts=1234*
 :::
 
 ## Redimensionar a imagem
@@ -178,7 +178,7 @@ Adicione marcas d'água às suas imagens acrescentando a query `?ims=filters:wat
 - `WidthRatio` é um parâmetro opcional que define a largura da marca d'água como uma porcentagem em relação à imagem. Se você não especificar um valor, ele será definido como `none`.
 - `HeightRatio` é um parâmetro opcional que define a altura da marca d'água como uma porcentagem em relação à imagem. Se você não especificar um valor, ele será definido como `none`.
 
-Por exemplo, a query `?ims=filters:watermark(http://seudominio.com/imagens-marca-dagua.png,repeat,20p,50,10,none)` repetirá a marca d'água horizontalmente, a 20% da altura da imagem, com 50% de transparência, redimensionada para 10% da largura da imagem.
+Por exemplo, a query `?ims=filters:watermark(http://[seudominio].com/imagens-marca-dagua.png,repeat,20p,50,10,none)` repetirá a marca d'água horizontalmente, a 20% da altura da imagem, com 50% de transparência, redimensionada para 10% da largura da imagem.
 
 <p align="center">[![Image_Processor_1](/assets/docs/images/image-processor/Image_Processor_2.png?ims=filters:watermark(https://raw.githubusercontent.com/aziontech/docs/main/public/assets/docs/images/azion-logo.png,repeat,20p,50,10,none))](/assets/docs/images/image-processor/Image_Processor_2.png?ims=filters:watermark(https://raw.githubusercontent.com/aziontech/docs/main/public/assets/docs/images/azion-logo.png,repeat,20p,50,10,none))</p>
 


### PR DESCRIPTION
fix: update example URLs in image processor documentation to use asterisks for emphasis