### PR TITLE
docs: enrich low-word-count Runtime APIs pages (14 pages, EN + PT-BR)

### DIFF
--- a/src/content/docs/en/pages/devtools/azion-edge-runtime/runtime-apis/add-eventlistener/2021-01-14-index.mdx
+++ b/src/content/docs/en/pages/devtools/azion-edge-runtime/runtime-apis/add-eventlistener/2021-01-14-index.mdx
@@ -14,7 +14,7 @@ menu_namespace: runtimeMenu
 
 The *addEventListener* function defines the trigger for the execution of JavaScript code to receive the request data. The event listener type is `fetch` and gets the [fetchEvent](/en/documentation/products/applications/functions/runtime-apis/javascript/fetch-event/)
 
-Inside an Azion edge function, `addEventListener` is the entry point that wires your code to the request lifecycle. When the edge runtime receives an incoming HTTP request, it dispatches a `fetch` event, and the listener you register is the callback that runs to build and return a response. Because the function executes on Azion's distributed network close to the end user, registering the handler this way lets you intercept, inspect, and respond to traffic with minimal latency. You typically register a single `fetch` listener per function and call `event.respondWith()` from within it to deliver the final response.
+Inside an Azion function, `addEventListener` is the entry point that wires your code to the request lifecycle. When the runtime receives an incoming HTTP request, it dispatches a `fetch` event, and the listener you register is the callback that runs to build and return a response. Because the function executes on Azion's distributed network close to the end user, registering the handler this way lets you intercept, inspect, and respond to traffic with minimal latency. You typically register a single `fetch` listener per function and call `event.respondWith()` from within it to deliver the final response.
 
 ## Syntax
 
@@ -40,9 +40,9 @@ Inside an Azion edge function, `addEventListener` is the entry point that wires 
 
 ## Use cases
 
-- Registering the main `fetch` handler that powers an edge application, routing requests to the right logic based on path or method.
+- Registering the main `fetch` handler that powers an application, routing requests to the right logic based on path or method.
 - Intercepting incoming requests to add authentication, rewrite headers, or perform redirects before reaching an origin.
-- Generating dynamic responses directly at the edge, such as personalized content or A/B testing variants.
+- Generating dynamic responses directly on Azion's global network, such as personalized content or A/B testing variants.
 - Implementing custom caching strategies by inspecting the request and returning a synthesized response.
 
 ## Related resources

--- a/src/content/docs/en/pages/devtools/azion-edge-runtime/runtime-apis/add-eventlistener/2021-01-14-index.mdx
+++ b/src/content/docs/en/pages/devtools/azion-edge-runtime/runtime-apis/add-eventlistener/2021-01-14-index.mdx
@@ -14,6 +14,8 @@ menu_namespace: runtimeMenu
 
 The *addEventListener* function defines the trigger for the execution of JavaScript code to receive the request data. The event listener type is `fetch` and gets the [fetchEvent](/en/documentation/products/applications/functions/runtime-apis/javascript/fetch-event/)
 
+Inside an Azion edge function, `addEventListener` is the entry point that wires your code to the request lifecycle. When the edge runtime receives an incoming HTTP request, it dispatches a `fetch` event, and the listener you register is the callback that runs to build and return a response. Because the function executes on Azion's distributed network close to the end user, registering the handler this way lets you intercept, inspect, and respond to traffic with minimal latency. You typically register a single `fetch` listener per function and call `event.respondWith()` from within it to deliver the final response.
+
 ## Syntax
 
 ```js
@@ -35,6 +37,18 @@ The *addEventListener* function defines the trigger for the execution of JavaScr
     )
   })
 ```
+
+## Use cases
+
+- Registering the main `fetch` handler that powers an edge application, routing requests to the right logic based on path or method.
+- Intercepting incoming requests to add authentication, rewrite headers, or perform redirects before reaching an origin.
+- Generating dynamic responses directly at the edge, such as personalized content or A/B testing variants.
+- Implementing custom caching strategies by inspecting the request and returning a synthesized response.
+
+## Related resources
+
+- [addEventListener on MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener)
+- [Runtime APIs](/en/documentation/products/applications/functions/runtime-apis/javascript/fetch/)
 
 ---
 

--- a/src/content/docs/en/pages/devtools/azion-edge-runtime/runtime-apis/crypto-key/2023-02-28-index.mdx
+++ b/src/content/docs/en/pages/devtools/azion-edge-runtime/runtime-apis/crypto-key/2023-02-28-index.mdx
@@ -14,7 +14,7 @@ menu_namespace: runtimeMenu
 
 The `CryptoKey` interface represents a cryptographic key obtained from one of the [SubtleCrypto methods](/en/documentation/products/applications/functions/runtime-apis/javascript/subtle-crypto/).
 
-In an Azion edge function, a `CryptoKey` is the object you pass to SubtleCrypto operations when you encrypt, decrypt, sign, or verify data. You don't construct it directly; instead, it is returned by methods such as `generateKey()`, `importKey()`, or `deriveKey()`. Its read-only properties describe what the key is and how it may be used, so the runtime can enforce that a key is only applied to the operations it was created for. Handling keys as opaque `CryptoKey` objects keeps raw key material out of your function code while still allowing fast cryptographic work at the edge.
+In an Azion function, a `CryptoKey` is the object you pass to SubtleCrypto operations when you encrypt, decrypt, sign, or verify data. You don't construct it directly; instead, it is returned by methods such as `generateKey()`, `importKey()`, or `deriveKey()`. Its read-only properties describe what the key is and how it may be used, so the runtime can enforce that a key is only applied to the operations it was created for. Handling keys as opaque `CryptoKey` objects keeps raw key material out of your function code while still allowing fast cryptographic work on Azion's global network.
 
 ## Instance properties
 
@@ -32,7 +32,7 @@ An array of strings, indicating what can be done with the key. Possible values f
 
 ## Use cases
 
-- Holding an imported secret key used to verify signed tokens or HMAC signatures at the edge.
+- Holding an imported secret key used to verify signed tokens or HMAC signatures on Azion's global network.
 - Carrying a generated key pair for signing or encrypting payloads before they leave the function.
 - Restricting how a key is applied through its `usages` so it can sign but not decrypt, for example.
 

--- a/src/content/docs/en/pages/devtools/azion-edge-runtime/runtime-apis/crypto-key/2023-02-28-index.mdx
+++ b/src/content/docs/en/pages/devtools/azion-edge-runtime/runtime-apis/crypto-key/2023-02-28-index.mdx
@@ -10,7 +10,11 @@ permalink: >-
 menu_namespace: runtimeMenu
 ---
 
+## How it works
+
 The `CryptoKey` interface represents a cryptographic key obtained from one of the [SubtleCrypto methods](/en/documentation/products/applications/functions/runtime-apis/javascript/subtle-crypto/).
+
+In an Azion edge function, a `CryptoKey` is the object you pass to SubtleCrypto operations when you encrypt, decrypt, sign, or verify data. You don't construct it directly; instead, it is returned by methods such as `generateKey()`, `importKey()`, or `deriveKey()`. Its read-only properties describe what the key is and how it may be used, so the runtime can enforce that a key is only applied to the operations it was created for. Handling keys as opaque `CryptoKey` objects keeps raw key material out of your function code while still allowing fast cryptographic work at the edge.
 
 ## Instance properties
 
@@ -25,6 +29,17 @@ An object describing the algorithm for which this key can be used and any associ
 
 [CryptoKey.usages](https://developer.mozilla.org/en-US/docs/Web/API/CryptoKey/usages)
 An array of strings, indicating what can be done with the key. Possible values for array elements are "encrypt", "decrypt", "sign", "verify", "deriveKey", "deriveBits", "wrapKey", and "unwrapKey".
+
+## Use cases
+
+- Holding an imported secret key used to verify signed tokens or HMAC signatures at the edge.
+- Carrying a generated key pair for signing or encrypting payloads before they leave the function.
+- Restricting how a key is applied through its `usages` so it can sign but not decrypt, for example.
+
+## Related resources
+
+- [CryptoKey on MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/CryptoKey)
+- [Runtime APIs](/en/documentation/products/applications/functions/runtime-apis/javascript/fetch/)
 
 For more information on [CryptoKey](https://developer.mozilla.org/en-US/docs/Web/API/CryptoKey) visit MDN Web Docs.
 

--- a/src/content/docs/en/pages/devtools/azion-edge-runtime/runtime-apis/crypto/2023-02-28-index.mdx
+++ b/src/content/docs/en/pages/devtools/azion-edge-runtime/runtime-apis/crypto/2023-02-28-index.mdx
@@ -10,7 +10,11 @@ permalink: >-
 menu_namespace: runtimeMenu
 ---
 
+## How it works
+
 The `Crypto` interface allows access to a cryptographically strong random number generator and cryptographic primitives.
+
+Within an Azion edge function, the global `crypto` object exposes these capabilities so you can run secure operations without pulling in external libraries. Through `crypto.getRandomValues()` and `crypto.randomUUID()` you can produce unpredictable random values and identifiers, while the `crypto.subtle` property unlocks the full SubtleCrypto API for hashing, signing, and verifying data. Because the work happens at the edge, sensitive computations such as token validation or request signing run close to the user and never need to round-trip to a central server, reducing latency and exposure.
 
 ## Instance properties
 
@@ -24,6 +28,18 @@ Fills the passed TypedArray with cryptographically sound random values.
 
 `Crypto.randomUUID()`
 Returns a randomly generated, 36 character-long v4 UUID.
+
+## Use cases
+
+- Generating secure, collision-resistant identifiers for sessions, requests, or trace IDs with `randomUUID()`.
+- Producing cryptographically strong random values to build nonces or tokens at the edge.
+- Hashing request payloads or computing digests to verify integrity before forwarding traffic.
+- Validating signed tokens, such as JWTs, directly in the edge function without contacting an origin.
+
+## Related resources
+
+- [Crypto on MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/Crypto)
+- [Runtime APIs](/en/documentation/products/applications/functions/runtime-apis/javascript/fetch/)
 
 For more information on [Crypto](https://developer.mozilla.org/en-US/docs/Web/API/Crypto) visit MDN Web Docs.
 

--- a/src/content/docs/en/pages/devtools/azion-edge-runtime/runtime-apis/crypto/2023-02-28-index.mdx
+++ b/src/content/docs/en/pages/devtools/azion-edge-runtime/runtime-apis/crypto/2023-02-28-index.mdx
@@ -14,7 +14,7 @@ menu_namespace: runtimeMenu
 
 The `Crypto` interface allows access to a cryptographically strong random number generator and cryptographic primitives.
 
-Within an Azion edge function, the global `crypto` object exposes these capabilities so you can run secure operations without pulling in external libraries. Through `crypto.getRandomValues()` and `crypto.randomUUID()` you can produce unpredictable random values and identifiers, while the `crypto.subtle` property unlocks the full SubtleCrypto API for hashing, signing, and verifying data. Because the work happens at the edge, sensitive computations such as token validation or request signing run close to the user and never need to round-trip to a central server, reducing latency and exposure.
+Within an Azion function, the global `crypto` object exposes these capabilities so you can run secure operations without pulling in external libraries. Through `crypto.getRandomValues()` and `crypto.randomUUID()` you can produce unpredictable random values and identifiers, while the `crypto.subtle` property unlocks the full SubtleCrypto API for hashing, signing, and verifying data. Because the work happens on Azion's distributed architecture, sensitive computations such as token validation or request signing run close to the user and never need to round-trip to a central server, reducing latency and exposure.
 
 ## Instance properties
 
@@ -32,9 +32,9 @@ Returns a randomly generated, 36 character-long v4 UUID.
 ## Use cases
 
 - Generating secure, collision-resistant identifiers for sessions, requests, or trace IDs with `randomUUID()`.
-- Producing cryptographically strong random values to build nonces or tokens at the edge.
+- Producing cryptographically strong random values to build nonces or tokens on Azion's global network.
 - Hashing request payloads or computing digests to verify integrity before forwarding traffic.
-- Validating signed tokens, such as JWTs, directly in the edge function without contacting an origin.
+- Validating signed tokens, such as JWTs, directly in the function without contacting an origin.
 
 ## Related resources
 

--- a/src/content/docs/en/pages/devtools/azion-edge-runtime/runtime-apis/event-target/2023-03-30-index.mdx
+++ b/src/content/docs/en/pages/devtools/azion-edge-runtime/runtime-apis/event-target/2023-03-30-index.mdx
@@ -30,11 +30,11 @@ Removes an event listener from the EventTarget.
 [EventTarget.dispatchEvent()](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/dispatchEvent)
 Dispatches an event to this EventTarget.
 
-In an Azion edge function, `EventTarget` is the foundation behind the global `addEventListener` used to register the `fetch` handler, and it can also back your own objects that need to emit and listen for custom events during request processing.
+In an Azion function, `EventTarget` is the foundation behind the global `addEventListener` used to register the `fetch` handler, and it can also back your own objects that need to emit and listen for custom events during request processing.
 
 ## Use cases
 
-- Building custom objects that dispatch and listen for events while a request is being handled at the edge.
+- Building custom objects that dispatch and listen for events while a request is being handled on Azion's global network.
 - Composing event-driven logic on top of the same interface that powers the runtime's `fetch` event.
 - Adding and later removing listeners dynamically to control which handlers react to a given event.
 

--- a/src/content/docs/en/pages/devtools/azion-edge-runtime/runtime-apis/event-target/2023-03-30-index.mdx
+++ b/src/content/docs/en/pages/devtools/azion-edge-runtime/runtime-apis/event-target/2023-03-30-index.mdx
@@ -30,6 +30,19 @@ Removes an event listener from the EventTarget.
 [EventTarget.dispatchEvent()](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/dispatchEvent)
 Dispatches an event to this EventTarget.
 
+In an Azion edge function, `EventTarget` is the foundation behind the global `addEventListener` used to register the `fetch` handler, and it can also back your own objects that need to emit and listen for custom events during request processing.
+
+## Use cases
+
+- Building custom objects that dispatch and listen for events while a request is being handled at the edge.
+- Composing event-driven logic on top of the same interface that powers the runtime's `fetch` event.
+- Adding and later removing listeners dynamically to control which handlers react to a given event.
+
+## Related resources
+
+- [EventTarget on MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget)
+- [Runtime APIs](/en/documentation/products/applications/functions/runtime-apis/javascript/fetch/)
+
 For more information on [EventTarget](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget) visit MDN Web Docs.
 
 

--- a/src/content/docs/en/pages/devtools/azion-edge-runtime/runtime-apis/fetch-event/2021-01-14-index.mdx
+++ b/src/content/docs/en/pages/devtools/azion-edge-runtime/runtime-apis/fetch-event/2021-01-14-index.mdx
@@ -12,7 +12,7 @@ menu_namespace: runtimeMenu
 
 FetchEvent is the event that passes the request through the *addEventListener* function. The *addEventListener*, in turn, defines the trigger for executing the JavaScript code and receives the request data.
 
-When the Azion edge runtime receives an HTTP request, it creates a `FetchEvent` and hands it to the `fetch` listener you registered. The event carries the original `request` object, giving your function access to the URL, method, headers, and body of the incoming traffic. To produce the answer, you call `event.respondWith()` with a `Response` or a promise that resolves to one, telling the runtime exactly what to send back to the client. This pattern lets an edge function fully control each request and response cycle.
+When the Azion runtime receives an HTTP request, it creates a `FetchEvent` and hands it to the `fetch` listener you registered. The event carries the original `request` object, giving your function access to the URL, method, headers, and body of the incoming traffic. To produce the answer, you call `event.respondWith()` with a `Response` or a promise that resolves to one, telling the runtime exactly what to send back to the client. This pattern lets a function fully control each request and response cycle.
 
 ## Syntax
 
@@ -44,7 +44,7 @@ event.respondWith(response Request|Promise) // the HTTP request received by the 
 
 ## Use cases
 
-- Reading the incoming `request` to route, filter, or transform traffic at the edge.
+- Reading the incoming `request` to route, filter, or transform traffic on Azion's global network.
 - Returning a custom or synthesized response by passing it to `event.respondWith()`.
 - Forwarding the request to an origin with `fetch()` and resolving the response back to the client.
 

--- a/src/content/docs/en/pages/devtools/azion-edge-runtime/runtime-apis/fetch-event/2021-01-14-index.mdx
+++ b/src/content/docs/en/pages/devtools/azion-edge-runtime/runtime-apis/fetch-event/2021-01-14-index.mdx
@@ -12,6 +12,8 @@ menu_namespace: runtimeMenu
 
 FetchEvent is the event that passes the request through the *addEventListener* function. The *addEventListener*, in turn, defines the trigger for executing the JavaScript code and receives the request data.
 
+When the Azion edge runtime receives an HTTP request, it creates a `FetchEvent` and hands it to the `fetch` listener you registered. The event carries the original `request` object, giving your function access to the URL, method, headers, and body of the incoming traffic. To produce the answer, you call `event.respondWith()` with a `Response` or a promise that resolves to one, telling the runtime exactly what to send back to the client. This pattern lets an edge function fully control each request and response cycle.
+
 ## Syntax
 
 ```js
@@ -39,6 +41,17 @@ event.respondWith(response Request|Promise) // the HTTP request received by the 
     event.respondWith(handleRequest(event))
   })
 ```
+
+## Use cases
+
+- Reading the incoming `request` to route, filter, or transform traffic at the edge.
+- Returning a custom or synthesized response by passing it to `event.respondWith()`.
+- Forwarding the request to an origin with `fetch()` and resolving the response back to the client.
+
+## Related resources
+
+- [FetchEvent on MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/FetchEvent)
+- [Runtime APIs](/en/documentation/products/applications/functions/runtime-apis/javascript/fetch/)
 
 For more information on [fetchEvent](https://developer.mozilla.org/en-US/docs/Web/API/FetchEvent) visit MDN Web Docs.
 

--- a/src/content/docs/en/pages/devtools/azion-edge-runtime/runtime-apis/fetch/2021-01-14-index.mdx
+++ b/src/content/docs/en/pages/devtools/azion-edge-runtime/runtime-apis/fetch/2021-01-14-index.mdx
@@ -10,13 +10,13 @@ menu_namespace: runtimeMenu
 
 ## How it works
 
-The [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) provides an interface for fetching resources from the edge network, such as external resources across the network.
+The [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) provides an interface for fetching resources from Azion's global network, such as external resources across the network.
 
 Fetch provides a generic definition of [`Request`](https://developer.mozilla.org/pt-BR/docs/Web/API/Request) and [`Response`](https://developer.mozilla.org/pt-BR/docs/Web/API/Response) objects. It allows them to handle or modify requests and responses or any kind of use case that may require you to generate your responses programmatically.
 
 It also defines related concepts like CORS and the HTTP Origin header semantics, supplanting its separate definitions elsewhere.
 
-Inside an Azion edge function, `fetch()` is how you reach out to other systems while handling a request: you can call an origin server, query a third-party API, or retrieve assets, all from a location close to the end user. The call returns a promise that resolves to a `Response`, which you can read, modify, or pass straight back through `event.respondWith()`. Because the request originates at the edge, these outbound calls benefit from Azion's network and can be combined with caching and header manipulation to optimize delivery.
+Inside an Azion function, `fetch()` is how you reach out to other systems while handling a request: you can call an origin server, query a third-party API, or retrieve assets, all from a location close to the end user. The call returns a promise that resolves to a `Response`, which you can read, modify, or pass straight back through `event.respondWith()`. Because the request originates on Azion's distributed architecture, these outbound calls benefit from Azion's network and can be combined with caching and header manipulation to optimize delivery.
 
 ## Constructor
 
@@ -42,8 +42,8 @@ init: `requestInit`  - the content of the request.
 ## Use cases
 
 - Forwarding a request to an origin server and returning the response to the client.
-- Calling external REST or GraphQL APIs to enrich or assemble a response at the edge.
-- Aggregating data from multiple backends within a single edge function before responding.
+- Calling external REST or GraphQL APIs to enrich or assemble a response on Azion's global network.
+- Aggregating data from multiple backends within a single function before responding.
 - Retrieving remote assets or configuration and rewriting them before delivery.
 
 ## Related resources

--- a/src/content/docs/en/pages/devtools/azion-edge-runtime/runtime-apis/fetch/2021-01-14-index.mdx
+++ b/src/content/docs/en/pages/devtools/azion-edge-runtime/runtime-apis/fetch/2021-01-14-index.mdx
@@ -16,6 +16,8 @@ Fetch provides a generic definition of [`Request`](https://developer.mozilla.org
 
 It also defines related concepts like CORS and the HTTP Origin header semantics, supplanting its separate definitions elsewhere.
 
+Inside an Azion edge function, `fetch()` is how you reach out to other systems while handling a request: you can call an origin server, query a third-party API, or retrieve assets, all from a location close to the end user. The call returns a promise that resolves to a `Response`, which you can read, modify, or pass straight back through `event.respondWith()`. Because the request originates at the edge, these outbound calls benefit from Azion's network and can be combined with caching and header manipulation to optimize delivery.
+
 ## Constructor
 
 ```js
@@ -36,6 +38,18 @@ init: `requestInit`  - the content of the request.
     )
   })
 ```
+
+## Use cases
+
+- Forwarding a request to an origin server and returning the response to the client.
+- Calling external REST or GraphQL APIs to enrich or assemble a response at the edge.
+- Aggregating data from multiple backends within a single edge function before responding.
+- Retrieving remote assets or configuration and rewriting them before delivery.
+
+## Related resources
+
+- [fetch on MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/fetch)
+- [Runtime APIs](/en/documentation/products/applications/functions/runtime-apis/javascript/fetch/)
 
 For more information on [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) visit MDN Web Docs.
 

--- a/src/content/docs/en/pages/devtools/azion-edge-runtime/runtime-apis/web-standards/2021-01-14-index.mdx
+++ b/src/content/docs/en/pages/devtools/azion-edge-runtime/runtime-apis/web-standards/2021-01-14-index.mdx
@@ -19,7 +19,7 @@ Native JavaScript APIs are available for use, such as **Math** and **JSON** obje
 
 ## How it works
 
-The Azion edge runtime is built on web standards, so the JavaScript you write in an edge function relies on the same language features and global objects you already know from the browser and modern server environments. Standard built-ins like `Math`, `JSON`, `Date`, `String`, `Array`, `Map`, `Set`, and the `Promise`-based async model are all available, which means most portable JavaScript runs without modification. On top of the language itself, the runtime exposes widely adopted Web APIs such as `fetch`, `Request`, `Response`, the Web Crypto interfaces, streams, and event handling, letting you build edge logic with familiar tools instead of proprietary ones. Relying on these standards keeps your code interoperable, easier to test locally, and simpler to port across platforms, while still executing close to your end users on Azion's network.
+The Azion runtime is built on web standards, so the JavaScript you write in a function relies on the same language features and global objects you already know from the browser and modern server environments. Standard built-ins like `Math`, `JSON`, `Date`, `String`, `Array`, `Map`, `Set`, and the `Promise`-based async model are all available, which means most portable JavaScript runs without modification. On top of the language itself, the runtime exposes widely adopted Web APIs such as `fetch`, `Request`, `Response`, the Web Crypto interfaces, streams, and event handling, letting you build logic with familiar tools instead of proprietary ones. Relying on these standards keeps your code interoperable, easier to test locally, and simpler to port across platforms, while still executing close to your end users on Azion's global network.
 
 You will find more details about the JavaScript reference in this link: [https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference)
 
@@ -29,10 +29,10 @@ For security reasons, dynamic code evaluation through `eval` and the `Function` 
 
 ## Use cases
 
-- Parsing and serializing payloads with the `JSON` object as requests flow through an edge function.
+- Parsing and serializing payloads with the `JSON` object as requests flow through a function.
 - Performing calculations, formatting, and data manipulation using standard `Math`, `Date`, and `String` methods.
-- Writing portable logic that behaves consistently between local development and the edge runtime.
-- Combining native language features with supported Web APIs to assemble responses entirely at the edge.
+- Writing portable logic that behaves consistently between local development and the Azion runtime.
+- Combining native language features with supported Web APIs to assemble responses entirely on Azion's global network.
 
 ## Related resources
 

--- a/src/content/docs/en/pages/devtools/azion-edge-runtime/runtime-apis/web-standards/2021-01-14-index.mdx
+++ b/src/content/docs/en/pages/devtools/azion-edge-runtime/runtime-apis/web-standards/2021-01-14-index.mdx
@@ -17,9 +17,28 @@ menu_namespace: runtimeMenu
 
 Native JavaScript APIs are available for use, such as **Math** and **JSON** objects.
 
+## How it works
+
+The Azion edge runtime is built on web standards, so the JavaScript you write in an edge function relies on the same language features and global objects you already know from the browser and modern server environments. Standard built-ins like `Math`, `JSON`, `Date`, `String`, `Array`, `Map`, `Set`, and the `Promise`-based async model are all available, which means most portable JavaScript runs without modification. On top of the language itself, the runtime exposes widely adopted Web APIs such as `fetch`, `Request`, `Response`, the Web Crypto interfaces, streams, and event handling, letting you build edge logic with familiar tools instead of proprietary ones. Relying on these standards keeps your code interoperable, easier to test locally, and simpler to port across platforms, while still executing close to your end users on Azion's network.
+
 You will find more details about the JavaScript reference in this link: [https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference)
 
     eval, new Function are blocked for security reasons.
+
+For security reasons, dynamic code evaluation through `eval` and the `Function` constructor is disabled, so functions cannot generate and run arbitrary code at runtime.
+
+## Use cases
+
+- Parsing and serializing payloads with the `JSON` object as requests flow through an edge function.
+- Performing calculations, formatting, and data manipulation using standard `Math`, `Date`, and `String` methods.
+- Writing portable logic that behaves consistently between local development and the edge runtime.
+- Combining native language features with supported Web APIs to assemble responses entirely at the edge.
+
+## Related resources
+
+- [Web APIs on MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API)
+- [JavaScript reference on MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference)
+- [Runtime APIs](/en/documentation/products/applications/functions/runtime-apis/javascript/fetch/)
 
 
 

--- a/src/content/docs/en/pages/devtools/azion-edge-runtime/runtime-apis/writable-stream/2023-03-30-index.mdx
+++ b/src/content/docs/en/pages/devtools/azion-edge-runtime/runtime-apis/writable-stream/2023-03-30-index.mdx
@@ -15,6 +15,8 @@ menu_namespace: runtimeMenu
 
 The WritableStream interface is a part of the Streams API that provides a standardized way to write streaming data to a sink (destination). It comes with its own queuing and backpressure mechanism to ensure that the data is written in an efficient way.
 
+In an Azion edge function, a `WritableStream` lets you produce output incrementally instead of buffering an entire response in memory. This is especially useful when piping or transforming large payloads, because the built-in backpressure keeps the function from overwhelming the destination while data streams through close to the end user.
+
 ## Constructor
 
 [WritableStream()](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream/WritableStream)
@@ -35,6 +37,18 @@ Closes the stream.
 
 [WritableStream.getWriter()](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream/getWriter)
 Returns a new instance of WritableStreamDefaultWriter and locks the stream to that instance. While the stream is locked, no other writer can be acquired until this one is released.
+
+## Use cases
+
+- Streaming a large or generated response body to the client chunk by chunk instead of holding it all in memory.
+- Acting as the writable end of a `TransformStream` when you need to rewrite or filter a payload as it passes through an edge function.
+- Piping data from an upstream `ReadableStream` into a sink while the built-in backpressure throttles the producer to match the consumer.
+- Aborting an in-progress write with `abort()` when an error occurs, so partial or invalid output is discarded cleanly.
+
+## Related resources
+
+- [WritableStream on MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream)
+- [Runtime APIs](/en/documentation/products/applications/functions/runtime-apis/javascript/fetch/)
 
 For more information on [WritableStream](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream) visit MDN Web Docs.
 

--- a/src/content/docs/en/pages/devtools/azion-edge-runtime/runtime-apis/writable-stream/2023-03-30-index.mdx
+++ b/src/content/docs/en/pages/devtools/azion-edge-runtime/runtime-apis/writable-stream/2023-03-30-index.mdx
@@ -15,7 +15,7 @@ menu_namespace: runtimeMenu
 
 The WritableStream interface is a part of the Streams API that provides a standardized way to write streaming data to a sink (destination). It comes with its own queuing and backpressure mechanism to ensure that the data is written in an efficient way.
 
-In an Azion edge function, a `WritableStream` lets you produce output incrementally instead of buffering an entire response in memory. This is especially useful when piping or transforming large payloads, because the built-in backpressure keeps the function from overwhelming the destination while data streams through close to the end user.
+In an Azion function, a `WritableStream` lets you produce output incrementally instead of buffering an entire response in memory. This is especially useful when piping or transforming large payloads, because the built-in backpressure keeps the function from overwhelming the destination while data streams through close to the end user.
 
 ## Constructor
 
@@ -41,7 +41,7 @@ Returns a new instance of WritableStreamDefaultWriter and locks the stream to th
 ## Use cases
 
 - Streaming a large or generated response body to the client chunk by chunk instead of holding it all in memory.
-- Acting as the writable end of a `TransformStream` when you need to rewrite or filter a payload as it passes through an edge function.
+- Acting as the writable end of a `TransformStream` when you need to rewrite or filter a payload as it passes through a function.
 - Piping data from an upstream `ReadableStream` into a sink while the built-in backpressure throttles the producer to match the consumer.
 - Aborting an in-progress write with `abort()` when an error occurs, so partial or invalid output is discarded cleanly.
 

--- a/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/runtime-apis/add-eventlistener/index.mdx
+++ b/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/runtime-apis/add-eventlistener/index.mdx
@@ -14,6 +14,8 @@ menu_namespace: runtimeMenu
 
 A função *addEventListener* define o gatilho para execução do código JavaScript para receber os dados da requisição. O tipo do event listener é `fetch`, o qual recebe o [fetchEvent](/pt-br/documentacao/produtos/applications/functions/runtime-apis/javascript/fetch-event/).
 
+Dentro de uma edge function da Azion, o `addEventListener` é o ponto de entrada que conecta o seu código ao ciclo de vida da requisição. Quando o edge runtime recebe uma requisição HTTP, ele dispara um evento `fetch`, e o listener que você registra é a função de callback executada para montar e retornar a resposta. Como a função roda na rede distribuída da Azion, próxima ao usuário final, registrar o handler dessa forma permite interceptar, inspecionar e responder ao tráfego com latência mínima. Normalmente você registra um único listener `fetch` por função e chama `event.respondWith()` dentro dele para entregar a resposta final.
+
 ### Sintaxe
 
 `addEventListener(type, listener)`
@@ -34,7 +36,17 @@ addEventListener("fetch", event => {
 })
 ```
 
+## Casos de uso
 
+- Registrar o handler `fetch` principal que dá vida a uma aplicação no edge, direcionando requisições para a lógica correta conforme o caminho ou o método.
+- Interceptar requisições recebidas para adicionar autenticação, reescrever headers ou aplicar redirecionamentos antes de chegar à origem.
+- Gerar respostas dinâmicas diretamente no edge, como conteúdo personalizado ou variantes de testes A/B.
+- Implementar estratégias de cache personalizadas inspecionando a requisição e retornando uma resposta sintetizada.
+
+## Recursos relacionados
+
+- [addEventListener na MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener)
+- [Runtime APIs](/pt-br/documentacao/produtos/applications/functions/runtime-apis/javascript/fetch/)
 
 
 

--- a/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/runtime-apis/add-eventlistener/index.mdx
+++ b/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/runtime-apis/add-eventlistener/index.mdx
@@ -14,7 +14,7 @@ menu_namespace: runtimeMenu
 
 A função *addEventListener* define o gatilho para execução do código JavaScript para receber os dados da requisição. O tipo do event listener é `fetch`, o qual recebe o [fetchEvent](/pt-br/documentacao/produtos/applications/functions/runtime-apis/javascript/fetch-event/).
 
-Dentro de uma edge function da Azion, o `addEventListener` é o ponto de entrada que conecta o seu código ao ciclo de vida da requisição. Quando o edge runtime recebe uma requisição HTTP, ele dispara um evento `fetch`, e o listener que você registra é a função de callback executada para montar e retornar a resposta. Como a função roda na rede distribuída da Azion, próxima ao usuário final, registrar o handler dessa forma permite interceptar, inspecionar e responder ao tráfego com latência mínima. Normalmente você registra um único listener `fetch` por função e chama `event.respondWith()` dentro dele para entregar a resposta final.
+Dentro de uma function da Azion, o `addEventListener` é o ponto de entrada que conecta o seu código ao ciclo de vida da requisição. Quando o runtime recebe uma requisição HTTP, ele dispara um evento `fetch`, e o listener que você registra é a função de callback executada para montar e retornar a resposta. Como a função roda na rede distribuída da Azion, próxima ao usuário final, registrar o handler dessa forma permite interceptar, inspecionar e responder ao tráfego com latência mínima. Normalmente você registra um único listener `fetch` por função e chama `event.respondWith()` dentro dele para entregar a resposta final.
 
 ### Sintaxe
 
@@ -38,9 +38,9 @@ addEventListener("fetch", event => {
 
 ## Casos de uso
 
-- Registrar o handler `fetch` principal que dá vida a uma aplicação no edge, direcionando requisições para a lógica correta conforme o caminho ou o método.
+- Registrar o handler `fetch` principal que dá vida a uma aplicação, direcionando requisições para a lógica correta conforme o caminho ou o método.
 - Interceptar requisições recebidas para adicionar autenticação, reescrever headers ou aplicar redirecionamentos antes de chegar à origem.
-- Gerar respostas dinâmicas diretamente no edge, como conteúdo personalizado ou variantes de testes A/B.
+- Gerar respostas dinâmicas diretamente na rede global da Azion, como conteúdo personalizado ou variantes de testes A/B.
 - Implementar estratégias de cache personalizadas inspecionando a requisição e retornando uma resposta sintetizada.
 
 ## Recursos relacionados

--- a/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/runtime-apis/crypto-key/index.mdx
+++ b/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/runtime-apis/crypto-key/index.mdx
@@ -12,6 +12,8 @@ menu_namespace: runtimeMenu
 
 A interface `CryptoKey` representa uma chave criptográfica obtida de um dos [métodos SubtleCrypto](/pt-br/documentacao/produtos/applications/functions/runtime-apis/javascript/subtle-crypto/).
 
+Em uma edge function da Azion, uma `CryptoKey` é o objeto que você passa para as operações do SubtleCrypto ao criptografar, descriptografar, assinar ou verificar dados. Você não a constrói diretamente; em vez disso, ela é retornada por métodos como `generateKey()`, `importKey()` ou `deriveKey()`. Suas propriedades somente leitura descrevem o que a chave é e como ela pode ser usada, permitindo que o runtime garanta que uma chave seja aplicada apenas às operações para as quais foi criada. Tratar as chaves como objetos `CryptoKey` opacos mantém o material bruto da chave fora do código da função e ainda assim viabiliza um trabalho criptográfico rápido no edge.
+
 ## Propriedades
 
 [CryptoKey.type](https://developer.mozilla.org/en-US/docs/Web/API/CryptoKey/type)
@@ -25,6 +27,17 @@ Um objeto que descreve o algoritmo para o qual essa chave pode ser usada e quais
 
 [CryptoKey.usages](https://developer.mozilla.org/en-US/docs/Web/API/CryptoKey/usages)
 Um array de strings, indicando o que pode ser feito com a chave. Os valores possíveis para os elementos da matriz são "encrypt", "decrypt", "sign", "verify", "deriveKey", "deriveBits", "wrapKey" e "unwrapKey".
+
+## Casos de uso
+
+- Armazenar uma chave secreta importada usada para verificar tokens assinados ou assinaturas HMAC no edge.
+- Carregar um par de chaves gerado para assinar ou criptografar payloads antes que eles deixem a função.
+- Restringir como uma chave é aplicada por meio de suas `usages`, de modo que ela possa assinar, mas não descriptografar, por exemplo.
+
+## Recursos relacionados
+
+- [CryptoKey na MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/CryptoKey)
+- [Runtime APIs](/pt-br/documentacao/produtos/applications/functions/runtime-apis/javascript/fetch/)
 
 Para mais informações sobre [CryptoKey](https://developer.mozilla.org/en-US/docs/Web/API/CryptoKey) visite MDN Web Docs.
 

--- a/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/runtime-apis/crypto-key/index.mdx
+++ b/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/runtime-apis/crypto-key/index.mdx
@@ -12,7 +12,7 @@ menu_namespace: runtimeMenu
 
 A interface `CryptoKey` representa uma chave criptográfica obtida de um dos [métodos SubtleCrypto](/pt-br/documentacao/produtos/applications/functions/runtime-apis/javascript/subtle-crypto/).
 
-Em uma edge function da Azion, uma `CryptoKey` é o objeto que você passa para as operações do SubtleCrypto ao criptografar, descriptografar, assinar ou verificar dados. Você não a constrói diretamente; em vez disso, ela é retornada por métodos como `generateKey()`, `importKey()` ou `deriveKey()`. Suas propriedades somente leitura descrevem o que a chave é e como ela pode ser usada, permitindo que o runtime garanta que uma chave seja aplicada apenas às operações para as quais foi criada. Tratar as chaves como objetos `CryptoKey` opacos mantém o material bruto da chave fora do código da função e ainda assim viabiliza um trabalho criptográfico rápido no edge.
+Em uma function da Azion, uma `CryptoKey` é o objeto que você passa para as operações do SubtleCrypto ao criptografar, descriptografar, assinar ou verificar dados. Você não a constrói diretamente; em vez disso, ela é retornada por métodos como `generateKey()`, `importKey()` ou `deriveKey()`. Suas propriedades somente leitura descrevem o que a chave é e como ela pode ser usada, permitindo que o runtime garanta que uma chave seja aplicada apenas às operações para as quais foi criada. Tratar as chaves como objetos `CryptoKey` opacos mantém o material bruto da chave fora do código da função e ainda assim viabiliza um trabalho criptográfico rápido na rede global da Azion.
 
 ## Propriedades
 
@@ -30,7 +30,7 @@ Um array de strings, indicando o que pode ser feito com a chave. Os valores poss
 
 ## Casos de uso
 
-- Armazenar uma chave secreta importada usada para verificar tokens assinados ou assinaturas HMAC no edge.
+- Armazenar uma chave secreta importada usada para verificar tokens assinados ou assinaturas HMAC na rede global da Azion.
 - Carregar um par de chaves gerado para assinar ou criptografar payloads antes que eles deixem a função.
 - Restringir como uma chave é aplicada por meio de suas `usages`, de modo que ela possa assinar, mas não descriptografar, por exemplo.
 

--- a/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/runtime-apis/crypto/index.mdx
+++ b/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/runtime-apis/crypto/index.mdx
@@ -13,6 +13,8 @@ permalink: >-
 
 A interface [Crypto](https://developer.mozilla.org/en-US/docs/Web/API/Crypto)&nbsp;possibilita acesso a um gerador de números aleatórios criptograficamente forte e a primitivas criptográficas.
 
+Dentro de uma edge function da Azion, o objeto global `crypto` expõe esses recursos para que você execute operações seguras sem recorrer a bibliotecas externas. Por meio de `crypto.getRandomValues()` e `crypto.randomUUID()` você gera valores e identificadores aleatórios imprevisíveis, enquanto a propriedade `crypto.subtle` libera toda a API SubtleCrypto para gerar hash, assinar e verificar dados. Como o processamento acontece no edge, computações sensíveis como validação de tokens ou assinatura de requisições rodam próximas ao usuário e dispensam idas e voltas até um servidor central, reduzindo a latência e a exposição.
+
 ## Propriedades
 
 [Crypto.subtle](/pt-br/documentacao/produtos/applications/functions/runtime-apis/javascript/subtle-crypto/) retorna um objeto SubtleCrypto que fornece acesso a primitivas criptográficas comuns, como hash, assinatura, criptografia ou descriptografia.
@@ -22,6 +24,18 @@ A interface [Crypto](https://developer.mozilla.org/en-US/docs/Web/API/Crypto)&nb
 `Crypto.getRandomValues()` Preenche o TypedArray passado com valores aleatórios criptograficamente sólidos.
 
 `Crypto.randomUUID()` Retorna um UUID v4 de 36 caracteres gerado aleatoriamente.
+
+## Casos de uso
+
+- Gerar identificadores seguros e resistentes a colisões para sessões, requisições ou trace IDs com `randomUUID()`.
+- Produzir valores aleatórios criptograficamente fortes para construir nonces ou tokens no edge.
+- Calcular hash de payloads de requisição ou digests para verificar a integridade antes de encaminhar o tráfego.
+- Validar tokens assinados, como JWTs, diretamente na edge function sem contatar uma origem.
+
+## Recursos relacionados
+
+- [Crypto na MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/Crypto)
+- [Runtime APIs](/pt-br/documentacao/produtos/applications/functions/runtime-apis/javascript/fetch/)
 
 Para mais informações sobre [Crypto](https://developer.mozilla.org/en-US/docs/Web/API/Crypto) visite MDN Web Docs.
 

--- a/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/runtime-apis/crypto/index.mdx
+++ b/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/runtime-apis/crypto/index.mdx
@@ -13,7 +13,7 @@ permalink: >-
 
 A interface [Crypto](https://developer.mozilla.org/en-US/docs/Web/API/Crypto)&nbsp;possibilita acesso a um gerador de números aleatórios criptograficamente forte e a primitivas criptográficas.
 
-Dentro de uma edge function da Azion, o objeto global `crypto` expõe esses recursos para que você execute operações seguras sem recorrer a bibliotecas externas. Por meio de `crypto.getRandomValues()` e `crypto.randomUUID()` você gera valores e identificadores aleatórios imprevisíveis, enquanto a propriedade `crypto.subtle` libera toda a API SubtleCrypto para gerar hash, assinar e verificar dados. Como o processamento acontece no edge, computações sensíveis como validação de tokens ou assinatura de requisições rodam próximas ao usuário e dispensam idas e voltas até um servidor central, reduzindo a latência e a exposição.
+Dentro de uma function da Azion, o objeto global `crypto` expõe esses recursos para que você execute operações seguras sem recorrer a bibliotecas externas. Por meio de `crypto.getRandomValues()` e `crypto.randomUUID()` você gera valores e identificadores aleatórios imprevisíveis, enquanto a propriedade `crypto.subtle` libera toda a API SubtleCrypto para gerar hash, assinar e verificar dados. Como o processamento acontece na arquitetura distribuída da Azion, computações sensíveis como validação de tokens ou assinatura de requisições rodam próximas ao usuário e dispensam idas e voltas até um servidor central, reduzindo a latência e a exposição.
 
 ## Propriedades
 
@@ -28,9 +28,9 @@ Dentro de uma edge function da Azion, o objeto global `crypto` expõe esses recu
 ## Casos de uso
 
 - Gerar identificadores seguros e resistentes a colisões para sessões, requisições ou trace IDs com `randomUUID()`.
-- Produzir valores aleatórios criptograficamente fortes para construir nonces ou tokens no edge.
+- Produzir valores aleatórios criptograficamente fortes para construir nonces ou tokens na rede global da Azion.
 - Calcular hash de payloads de requisição ou digests para verificar a integridade antes de encaminhar o tráfego.
-- Validar tokens assinados, como JWTs, diretamente na edge function sem contatar uma origem.
+- Validar tokens assinados, como JWTs, diretamente na function sem contatar uma origem.
 
 ## Recursos relacionados
 

--- a/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/runtime-apis/fetch-event/index.mdx
+++ b/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/runtime-apis/fetch-event/index.mdx
@@ -14,7 +14,7 @@ menu_namespace: runtimeMenu
 
 FetchEvent consiste no evento que passa a request através da função *addEventListener*. A função *addEventListener*, por sua vez, define o gatilho para a execução do código JavaScript e receber os dados da requisição.
 
-Quando o edge runtime da Azion recebe uma requisição HTTP, ele cria um `FetchEvent` e o entrega ao listener `fetch` que você registrou. O evento carrega o objeto `request` original, dando à sua função acesso à URL, ao método, aos headers e ao corpo do tráfego de entrada. Para produzir a resposta, você chama `event.respondWith()` com um `Response` ou uma promise que resolve em um, indicando ao runtime exatamente o que enviar de volta ao cliente. Esse padrão permite que uma edge function controle por completo cada ciclo de requisição e resposta.
+Quando o runtime da Azion recebe uma requisição HTTP, ele cria um `FetchEvent` e o entrega ao listener `fetch` que você registrou. O evento carrega o objeto `request` original, dando à sua função acesso à URL, ao método, aos headers e ao corpo do tráfego de entrada. Para produzir a resposta, você chama `event.respondWith()` com um `Response` ou uma promise que resolve em um, indicando ao runtime exatamente o que enviar de volta ao cliente. Esse padrão permite que uma function controle por completo cada ciclo de requisição e resposta.
 
 ### Sintaxe
 
@@ -42,7 +42,7 @@ addEventListener("fetch", event => {
 
 ## Casos de uso
 
-- Ler a `request` recebida para rotear, filtrar ou transformar o tráfego no edge.
+- Ler a `request` recebida para rotear, filtrar ou transformar o tráfego na rede global da Azion.
 - Retornar uma resposta personalizada ou sintetizada passando-a para `event.respondWith()`.
 - Encaminhar a requisição a uma origem com `fetch()` e resolver a resposta de volta ao cliente.
 

--- a/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/runtime-apis/fetch-event/index.mdx
+++ b/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/runtime-apis/fetch-event/index.mdx
@@ -14,6 +14,8 @@ menu_namespace: runtimeMenu
 
 FetchEvent consiste no evento que passa a request através da função *addEventListener*. A função *addEventListener*, por sua vez, define o gatilho para a execução do código JavaScript e receber os dados da requisição.
 
+Quando o edge runtime da Azion recebe uma requisição HTTP, ele cria um `FetchEvent` e o entrega ao listener `fetch` que você registrou. O evento carrega o objeto `request` original, dando à sua função acesso à URL, ao método, aos headers e ao corpo do tráfego de entrada. Para produzir a resposta, você chama `event.respondWith()` com um `Response` ou uma promise que resolve em um, indicando ao runtime exatamente o que enviar de volta ao cliente. Esse padrão permite que uma edge function controle por completo cada ciclo de requisição e resposta.
+
 ### Sintaxe
 
 `addEventListener(type, listener)`
@@ -38,7 +40,16 @@ addEventListener("fetch", event => {
 })
 ```
 
+## Casos de uso
 
+- Ler a `request` recebida para rotear, filtrar ou transformar o tráfego no edge.
+- Retornar uma resposta personalizada ou sintetizada passando-a para `event.respondWith()`.
+- Encaminhar a requisição a uma origem com `fetch()` e resolver a resposta de volta ao cliente.
+
+## Recursos relacionados
+
+- [FetchEvent na MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/FetchEvent)
+- [Runtime APIs](/pt-br/documentacao/produtos/applications/functions/runtime-apis/javascript/fetch/)
 
 
 

--- a/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/runtime-apis/web-standards/index.mdx
+++ b/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/runtime-apis/web-standards/index.mdx
@@ -12,9 +12,28 @@ menu_namespace: runtimeMenu
 
 As APIs JavaScript nativas estão disponíveis para uso, como Objetos **Math** e **JSON**, por exemplo.
 
+### Como Funciona
+
+O edge runtime da Azion é construído sobre padrões web, então o JavaScript que você escreve em uma edge function se apoia nos mesmos recursos da linguagem e objetos globais que você já conhece do navegador e de ambientes de servidor modernos. Built-ins padrão como `Math`, `JSON`, `Date`, `String`, `Array`, `Map`, `Set` e o modelo assíncrono baseado em `Promise` estão todos disponíveis, o que significa que a maior parte do JavaScript portável roda sem modificações. Além da própria linguagem, o runtime expõe Web APIs amplamente adotadas, como `fetch`, `Request`, `Response`, as interfaces de Web Crypto, streams e tratamento de eventos, permitindo construir a lógica no edge com ferramentas familiares em vez de proprietárias. Apoiar-se nesses padrões mantém o seu código interoperável, mais fácil de testar localmente e mais simples de portar entre plataformas, enquanto ainda executa próximo aos seus usuários finais na rede da Azion.
+
 Neste link, você encontra mais detalhes sobre a referência de JavaScript: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference
 
     eval, new Function estão bloqueados por razões de segurança.
+
+Por razões de segurança, a avaliação dinâmica de código por meio de `eval` e do construtor `Function` está desabilitada, de modo que as funções não podem gerar e executar código arbitrário em tempo de execução.
+
+## Casos de uso
+
+- Fazer o parsing e a serialização de payloads com o objeto `JSON` à medida que as requisições passam por uma edge function.
+- Realizar cálculos, formatações e manipulação de dados usando os métodos padrão de `Math`, `Date` e `String`.
+- Escrever uma lógica portável que se comporta de forma consistente entre o desenvolvimento local e o edge runtime.
+- Combinar recursos nativos da linguagem com Web APIs suportadas para montar respostas inteiramente no edge.
+
+## Recursos relacionados
+
+- [Web APIs na MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API)
+- [Referência de JavaScript na MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference)
+- [Runtime APIs](/pt-br/documentacao/produtos/applications/functions/runtime-apis/javascript/fetch/)
 
 
 

--- a/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/runtime-apis/web-standards/index.mdx
+++ b/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/runtime-apis/web-standards/index.mdx
@@ -14,7 +14,7 @@ As APIs JavaScript nativas estão disponíveis para uso, como Objetos **Math** e
 
 ### Como Funciona
 
-O edge runtime da Azion é construído sobre padrões web, então o JavaScript que você escreve em uma edge function se apoia nos mesmos recursos da linguagem e objetos globais que você já conhece do navegador e de ambientes de servidor modernos. Built-ins padrão como `Math`, `JSON`, `Date`, `String`, `Array`, `Map`, `Set` e o modelo assíncrono baseado em `Promise` estão todos disponíveis, o que significa que a maior parte do JavaScript portável roda sem modificações. Além da própria linguagem, o runtime expõe Web APIs amplamente adotadas, como `fetch`, `Request`, `Response`, as interfaces de Web Crypto, streams e tratamento de eventos, permitindo construir a lógica no edge com ferramentas familiares em vez de proprietárias. Apoiar-se nesses padrões mantém o seu código interoperável, mais fácil de testar localmente e mais simples de portar entre plataformas, enquanto ainda executa próximo aos seus usuários finais na rede da Azion.
+O runtime da Azion é construído sobre padrões web, então o JavaScript que você escreve em uma function se apoia nos mesmos recursos da linguagem e objetos globais que você já conhece do navegador e de ambientes de servidor modernos. Built-ins padrão como `Math`, `JSON`, `Date`, `String`, `Array`, `Map`, `Set` e o modelo assíncrono baseado em `Promise` estão todos disponíveis, o que significa que a maior parte do JavaScript portável roda sem modificações. Além da própria linguagem, o runtime expõe Web APIs amplamente adotadas, como `fetch`, `Request`, `Response`, as interfaces de Web Crypto, streams e tratamento de eventos, permitindo construir a lógica com ferramentas familiares em vez de proprietárias. Apoiar-se nesses padrões mantém o seu código interoperável, mais fácil de testar localmente e mais simples de portar entre plataformas, enquanto ainda executa próximo aos seus usuários finais na rede global da Azion.
 
 Neste link, você encontra mais detalhes sobre a referência de JavaScript: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference
 
@@ -24,10 +24,10 @@ Por razões de segurança, a avaliação dinâmica de código por meio de `eval`
 
 ## Casos de uso
 
-- Fazer o parsing e a serialização de payloads com o objeto `JSON` à medida que as requisições passam por uma edge function.
+- Fazer o parsing e a serialização de payloads com o objeto `JSON` à medida que as requisições passam por uma function.
 - Realizar cálculos, formatações e manipulação de dados usando os métodos padrão de `Math`, `Date` e `String`.
-- Escrever uma lógica portável que se comporta de forma consistente entre o desenvolvimento local e o edge runtime.
-- Combinar recursos nativos da linguagem com Web APIs suportadas para montar respostas inteiramente no edge.
+- Escrever uma lógica portável que se comporta de forma consistente entre o desenvolvimento local e o runtime da Azion.
+- Combinar recursos nativos da linguagem com Web APIs suportadas para montar respostas inteiramente na rede global da Azion.
 
 ## Recursos relacionados
 

--- a/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/runtime-apis/writable-stream/index.mdx
+++ b/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/runtime-apis/writable-stream/index.mdx
@@ -13,6 +13,8 @@ menu_namespace: runtimeMenu
 
 A interface WritableStream é uma parte da API Streams que fornece uma maneira padronizada de gravar dados de streaming em uma sink (ou destino). Ela vem com seu próprio mecanismo de fila e backpressure para garantir que os dados sejam escritos de maneira eficiente.
 
+Em uma edge function da Azion, uma `WritableStream` permite produzir a saída de forma incremental, em vez de armazenar uma resposta inteira em memória. Isso é especialmente útil ao canalizar ou transformar grandes payloads, porque o backpressure embutido evita que a função sobrecarregue o destino enquanto os dados fluem próximos ao usuário final.
+
 ## Construtor
 
 [WritableStream()](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream/WritableStream)
@@ -33,6 +35,18 @@ Fecha o fluxo.
 
 [WritableStream.getWriter()](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream/getWriter)
 Retorna uma nova instância de WritableStreamDefaultWriter e bloqueia o fluxo para essa instância. Enquanto a stream está bloqueada, nenhum outro writer pode ser adquirido até que este seja liberado.
+
+## Casos de uso
+
+- Transmitir um corpo de resposta grande ou gerado dinamicamente ao cliente em pedaços, em vez de mantê-lo todo em memória.
+- Atuar como a extremidade gravável de um `TransformStream` quando você precisa reescrever ou filtrar um payload enquanto ele passa por uma edge function.
+- Canalizar dados de um `ReadableStream` de upstream para uma sink enquanto o backpressure embutido ajusta o produtor ao ritmo do consumidor.
+- Abortar uma gravação em andamento com `abort()` quando ocorre um erro, descartando de forma limpa a saída parcial ou inválida.
+
+## Recursos relacionados
+
+- [WritableStream na MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream)
+- [Runtime APIs](/pt-br/documentacao/produtos/applications/functions/runtime-apis/javascript/fetch/)
 
 Para mais informações sobre [o WritableStream](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream), visite MDN Web Docs.
 

--- a/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/runtime-apis/writable-stream/index.mdx
+++ b/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/runtime-apis/writable-stream/index.mdx
@@ -13,7 +13,7 @@ menu_namespace: runtimeMenu
 
 A interface WritableStream é uma parte da API Streams que fornece uma maneira padronizada de gravar dados de streaming em uma sink (ou destino). Ela vem com seu próprio mecanismo de fila e backpressure para garantir que os dados sejam escritos de maneira eficiente.
 
-Em uma edge function da Azion, uma `WritableStream` permite produzir a saída de forma incremental, em vez de armazenar uma resposta inteira em memória. Isso é especialmente útil ao canalizar ou transformar grandes payloads, porque o backpressure embutido evita que a função sobrecarregue o destino enquanto os dados fluem próximos ao usuário final.
+Em uma function da Azion, uma `WritableStream` permite produzir a saída de forma incremental, em vez de armazenar uma resposta inteira em memória. Isso é especialmente útil ao canalizar ou transformar grandes payloads, porque o backpressure embutido evita que a função sobrecarregue o destino enquanto os dados fluem próximos ao usuário final.
 
 ## Construtor
 
@@ -39,7 +39,7 @@ Retorna uma nova instância de WritableStreamDefaultWriter e bloqueia o fluxo pa
 ## Casos de uso
 
 - Transmitir um corpo de resposta grande ou gerado dinamicamente ao cliente em pedaços, em vez de mantê-lo todo em memória.
-- Atuar como a extremidade gravável de um `TransformStream` quando você precisa reescrever ou filtrar um payload enquanto ele passa por uma edge function.
+- Atuar como a extremidade gravável de um `TransformStream` quando você precisa reescrever ou filtrar um payload enquanto ele passa por uma function.
 - Canalizar dados de um `ReadableStream` de upstream para uma sink enquanto o backpressure embutido ajusta o produtor ao ritmo do consumidor.
 - Abortar uma gravação em andamento com `abort()` quando ocorre um erro, descartando de forma limpa a saída parcial ou inválida.
 


### PR DESCRIPTION
## Context

Part of the effort to fix the 147 pages flagged with a **low word count**. This PR covers the **JavaScript Runtime APIs** reference pages (`…/runtime-apis/…`).

## What changed

Across **14 pages (8 EN + 6 PT-BR)** — `add-eventlistener`, `crypto`, `crypto-key`, `event-target`, `fetch-event`, `fetch`, `web-standards`, `writable-stream` (and the 6 flagged PT-BR equivalents) — each page now has:

- An **expanded "How it works"** explaining how the API is used inside an Azion edge function.
- A **`## Use cases`** / **`## Casos de uso`** section with concrete edge scenarios.
- A **`## Related resources`** / **`## Recursos relacionados`** section linking the relevant MDN reference and the Runtime APIs docs.

The existing Constructor / Syntax / Properties / Example sections and all **code blocks remain unchanged**; only prose was added. Code-fence parity verified on all 14 files.

## A note on depth

These pages received a more thorough expansion than the strict "just clear 200" minimum — each now lands well above the threshold with a genuine Use cases + Related resources section, which improves the reference value. Content is technically accurate (verified by spot-check), not padding.

⚠️ `astro build` couldn't run locally (restricted network) — **CI on this PR is the build gate.**

## Scope

This is **4 of 6 category PRs**. Companions: Templates [#2176](https://github.com/aziontech/docs/pull/2176), JS examples [#2177](https://github.com/aziontech/docs/pull/2177), Node compat [#2178](https://github.com/aziontech/docs/pull/2178). Next: CLI commands and a small misc group.

https://claude.ai/code/session_01KCHEDmoe3XWrZkTjksHfGY

---
_Generated by [Claude Code](https://claude.ai/code/session_01KCHEDmoe3XWrZkTjksHfGY)_