### PR TITLE
docs: enrich low-word-count CLI command pages (10 pages, EN + PT-BR)

### DIFF
--- a/src/content/docs/en/pages/devtools/cli/azion-cli/commands/login/login.mdx
+++ b/src/content/docs/en/pages/devtools/cli/azion-cli/commands/login/login.mdx
@@ -9,7 +9,7 @@ menu_namespace: cliMenuAlpha
 permalink: /documentation/products/cli/login/
 ---
 
-Log in to your Azion account and save a personal token locally to authorize CLI commands.
+The `azion login` command authenticates the CLI with your Azion account. You can sign in by passing a personal token or your credentials directly, or let the CLI open a browser-based flow when fields are omitted. Run it before any other command: once you're authenticated, the resulting credentials are stored locally so that subsequent CLI requests are authorized against your account.
 
 :::note 
 In case one or more required fields aren't informed through the specific flags, an interactive message prompts and asks for the missing information.
@@ -37,3 +37,8 @@ The `--password` flag inputs the password related to the email.
 ### help
 
 The `-h` or `--help` option displays more information about the `azion login` command.
+
+## Related commands
+
+- [azion logout](/en/documentation/products/cli/logout/): logs out and removes the personal token stored locally.
+- [azion whoami](/en/documentation/devtools/cli/whoami/): confirms which authenticated account the CLI is currently using.

--- a/src/content/docs/en/pages/devtools/cli/azion-cli/commands/logout/logout.mdx
+++ b/src/content/docs/en/pages/devtools/cli/azion-cli/commands/logout/logout.mdx
@@ -7,7 +7,11 @@ menu_namespace: cliMenuAlpha
 permalink: /documentation/products/cli/logout/
 ---
 
-Log out of your Azion account and remove the personal token saved locally.
+The `azion logout` command signs you out of your Azion account from the CLI. Use it when you want to end your session or switch to a different account on the same machine. Running it removes the personal token saved locally during login, so the CLI can no longer make authorized requests until you authenticate again.
+
+:::note
+After logging out, you'll need to run `azion login` again before any command that requires authentication will work.
+:::
 
 ## Usage
 
@@ -20,4 +24,9 @@ azion logout
 ### help
 
 The `-h` or `--help` option displays more information about the `azion logout` command.
+
+## Related commands
+
+- [azion login](/en/documentation/products/cli/login/): authenticates the CLI and stores a personal token locally.
+- [azion whoami](/en/documentation/devtools/cli/whoami/): shows the email of the account currently signed in.
 

--- a/src/content/docs/en/pages/devtools/cli/azion-cli/commands/reset/index.mdx
+++ b/src/content/docs/en/pages/devtools/cli/azion-cli/commands/reset/index.mdx
@@ -9,10 +9,10 @@ menu_namespace: cliMenuAlpha
 permalink: /documentation/devtools/cli/reset/
 ---
 
-Reset your Azion CLI settings to default and delete the personal token if possible.
+The `azion reset` command restores the CLI's stored settings and metadata to a clean, default state. Reach for it when your local configuration becomes inconsistent or when you want to start fresh on a machine. Running it reverts the saved preferences to their defaults and, when possible, deletes the personal token kept locally.
 
 :::note 
-This command is unrelated to the projects. This action affects only the use of Azion CLI.
+This command is unrelated to the projects. This action affects only the use of Azion CLI. Use it with care, since your stored settings will be returned to their defaults.
 :::
 
 ## Usage
@@ -26,4 +26,9 @@ azion reset
 #### help
 
 The `--help` option displays more information about the `reset` command.
+
+## Related commands
+
+- [azion unlink](/en/documentation/devtools/cli/unlink-command/): detaches a local project from its linked Azion resources.
+- [azion logout](/en/documentation/products/cli/logout/): signs out and removes the personal token saved locally.
 

--- a/src/content/docs/en/pages/devtools/cli/azion-cli/commands/unlink/unlink.mdx
+++ b/src/content/docs/en/pages/devtools/cli/azion-cli/commands/unlink/unlink.mdx
@@ -15,7 +15,11 @@ In case one or more required fields aren't informed through the specific flags, 
 
 ## Unlink
 
-The `azion unlink` command disconnects a local repo or project folder from Azion. The use of the `--yes` option allows the action to complete without asking for confirmation. To get more information about this command, you can use the `-h` or `--help` option.
+The `azion unlink` command removes the association between your local project directory and the Azion resources and configuration it was linked to. Use it when you want to detach a repo or project folder from Azion without touching anything in the cloud, for example before relinking to a different application. The use of the `--yes` option allows the action to complete without asking for confirmation. To get more information about this command, you can use the `-h` or `--help` option.
+
+:::note
+Unlinking only affects local configuration. Your remote resources on the Azion Web Platform are not deleted, so the project can be linked again later.
+:::
 
 ---
 
@@ -36,4 +40,9 @@ The `--help` option provides more information about the `azion unlink` action.
 ### yes
 
 The `--yes` option completes the unlink action without asking for confirmation.
+
+## Related commands
+
+- [azion reset](/en/documentation/devtools/cli/reset/): restores the CLI's stored settings to a clean state.
+- [azion login](/en/documentation/products/cli/login/): authenticates the CLI before you link or work with a project.
 

--- a/src/content/docs/en/pages/devtools/cli/azion-cli/commands/whoami/whoami.mdx
+++ b/src/content/docs/en/pages/devtools/cli/azion-cli/commands/whoami/whoami.mdx
@@ -7,10 +7,10 @@ menu_namespace: cliMenuAlpha
 permalink: /documentation/devtools/cli/whoami/
 ---
 
-Shows the email of the currently logged in user on Azion CLI.
+The `azion whoami` command prints the email address of the user currently authenticated on the Azion CLI. It's a quick way to confirm which account your commands will run against, which is especially handy when you work with more than one Azion account on the same machine. The command reads the locally stored credentials and outputs the associated email.
 
 :::note 
-In case one or more required fields aren't informed through the specific flags, an interactive message prompts and asks for the missing information.
+If you aren't logged in, `azion whoami` has no authenticated user to report. Run `azion login` first to authenticate the CLI.
 :::
 
 ---
@@ -26,3 +26,8 @@ $ azion whoami
 ### help
 
 The `-h` or `--help` flag displays more information about the `azion whoami` command. It's an optional flag.
+
+## Related commands
+
+- [azion login](/en/documentation/products/cli/login/): authenticates the CLI with your Azion account.
+- [azion logout](/en/documentation/products/cli/logout/): signs out and removes the locally stored personal token.

--- a/src/content/docs/pt-br/pages/devtools/cli/azion-cli/comandos/login/login.mdx
+++ b/src/content/docs/pt-br/pages/devtools/cli/azion-cli/comandos/login/login.mdx
@@ -11,7 +11,7 @@ namespace: documentation_cli_login
 menu_namespace: cliMenuAlpha
 ---
 
-Faça login na sua conta da Azion e salve um personal token localmente para autorizar comandos na Azion CLI.
+O comando `azion login` autentica a CLI com a sua conta da Azion. Você pode entrar informando um personal token ou suas credenciais diretamente, ou deixar que a CLI abra o fluxo de autenticação pelo navegador quando os campos forem omitidos. Execute-o antes de qualquer outro comando: depois de autenticado, as credenciais ficam salvas localmente para que as próximas requisições da CLI sejam autorizadas na sua conta.
 
 :::note
 Se um ou mais campos obrigatórios não forem informados através das flags específicas, uma mensagem interativa será exibida, solicitando essas informações.
@@ -40,3 +40,8 @@ A flag `--password` insere a senha relacionada ao email.
 ### help
 
 A opção `-h` ou `--help` exibe mais informações sobre o comando `azion login`.
+
+## Comandos relacionados
+
+- [azion logout](/pt-br/documentacao/produtos/cli/logout/): faz logout e remove o personal token salvo localmente.
+- [azion whoami](/pt-br/documentacao/devtools/cli/whoami/): confirma qual conta autenticada a CLI está utilizando.

--- a/src/content/docs/pt-br/pages/devtools/cli/azion-cli/comandos/logout/logout.mdx
+++ b/src/content/docs/pt-br/pages/devtools/cli/azion-cli/comandos/logout/logout.mdx
@@ -9,7 +9,11 @@ namespace: documentation_cli_logout
 menu_namespace: cliMenuAlpha
 ---
 
-Saia da sua conta Azion e remova o personal token salvo localmente.
+O comando `azion logout` encerra a sua sessão na conta da Azion a partir da CLI. Use-o quando quiser finalizar a sessão ou alternar para outra conta na mesma máquina. Ao executá-lo, o personal token salvo localmente durante o login é removido, de modo que a CLI não consegue mais fazer requisições autorizadas até que você se autentique novamente.
+
+:::note
+Após o logout, será necessário executar `azion login` novamente antes que qualquer comando que exija autenticação volte a funcionar.
+:::
 
 ## Uso
 
@@ -22,3 +26,8 @@ azion logout
 ### help
 
 A opção `-h` ou `--help` exibe mais informações sobre o comando `azion logout`.
+
+## Comandos relacionados
+
+- [azion login](/pt-br/documentacao/produtos/cli/login/): autentica a CLI e salva um personal token localmente.
+- [azion whoami](/pt-br/documentacao/devtools/cli/whoami/): exibe o email da conta atualmente autenticada.

--- a/src/content/docs/pt-br/pages/devtools/cli/azion-cli/comandos/reset/reset.mdx
+++ b/src/content/docs/pt-br/pages/devtools/cli/azion-cli/comandos/reset/reset.mdx
@@ -11,10 +11,10 @@ namespace: documentation_cli_reset
 menu_namespace: cliMenuAlpha
 ---
 
-Redefina suas configurações da Azion CLI para o padrão e exclua o personal token, se possível.
+O comando `azion reset` restaura as configurações e os metadados salvos da CLI para um estado limpo e padrão. Recorra a ele quando a sua configuração local ficar inconsistente ou quando quiser começar do zero em uma máquina. Ao executá-lo, as preferências salvas voltam aos valores padrão e, quando possível, o personal token mantido localmente é excluído.
 
 :::note 
-Este comando não está relacionado aos projetos. Esta ação afeta apenas o uso da Azion CLI.
+Este comando não está relacionado aos projetos. Esta ação afeta apenas o uso da Azion CLI. Use-o com cuidado, pois as suas configurações salvas serão retornadas aos valores padrão.
 :::
 
 ## Uso
@@ -28,3 +28,8 @@ azion reset
 #### help
 
 A opção `--help` exibe mais informações sobre o comando `reset`.
+
+## Comandos relacionados
+
+- [azion unlink](/pt-br/documentacao/devtools/cli/comando-unlink/): desvincula um projeto local dos recursos da Azion aos quais ele estava associado.
+- [azion logout](/pt-br/documentacao/produtos/cli/logout/): faz logout e remove o personal token salvo localmente.

--- a/src/content/docs/pt-br/pages/devtools/cli/azion-cli/comandos/unlink/unlink.mdx
+++ b/src/content/docs/pt-br/pages/devtools/cli/azion-cli/comandos/unlink/unlink.mdx
@@ -19,7 +19,11 @@ Se um ou mais campos obrigatórios não forem informados através das flags espe
 
 ## Unlink
 
-O comando `azion unlink` desconecta um repositório local ou pasta de projeto da Azion. O uso da opção `--yes` permite que a ação seja concluída sem pedir confirmação. Para obter mais informações sobre este comando, você pode usar a opção `-h` ou `--help`.
+O comando `azion unlink` remove a associação entre o seu diretório de projeto local e os recursos e a configuração da Azion aos quais ele estava vinculado. Use-o quando quiser desvincular um repositório ou pasta de projeto da Azion sem alterar nada na nuvem, por exemplo antes de vincular o projeto a outra aplicação. O uso da opção `--yes` permite que a ação seja concluída sem pedir confirmação. Para obter mais informações sobre este comando, você pode usar a opção `-h` ou `--help`.
+
+:::note
+A desvinculação afeta apenas a configuração local. Os seus recursos remotos na Azion Web Platform não são excluídos, então o projeto pode ser vinculado novamente mais tarde.
+:::
 
 ---
 
@@ -40,3 +44,8 @@ A opção `--help` fornece mais informações sobre a ação `azion unlink`.
 ### yes
 
 A opção `--yes` completa a ação de desvinculação sem pedir confirmação.
+
+## Comandos relacionados
+
+- [azion reset](/pt-br/documentacao/devtools/cli/reset/): restaura as configurações salvas da CLI para um estado limpo.
+- [azion login](/pt-br/documentacao/produtos/cli/login/): autentica a CLI antes de vincular ou trabalhar em um projeto.

--- a/src/content/docs/pt-br/pages/devtools/cli/azion-cli/comandos/whoami/whoami.mdx
+++ b/src/content/docs/pt-br/pages/devtools/cli/azion-cli/comandos/whoami/whoami.mdx
@@ -12,10 +12,10 @@ namespace: documentation_cli_whoami
 menu_namespace: cliMenuAlpha
 ---
 
-Exibe o email do usuário que está logado na Azion CLI.
+O comando `azion whoami` exibe o endereço de email do usuário atualmente autenticado na Azion CLI. É uma forma rápida de confirmar em qual conta os seus comandos serão executados, o que é especialmente útil quando você trabalha com mais de uma conta da Azion na mesma máquina. O comando lê as credenciais salvas localmente e mostra o email associado a elas.
 
 :::note
-Se um ou mais campos obrigatórios não forem informados através das flags específicas, uma mensagem interativa será exibida, solicitando essas informações.
+Se você não estiver logado, o `azion whoami` não tem um usuário autenticado para informar. Execute `azion login` primeiro para autenticar a CLI.
 :::
 
 ---
@@ -31,3 +31,8 @@ $ azion whoami
 ### help
 
 A flag `-h` ou `--help` exibe mais informações sobre o comando `azion whoami`. É uma flag opcional.
+
+## Comandos relacionados
+
+- [azion login](/pt-br/documentacao/produtos/cli/login/): autentica a CLI com a sua conta da Azion.
+- [azion logout](/pt-br/documentacao/produtos/cli/logout/): faz logout e remove o personal token salvo localmente.


### PR DESCRIPTION
## Context

Part of the effort to fix the 147 pages flagged with a **low word count**. This PR covers the **Azion CLI command** reference pages.

## What changed

Across **10 pages (5 EN + 5 PT-BR)** — `login`, `logout`, `whoami`, `unlink`, `reset` — each page now has:

- An **expanded intro** (2–3 sentences: what the command does, when to use it, what happens).
- A **`:::note`** callout with a useful behavioral detail (e.g. after `logout` you must `login` again).
- A **`## Related commands`** / **`## Comandos relacionados`** section linking sibling commands via their real permalinks (PT uses the localized `comando-unlink` slug, etc.).

The existing **`## Usage` sections and `bash` code blocks are unchanged**; only prose was added. Note and code-fence balance verified on all 10 files.

⚠️ `astro build` couldn't run locally (restricted network) — **CI on this PR is the build gate.**

## Scope

This is **5 of 6 category PRs**. Companions: Templates [#2176](https://github.com/aziontech/docs/pull/2176), JS examples [#2177](https://github.com/aziontech/docs/pull/2177), Node compat [#2178](https://github.com/aziontech/docs/pull/2178), Runtime APIs [#2179](https://github.com/aziontech/docs/pull/2179). Final group (Deploy / DevTools home / GraphQL / Azion Lib) coming next.

https://claude.ai/code/session_01KCHEDmoe3XWrZkTjksHfGY

---
_Generated by [Claude Code](https://claude.ai/code/session_01KCHEDmoe3XWrZkTjksHfGY)_