### PR TITLE
refactor: add overview heading to PageContent header

### DIFF
--- a/src/components/PageContent/PageContent.astro
+++ b/src/components/PageContent/PageContent.astro
@@ -58,6 +58,7 @@ const t = useTranslations(Astro);
 						<AskAISplitButton lang={lang} client:load />
 					  </div>
 				</div>
+				<h1 id="overview" set:html={title} />
 			</header>
 			<ReadableContent>
 				{


### PR DESCRIPTION
### Related issue
[NO-ISSUE]

### Changes
Added an `<h1>` heading element with id "overview" to the PageContent header component. This heading displays the page title using the `title` prop and is positioned after the action buttons section.

The change improves semantic HTML structure by explicitly marking the main page title as a heading element, which benefits accessibility and document outline clarity.

### Additional notes
This is a minor structural enhancement to the PageContent component template with no functional impact on existing features.

https://claude.ai/code/session_01NwE1zdBDTwRS68mpoxUnNv