### PR TITLE
docs: format example URLs in Image Processor guide for clarity

### DIFF
--- a/src/content/docs/en/pages/guides/edge-application/ea-fs-image-processor.mdx
+++ b/src/content/docs/en/pages/guides/edge-application/ea-fs-image-processor.mdx
@@ -28,9 +28,9 @@ For images, Azion recommends that you choose larger time-to-live (TTL) values, s
 :::caution
 To ensure proper processing of images, the `ims=` query string parameter must be the last parameter in the URL. If any additional query string parameters are included after `ims=`, the request may return a **504** error.
 
-Example of a **valid** URL: https://example.com/image.jpeg?ts=1234&ims=1000x1000
+Example of a **valid** URL: *example.com/image.jpeg?ts=1234&ims=1000x1000*
 
-Example of an **invalid** URL (causes error 504): https://example.com/image.jpeg?ims=1000x1000&ts=1234
+Example of an **invalid** URL (causes error 504): *example.com/image.jpeg?ims=1000x1000&ts=1234*
 :::
 
 6. Edit the remaining settings as required and click the **Save** button.


### PR DESCRIPTION
docs: format example URLs in Image Processor guide for clarity