### PR TITLE
fix: update Azion Brand Guidelines URL in affiliate agreements

### DIFF
--- a/src/content/docs/en/pages/agreements/affiliate-program/2025-10-03-index.mdx
+++ b/src/content/docs/en/pages/agreements/affiliate-program/2025-10-03-index.mdx
@@ -73,7 +73,7 @@ In connection with Affiliate's participation in the Program, Affiliate expressly
 
               3.1.2.7. Misrepresent the characteristics or qualification requirements for any Commission. The Affiliate acknowledges that Azion may change the characteristics or qualification requirements for Commissions at its discretion, and therefore, the Affiliate must not represent fixed characteristics.
 
-    3.1.3. **Prohibited content**. The Affiliate agrees to comply with the [Azion Brand Guidelines](https://www.azion.design/). Affiliate agrees that it will not use the Affiliate Link in connection with:
+    3.1.3. **Prohibited content**. The Affiliate agrees to comply with the [Azion Brand Guidelines](https://www.azion.com/en/). Affiliate agrees that it will not use the Affiliate Link in connection with:
 
          3.1.3.1. Derogatory or defamatory content about Azion or third parties;
 

--- a/src/content/docs/pt-br/pages/contratos/affiliate-terms/2025-10-03.mdx
+++ b/src/content/docs/pt-br/pages/contratos/affiliate-terms/2025-10-03.mdx
@@ -73,7 +73,7 @@ Em conexão com a participação do Affiliate no Programa, o Affiliate concorda 
 
               3.1.2.7. Deturpar as características ou requisitos de qualificação para qualquer Comissão. O Affiliate reconhece que a Azion pode alterar as características ou requisitos de qualificação para Comissões a seu critério e, portanto, o Affiliate não deve representar características fixas.
 
-      3.1.3. **Conteúdo proibido**. O Affiliate concorda em cumprir as [Diretrizes de Marca da Azion](https://www.azion.design/). O Affiliate concorda que não usará o Link de Affiliate em conexão com:
+      3.1.3. **Conteúdo proibido**. O Affiliate concorda em cumprir as [Diretrizes de Marca da Azion](https://www.azion.com/pt-br/). O Affiliate concorda que não usará o Link de Affiliate em conexão com:
 
                3.1.3.1. Conteúdo depreciativo ou difamatório sobre a Azion ou terceiros;
 


### PR DESCRIPTION
### Related issue
[NO-ISSUE]

### Changes

Updated the Azion Brand Guidelines URL in the affiliate program agreements for both English and Portuguese (Brazil) versions:

- **English version** (`src/content/docs/en/pages/agreements/affiliate-program/2025-10-03-index.mdx`): Changed URL from `https://www.azion.design/` to `https://www.azion.com/en/`
- **Portuguese version** (`src/content/docs/pt-br/pages/contratos/affiliate-terms/2025-10-03.mdx`): Changed URL from `https://www.azion.design/` to `https://www.azion.com/pt-br/`

These changes ensure that affiliates are directed to the correct, localized Brand Guidelines pages.

### Test Plan

N/A - Link URL updates are straightforward changes that can be verified by checking the updated documentation files.

https://claude.ai/code/session_012ZegTuovnvVjpVvpf4MyMm