### PR TITLE
refactor: enhance documentation for JSON return and Nextal template

### DIFF
--- a/src/content/docs/en/pages/devtools/azion-edge-runtime/javascript-examples/return-json/return-json.mdx
+++ b/src/content/docs/en/pages/devtools/azion-edge-runtime/javascript-examples/return-json/return-json.mdx
@@ -12,7 +12,7 @@ namespace: documentation_products_edge_functions_javascript_examples_return_json
 menu_namespace: runtimeMenu
 ---
 
-Return a JSON payload directly from a function. Use this pattern to build lightweight APIs or middleware that respond on Azion's global network, serving structured data to clients without forwarding the request to an origin.
+Return a JSON payload directly from a function. Use this pattern to build lightweight APIs or middleware that respond on Azion's global network, serving structured data to clients without forwarding the request to an origin. It's a common building block for API mocks, feature flags, configuration endpoints, and health checks, where you need a fast, predictable, structured response without standing up a dedicated backend service.
 
 ```js
   addEventListener("fetch", event => {
@@ -34,7 +34,7 @@ Return a JSON payload directly from a function. Use this pattern to build lightw
 
 ## How it works
 
-When the `fetch` event fires, the handler defines a plain JavaScript object and serializes it with `JSON.stringify(data, null, 2)`, where the `2` adds indentation so the output is easy to read. It then creates a new `Response` with that string as the body and sets the `content-type` header to `application/json;charset=UTF-8`, signaling to clients that the payload is JSON. Finally, `event.respondWith()` returns the response, delivering the data with low latency and without contacting an origin.
+When the `fetch` event fires, the handler defines a plain JavaScript object and serializes it with `JSON.stringify(data, null, 2)`, where the `2` adds indentation so the output is easy to read. It then creates a new `Response` with that string as the body and sets the `content-type` header to `application/json;charset=UTF-8`, signaling to clients that the payload is JSON. Finally, `event.respondWith()` returns the response, delivering the data with low latency and without contacting an origin. You can extend this pattern by setting a custom status code, adding CORS or cache-control headers, or building the object dynamically from request data such as query string parameters, cookies, or headers, all while keeping the response close to your users. Because the function runs on Azion's distributed network, the same logic scales automatically to absorb traffic spikes without any additional configuration or server management.
 
 ## Related resources
 

--- a/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/compatibilidade/frameworks/template-showcase/nextjs/nextal.mdx
+++ b/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/compatibilidade/frameworks/template-showcase/nextjs/nextal.mdx
@@ -29,7 +29,7 @@ import Container from 'azion-webkit/container';
 
 ## Sobre este template
 
-O Nextal é um starter opinativo para [Next.js](/pt-br/documentacao/produtos/devtools/azion-edge-runtime/compatibilidade-frameworks/nextjs/), o popular framework React para aplicações web de nível profissional. Ele reúne testes com Vitest, estilização com Tailwind CSS e Hero Icons, além de uma estrutura de pastas em Atomic Design e imports absolutos, oferecendo uma base limpa e escalável. Implantada na Azion, a aplicação SSR é servida por meio de uma arquitetura distribuída para respostas de baixa latência em todo o mundo.
+O Nextal é um starter opinativo para [Next.js](/pt-br/documentacao/produtos/devtools/azion-edge-runtime/compatibilidade-frameworks/nextjs/), o popular framework React para aplicações web de nível profissional. Ele reúne testes com Vitest, estilização com Tailwind CSS e Hero Icons, além de uma estrutura de pastas em Atomic Design e imports absolutos, oferecendo uma base limpa e escalável. Implantada na Azion, a aplicação SSR é servida por meio de uma arquitetura distribuída para respostas de baixa latência em todo o mundo. Por já incluir testes, estilização e uma estrutura de projeto organizada, o Nextal elimina grande parte da configuração repetitiva de um novo projeto Next.js, permitindo que as equipes se concentrem na lógica de negócio desde o primeiro commit. É uma escolha sólida para sites institucionais, dashboards e aplicações React que precisam de renderização no servidor com bom desempenho global.
 
 ## Principais recursos
 


### PR DESCRIPTION
### Related issue
[NO-ISSUE]

### Changes

Enhanced documentation clarity and completeness across two pages:

1. **Return JSON example** (`return-json.mdx`):
   - Expanded the introductory description to include common use cases (API mocks, feature flags, configuration endpoints, health checks)
   - Extended the "How it works" section with practical extension patterns (custom status codes, CORS/cache-control headers, dynamic object building from request data)
   - Added context about Azion's distributed network benefits for automatic scaling

2. **Nextal template documentation** (`nextal.mdx`):
   - Expanded the template overview to explain the value proposition: eliminates repetitive configuration and allows teams to focus on business logic
   - Added guidance on ideal use cases (institutional websites, dashboards, server-rendered React applications requiring global performance)

### Additional context

These changes improve developer understanding by providing more concrete examples of when and how to use these patterns, making the documentation more actionable for users building on Azion's Edge Runtime.

https://claude.ai/code/session_01HtHGoPapiWZh9em1BA417Z