### PR TITLE
refactor: remove bucket-as-origin guide references

### DIFF
--- a/src/content/docs/pt-br/pages/guias/akamai-to-azion/akamai-to-azion-comprehensive-guide.mdx
+++ b/src/content/docs/pt-br/pages/guias/akamai-to-azion/akamai-to-azion-comprehensive-guide.mdx
@@ -638,7 +638,6 @@ Use o endpoint S3 para operações de gerenciamento de objetos. Para entrega a u
 * [Como acessar o Object Storage usando o protocolo S3](https://www.azion.com/pt-br/documentacao/produtos/store/storage/s3-protocol-para-object-storage/)
 * [Como criar e modificar um bucket](https://www.azion.com/pt-br/documentacao/produtos/guias/criar-e-modificar-um-bucket/)
 * [Como fazer upload e download de objetos](https://www.azion.com/pt-br/documentacao/produtos/guias/upload-e-download-de-objetos-do-bucket/)
-* [Como usar um bucket como origem](https://www.azion.com/pt-br/documentacao/produtos/guias/usar-bucket-como-origem/)
 
 ### 2. Migrando EdgeKV para KV Store
 

--- a/src/content/docs/pt-br/pages/guias/edge-storage/bucket-actions/index.mdx
+++ b/src/content/docs/pt-br/pages/guias/edge-storage/bucket-actions/index.mdx
@@ -28,7 +28,7 @@ A interface gráfica é ideal para uploads rápidos e configurações iniciais.
 
 3. **Faça o Upload:** Entre no bucket criado e arraste seus arquivos diretamente para a interface ou use o botão de upload.
 
-Pronto! Seus arquivos agora estão na infraestrutura global da Azion. O próximo passo é [configurar um Workload para entregar esse conteúdo com performance de Edge](https://www.azion.com/pt-br/documentacao/produtos/guias/usar-bucket-como-origem/).
+Pronto! Seus arquivos agora estão na infraestrutura global da Azion.
 
 
 ---

--- a/src/content/docs/pt-br/pages/guias/guides.mdx
+++ b/src/content/docs/pt-br/pages/guias/guides.mdx
@@ -256,7 +256,6 @@ permalink: /documentacao/produtos/guias/
 
 - [Como criar e modificar um bucket do Object Storage](/pt-br/documentacao/produtos/guias/criar-e-modificar-um-bucket/)
 - [Como fazer o upload e download de objetos de um bucket do Object Storage](/pt-br/documentacao/produtos/guias/upload-e-download-de-objetos-do-bucket/)
-- [Como usar um bucket do Object Storage como origem de uma application estática](/pt-br/documentacao/produtos/guias/usar-bucket-como-origem/)
 - [Como acessar o Object Storage usando o protocolo S3](/pt-br/documentacao/produtos/store/storage/s3-protocol-para-object-storage/)
 
 ### Workloads

--- a/src/content/docs/pt-br/pages/menu-principal/referencia/store/edge-storage/index.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/referencia/store/edge-storage/index.mdx
@@ -71,7 +71,6 @@ Para gerenciar objetos (upload, delete, operações de listagem), continue usand
 | --- | --- |
 | Criar e modificar um bucket | [Como criar e modificar um bucket do Object Storage](/pt-br/documentacao/produtos/guias/criar-e-modificar-um-bucket/) |
 | Upload e download de objetos | [Como fazer o upload e download de objetos de um bucket do Object Storage](/pt-br/documentacao/produtos/guias/upload-e-download-de-objetos-do-bucket/) |
-| Usar bucket como origem | [Como usar um bucket do Object Storage como origem de uma application estática](/pt-br/documentacao/produtos/guias/usar-bucket-como-origem/) |
 | Configurar o protocolo S3 | [Como acessar um bucket do Object Storage usando o protocolo S3](/pt-br/documentacao/produtos/store/storage/s3-protocol-para-object-storage/) |
 | Runtime API | [Object Storage API](/pt-br/documentacao/runtime/api-reference/storage/) |
 

--- a/src/content/docs/pt-br/pages/menu-principal/release-notes/release-notes.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/release-notes/release-notes.mdx
@@ -1588,7 +1588,6 @@ Veja mais detalhes na [documentação de referência de Edge Storage](/pt-br/doc
 
 - [Como criar e modificar um bucket do Edge Storage](/pt-br/documentacao/produtos/guias/criar-e-modificar-um-bucket/)
 - [Como fazer o upload e download de objetos de um bucket do Edge Storage](/pt-br/documentacao/produtos/guias/upload-e-download-de-objetos-do-bucket/)
-- [Como usar um bucket do Edge Storage como origem de uma edge application estática](/pt-br/documentacao/produtos/guias/usar-bucket-como-origem/)
 
 ---
 


### PR DESCRIPTION
### Related issue
[NO-ISSUE]

### Changes

Removed references to the "Como usar um bucket como origem" (How to use a bucket as origin) guide across multiple documentation files:

- Removed the call-to-action link from the bucket actions guide introduction
- Removed the guide link from the Akamai-to-Azion migration guide
- Removed the guide entry from the main guides index
- Removed the guide entry from the Edge Storage reference documentation
- Removed the guide entry from the release notes

This appears to be a cleanup of deprecated or consolidated documentation content related to using Object Storage buckets as origins for static applications.

### Additional links

None

https://claude.ai/code/session_01NCNC5zXJ6b4heiWMDV5LQK