### PR TITLE
fix: update Object Storage bucket origin documentation URL

### DIFF
--- a/src/content/docs/pt-br/pages/guias/aws-to-azion/aws-to-azion-comprehensive-guide.mdx
+++ b/src/content/docs/pt-br/pages/guias/aws-to-azion/aws-to-azion-comprehensive-guide.mdx
@@ -2093,7 +2093,7 @@ Connectors são criados via `/v4/workspace/connectors`. Use `type: "object_stora
 * [Como acessar Object Storage usando protocolo S3](https://www.azion.com/pt-br/documentacao/produtos/store/storage/s3-protocol-para-object-storage/)
 * [Crie e modifique um bucket](https://www.azion.com/pt-br/documentacao/produtos/guias/criar-e-modificar-um-bucket/)
 * [Faça upload e download de objetos](https://www.azion.com/pt-br/documentacao/produtos/guias/upload-e-download-de-objetos-do-bucket/)
-* [Use um bucket como origem](https://www.azion.com/pt-br/documentacao/produtos/store/storage/usar-bucket-como-origin/)
+* [Use um bucket como origem](https://www.azion.com/pt-br/documentacao/produtos/store/storage/bucket-como-connector/)
 * [Referência da biblioteca Storage](https://www.azion.com/pt-br/documentacao/produtos/azion-lib/storage/)
 
 ### 2. Migrando DynamoDB para KV Store / SQL Database

--- a/src/content/docs/pt-br/pages/guias/cloudflare-to-azion/cf-to-azion-comprehensive-guide.mdx
+++ b/src/content/docs/pt-br/pages/guias/cloudflare-to-azion/cf-to-azion-comprehensive-guide.mdx
@@ -1465,7 +1465,7 @@ Migre dados usando ferramentas familiares como s3cmd, rclone ou AWS CLI. Antes d
 * [Como acessar Object Storage usando o protocolo S3](https://www.azion.com/pt-br/documentacao/produtos/store/storage/s3-protocol-para-object-storage/)
 * [Crie e modifique um bucket](https://www.azion.com/pt-br/documentacao/produtos/guias/criar-e-modificar-um-bucket/)
 * [Faça upload e download de objetos](https://www.azion.com/pt-br/documentacao/produtos/guias/upload-e-download-de-objetos-do-bucket/)
-* [Use um bucket como origem](https://www.azion.com/pt-br/documentacao/produtos/store/storage/usar-bucket-como-origin/)
+* [Use um bucket como origem](https://www.azion.com/pt-br/documentacao/produtos/store/storage/bucket-como-connector/)
 * [Referência da biblioteca Storage](https://www.azion.com/pt-br/documentacao/produtos/azion-lib/storage/)
 
 ### 3. Migrando D1 com SQL Database

--- a/src/content/docs/pt-br/pages/guias/fastly-to-azion/fastly-to-azion-comprehensive-guide.mdx
+++ b/src/content/docs/pt-br/pages/guias/fastly-to-azion/fastly-to-azion-comprehensive-guide.mdx
@@ -1199,7 +1199,7 @@ Use o endpoint S3 para operações de gerenciamento de objetos. Para entrega a u
 * [Como acessar Object Storage usando o protocolo S3](https://www.azion.com/pt-br/documentacao/produtos/store/storage/s3-protocol-para-object-storage/)
 * [Crie e modifique um bucket](https://www.azion.com/pt-br/documentacao/produtos/guias/criar-e-modificar-um-bucket/)
 * [Upload e download de objetos](https://www.azion.com/pt-br/documentacao/produtos/guias/upload-e-download-de-objetos-do-bucket/)
-* [Use um bucket como origem](https://www.azion.com/pt-br/documentacao/produtos/store/storage/usar-bucket-como-origin/)
+* [Use um bucket como origem](https://www.azion.com/pt-br/documentacao/produtos/store/storage/bucket-como-connector/)
 
 ### 2. Migrando Edge Data Storage para KV Store
 

--- a/src/i18n/pt-br/storeMenu.ts
+++ b/src/i18n/pt-br/storeMenu.ts
@@ -119,7 +119,7 @@ export default [
 				header: true,
 				anchor: true,
 				type: 'learn',
-				slug: '/documentacao/produtos/store/storage/usar-bucket-como-origin/',
+				slug: '/documentacao/produtos/store/storage/bucket-como-connector/',
 				key: 'useBucketAsOrigin',
 			},
 		],


### PR DESCRIPTION
### Related issue
[NO-ISSUE]

### Changes

Updated the documentation URL for "Use um bucket como origem" (Use a bucket as origin) across multiple migration guide pages and the store menu configuration.

**Files modified:**
- `src/content/docs/pt-br/pages/guias/aws-to-azion/aws-to-azion-comprehensive-guide.mdx`
- `src/content/docs/pt-br/pages/guias/cloudflare-to-azion/cf-to-azion-comprehensive-guide.mdx`
- `src/content/docs/pt-br/pages/guias/fastly-to-azion/fastly-to-azion-comprehensive-guide.mdx`
- `src/i18n/pt-br/storeMenu.ts`

**URL change:**
- Old: `/documentacao/produtos/store/storage/usar-bucket-como-origin/`
- New: `/documentacao/produtos/store/storage/bucket-como-connector/`

This change reflects the updated documentation structure for Object Storage bucket configuration as a connector/origin.

### Test Plan
N/A - Link updates only. Verify that the new URL paths exist in the documentation and that all four locations have been consistently updated.

https://claude.ai/code/session_01382qppW1tLcetzwjZLAqCH