### PR TITLE
docs: update Azion Plans terms

### DIFF
--- a/src/content/docs/en/pages/agreements/azion-plans/azion-plans.mdx
+++ b/src/content/docs/en/pages/agreements/azion-plans/azion-plans.mdx
@@ -1,5 +1,5 @@
 ---
-title: Azion Plans Terms and Conditions
+title: Terms and Conditions of Azion Plans
 description: Terms and Conditions related to the Azion Plans
 meta_tags: Terms and Conditions of the Azion Plans, Azion 
 namespace: docs_agreements_terms_and_conditions_azion_plan
@@ -8,7 +8,7 @@ permalink: /documentation/agreements/azion-plans-terms-and-conditions/
 
 Azion Plans is one of the available methods for contracting Azion Products and Services, subject to the terms of the [Customer Agreement](https://www.azion.com/en/documentation/agreements/customer-agreement/) and other related documents. Under this model, the Customer acquires a set of Products and Services with distinct features and limits, according to the selection made at the time of purchase.
 
-**1. Subscription Format**
+## 1. Subscription Format
 
 1.1. The Products and Services provided as part of Azion Plans are subscription-based, for the period specified during the initial sign-up process or at first use—monthly or annually (“Subscription Period”).
 
@@ -16,19 +16,21 @@ Azion Plans is one of the available methods for contracting Azion Products and S
 
 1.3. The features and usage volumes included in each plan are described on Azion Website, and such description is incorporated into these Terms for all legal purposes.
 
-**2. Free Plan**
+## 2. Hobby Plan
 
-2.1. Azion may offer a free plan (“Free Plan”) intended for personal, experimental, or non-commercial use, unless expressly authorized otherwise. The Free Plan will be available at no cost until any of the following occur: (a) the Customer subscribes to a paid plan (“Paid Plan”); (b) the Customer begins using Products and Services under the On Demand model; or (c) the Free Plan is discontinued by Azion. The purchase of paid Products and Services (“Paid Add-ons”) does not, by itself, revoke the Customer’s status under the Free Plan.
+2.1. Azion may offer a free Hobby plan (“Free Plan”) intended for personal, experimental, or non-commercial use, unless expressly authorized otherwise. The Free Plan will be available at no cost until any of the following occur: (a) the Customer subscribes to a paid plan (“Paid Plan”); (b) the Customer begins using Products and Services under the On Demand model; or (c) the Free Plan is discontinued by Azion. The purchase of paid Products and Services (“Paid Add-ons”) does not, by itself, revoke the Customer’s status under the Free Plan.
 
 2.2. Azion may, at its sole discretion, modify, suspend, or terminate the Free Plan, as well as disable the Customer’s account, workspaces, workloads, or related resources, with or without prior notice. Azion is not liable for any loss or damage resulting from the use of the Free Plan, including suspension or deletion of data.
 
-**3. Pricing and Payment**
+## 3. Pricing and Payment
 
 3.1. The Paid Plan is billed on a recurring and prepaid basis to the credit card or other valid payment method registered by the Customer (“Payment Method”), until it is canceled. Any Payment Method provided must be valid and kept up to date by the Customer throughout the Subscription Period. By providing a Payment Method to Azion, the Customer represents and warrants that they are authorized to use it.
 
 3.2. To access Paid Add-ons, the Customer authorizes Azion to charge the Payment Method monthly, annually, on demand, or as applicable, for the amount associated with the contracted Paid Add-ons. Charges will begin on the Paid Add-on subscription date, regardless of usage or whether it is fully configured. For usage-based Paid Add-ons, Azion may perform a pre-authorization hold on the Payment Method at any time during the billing cycle, which will be automatically removed upon expiration.
 
-**4. Plan Changes**
+3.3. Any usage exceeding the features or usage volumes included in a Paid Plan may be charged according to the applicable On Demand prices published on Azion Website.
+
+## 4. Plan Changes
 
 4.1. The Customer may voluntarily switch to a different plan at any time, with a pro-rated charge according to the migration date.
 
@@ -36,7 +38,7 @@ Azion Plans is one of the available methods for contracting Azion Products and S
     
      4.1.2. Downgrade: becomes effective in the next billing cycle.
 
-**5. Cancellation and Termination**
+## 5. Cancellation and Termination
 
 5.1. The Customer may cancel automatic renewal of the Azion Plan at any time. After cancellation, the Customer will continue to have access to the Products and Services included in the Paid Plan until the end of the Subscription Period, with no right to any refund.
 
@@ -44,15 +46,15 @@ Azion Plans is one of the available methods for contracting Azion Products and S
 
 5.3. Azion may, at its sole discretion, terminate any offered plans, with or without notice, for any reason. For Paid Plans, Customer access and configurations will remain available until the end of the Subscription Period.
 
-**6. Price Changes**
+## 6. Price Changes
 
 6.1. The price of each Azion Plan may be changed at any time, at Azion’s discretion, and new prices will take effect from the next Subscription Period.
 
-**7. Updates to These Terms**
+## 7. Updates to These Terms
 
 7.1. Azion may modify these Terms or the characteristics of Azion Plans by publishing a revised version on Azion Website, with or without prior notice. Continued use implies acceptance of the new terms.
 
-**8. General Provisions**
+## 8. General Provisions
 
 8.1. AZION RESERVES THE RIGHT TO MONITOR, AT ANY TIME, THE CUSTOMER’S CONSUMPTION UNDER THE SELECTED PLAN AND MAY, AT ITS SOLE DISCRETION, LIMIT, SUSPEND, OR DISABLE ACCESS TO AND/OR USAGE OF ANY PRODUCT OR SERVICE, IN WHOLE OR IN PART, IF IT IDENTIFIES OR HAS REASONABLE INDICATIONS THAT THE CUSTOMER’S USAGE IS NOT IN COMPLIANCE WITH THE LIMITS, PURPOSES, OR CONDITIONS ESTABLISHED FOR THE SELECTED PLAN. THIS MEASURE MAY BE TAKEN WITH OR WITHOUT PRIOR NOTICE, ESPECIALLY IN CASES WHERE SUCH USAGE COULD AFFECT THE STABILITY, SECURITY, OR PERFORMANCE OF THE AZION PLATFORM OR OTHER CUSTOMERS.
 

--- a/src/content/docs/pt-br/pages/contratos/azion-plans/azion-plans.mdx
+++ b/src/content/docs/pt-br/pages/contratos/azion-plans/azion-plans.mdx
@@ -8,7 +8,7 @@ permalink: /documentacao/contratos/termos-e-condicoes-azion-plan/
 
 O Azion Plans é uma das formas de contratação de Produtos e Serviços da Azion, sujeito aos termos do [Contrato de Cliente](https://www.azion.com/pt-br/documentacao/contratos/contrato-de-cliente/) e demais documentos vinculados. Neste formato, o Cliente adquire um conjunto de Produtos e Serviços com funcionalidades e limites distintos, de acordo com a sua escolha no momento da contratação.
 
-**1. Formato de Contratação**
+## 1. Formato de Contratação
 
 1.1. Os Produtos e Serviços fornecidos como parte do Azion Plans são contratados por assinatura, pelo período especificado durante o processo de inscrição inicial ou no primeiro uso – mensal ou anual (“Período de Assinatura”).
 
@@ -16,19 +16,21 @@ O Azion Plans é uma das formas de contratação de Produtos e Serviços da Azio
 
 1.3. As funcionalidades e os volumes incluídos em cada plano estão descritos no Site Azion, e a sua descrição integra estes Termos para todos os efeitos.
 
-**2. Free Plan**
+## 2. Plano Hobby
 
-2.1. A Azion poderá oferecer um plano gratuito (“Free Plan”), destinado a uso pessoal, experimental ou não comercial, salvo autorização expressa em contrário. O Free Plan será disponibilizado sem custos até que ocorra: (a) a contratação de um plano pago (“Paid Plan”); (b) o início da utilização dos Produtos e Serviços no modelo On Demand; ou (c) a descontinuação do Free Plan pela Azion. A contratação de Produtos e Serviços pagos (“Paid Add-ons”) não descaracteriza, por si só, a permanência no Free Plan.
+2.1. A Azion poderá oferecer um plano Hobby gratuito (“Free Plan”), destinado a uso pessoal, experimental ou não comercial, salvo autorização expressa em contrário. O Free Plan será disponibilizado sem custos até que ocorra: (a) a contratação de um plano pago (“Paid Plan”); (b) o início da utilização dos Produtos e Serviços no modelo On Demand; ou (c) a descontinuação do Free Plan pela Azion. A contratação de Produtos e Serviços pagos (“Paid Add-ons”) não descaracteriza, por si só, a permanência no Free Plan.
 
 2.2. A Azion poderá, a seu exclusivo critério, alterar, suspender ou encerrar o Free Plan, bem como desabilitar a conta do Cliente, workspaces, workloads ou recursos associados, com ou sem aviso prévio. A Azion não se responsabiliza por quaisquer perdas ou danos decorrentes do uso do Free Plan, incluindo a suspensão ou remoção de dados.
 
-**3. Preços e Pagamento**
+## 3. Preços e Pagamento
 
 3.1. O valor do Paid Plan é cobrado de forma recorrente e antecipada no cartão de crédito ou outro meio de pagamento válido cadastrado pelo Cliente ("Método de Pagamento"), até o seu cancelamento. Qualquer Método de Pagamento fornecido deve ser válido e mantido atualizado pelo Cliente durante o Período de Assinatura. Ao fornecer um Método de Pagamento à Azion, o Cliente declara e garante que está autorizado a utilizá-lo.
 
 3.2. Para acessar os Paid Add-ons, o Cliente autoriza a Azion a cobrar o Método de Pagamento de forma mensal, anual, sob demanda ou conforme aplicável, pelos valores associados aos Paid Add-ons contratados. A cobrança terá início na data da assinatura do Paid Add-on, independentemente de seu uso ou de sua configuração completa. Para Paid Add-ons sujeitos à cobrança com base no uso, a Azion poderá realizar uma pré-autorização no Método de Pagamento a qualquer momento durante o período de faturamento, a qual será removida automaticamente quando expirada.
 
-**4. Alteração de Plano**
+3.3. Qualquer uso que exceda as funcionalidades ou volumes de uso incluídos em um Paid Plan poderá ser cobrado de acordo com os preços On Demand aplicáveis publicados no Site Azion.
+
+## 4. Alteração de Plano
 
  4.1. A qualquer momento, o Cliente poderá migrar voluntariamente para outro plano, com nova cobrança proporcional conforme a data de migração.
     
@@ -36,7 +38,7 @@ O Azion Plans é uma das formas de contratação de Produtos e Serviços da Azio
     
       4.1.2. Downgrade: efetivo no ciclo de cobrança subsequente.
 
-**5. Cancelamento e Rescisão**
+## 5. Cancelamento e Rescisão
 
 5.1. O Cliente pode cancelar a renovação automática do Azion Plan a qualquer momento. Após o cancelamento, o Cliente continuará a ter acesso aos Produtos e Serviços inclusos no Paid Plan até o final do seu Período de Assinatura, sem direito a qualquer reembolso.
 
@@ -44,15 +46,15 @@ O Azion Plans é uma das formas de contratação de Produtos e Serviços da Azio
 
 5.3. A Azion poderá, a seu exclusivo critério, encerrar quaisquer dos planos oferecidos, com ou sem aviso prévio, por qualquer motivo. Para os Paid Plans, serão mantidos o acesso e as configurações do Cliente até o final do Período de Assinatura.
 
-**6. Alterações de Preços**
+## 6. Alterações de Preços
 
 6.1. O preço de cada Azion Plan pode ser alterado a qualquer momento, a critério da Azion, e a aplicação do novo preço acontecerá a partir do próximo Período de Assinatura.
 
-**7. Atualização destes Termos**
+## 7. Atualização destes Termos
 
 7.1. A Azion pode alterar estes Termos ou as características dos Azion Plans, publicando a versão revisada no Site Azion, com ou sem notificação prévia. O uso continuado implica na aceitação das novas condições.
 
-**8. Disposições Gerais**
+## 8. Disposições Gerais
 
 8.1. A AZION SE RESERVA O DIREITO DE MONITORAR, A QUALQUER MOMENTO, O CONSUMO DO PLANO CONTRATADO PELO CLIENTE E PODERÁ, A SEU EXCLUSIVO CRITÉRIO, LIMITAR, SUSPENDER OU DESABILITAR O ACESSO E/OU O USO DE QUALQUER PRODUTO OU SERVIÇO, DE FORMA TOTAL OU PARCIAL, CASO IDENTIFIQUE OU TENHA INDÍCIOS RAZOÁVEIS DE QUE O USO PELO CLIENTE ESTEJA EM DESACORDO COM OS LIMITES, PROPÓSITOS OU CONDIÇÕES ESTABELECIDOS PARA O PLANO CONTRATADO. ESSA MEDIDA PODERÁ SER ADOTADA COM OU SEM AVISO PRÉVIO, ESPECIALMENTE NOS CASOS EM QUE O USO POSSA COMPROMETER A ESTABILIDADE, A SEGURANÇA OU O DESEMPENHO DA PLATAFORMA AZION, OU DE OUTROS CLIENTES.
 


### PR DESCRIPTION
## Summary
- Update Azion Plans terms in English and Portuguese
- Align section headings with Markdown heading syntax
- Clarify Hobby as the free plan and add overage billing clause

## Tests
- Not run (content-only changes).