### PR TITLE
Normalize duplicate slashes in docs URLs

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -22,7 +22,7 @@ import SystemStatus from 'azion-webkit/systemstatus';
 import SelectLang from 'azion-webkit/selectlang';
 import ThemeSwitcher from 'azion-webkit/dropdownthemeswitcher';
 
-import { getLanguageFromURL, normalizePathSlashes, removeLeadingSlash } from '~/util';
+import { getLanguageFromURL, normalizeCanonicalPath, removeLeadingSlash } from '~/util';
 // import { getPageCategory } from '~/util/getPageCategory';
 import { getTranslatedPagesByNamespace } from '~/util/getPageTranslations';
 import { getHeaderMenuStrings, getFooterMenuStrings } from '~/i18n/translations';
@@ -79,9 +79,8 @@ const formatTitle = (content: { title?: string }) => {
     ? `${content.title.trim()} - ${t('site.title')}`
     : t('site.title');
 };
-// Ensures the canonicalURL uses collapsed slashes and always has a trailing slash.
-const normalizedPathname = normalizePathSlashes(Astro.url.pathname);
-const canonicalURL = new URL(normalizedPathname.replace(/([^/])$/, '$1/'), Astro.site);
+// Ensures canonical URLs collapse repeated slashes and always keep a single trailing slash.
+const canonicalURL = new URL(normalizeCanonicalPath(Astro.url.pathname), Astro.site);
 if (isFallback) canonicalURL.pathname = canonicalURL.pathname.replace(`/${lang}/`, '/en/');
 
 const translatedPages = await (async (c) => {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,9 +1,11 @@
 import { defineMiddleware } from 'astro/middleware';
 
-import { normalizePathSlashes } from '~/util';
+import { normalizeCanonicalPath, normalizePathSlashes } from '~/util';
 
 export const onRequest = defineMiddleware((context, next) => {
-	const normalizedPathname = normalizePathSlashes(context.url.pathname);
+	const normalizedPathname = context.url.pathname.endsWith('//')
+		? normalizeCanonicalPath(context.url.pathname)
+		: normalizePathSlashes(context.url.pathname);
 
 	if (normalizedPathname !== context.url.pathname) {
 		const redirectURL = new URL(context.url);

--- a/src/util.ts
+++ b/src/util.ts
@@ -23,6 +23,11 @@ export function normalizePathSlashes(path: string | undefined) {
 	return `${path}`
 }
 
+/** Collapse repeated slashes and ensure documentation URLs keep one trailing slash. */
+export function normalizeCanonicalPath(path: string | undefined) {
+	return normalizePathSlashes(path).replace(/([^/])$/, '$1/')
+}
+
 /** Get a page’s slug, without the language prefix (e.g. `'en/migrate'` => `'migrate'`). */
 export const stripLangFromSlug = (slug: CollectionEntry<'docs'>['slug']) => slug.split('/').slice(1).join('/');
 


### PR DESCRIPTION
### Motivation
- Ensure documentation pages requested with duplicated slashes normalize or redirect to a canonical path with a single trailing slash.
- Provide a single shared normalizer for canonical URLs so `HeadSEO` and layouts generate consistent alternate/canonical links.

### Description
- Added `normalizeCanonicalPath(path)` to `src/util.ts` to collapse repeated slashes and enforce a single trailing slash using the existing `normalizePathSlashes` helper.
- Updated `src/layouts/BaseLayout.astro` to build `canonicalURL` from `normalizeCanonicalPath(Astro.url.pathname)` instead of the previous inline replace logic.
- Updated `src/middleware.ts` to detect paths ending in `//` and perform a permanent redirect to the normalized pathname (preserving `search`), otherwise collapse duplicate slashes with `normalizePathSlashes`.
- Left `src/components/HeadSEO.astro` generation unchanged so alternates continue to be produced from normalized permalinks.

### Testing
- Ran the normalization unit/validation script with `npx tsx -e 'import { normalizeCanonicalPath, normalizePathSlashes } from "./src/util.ts"; ...'` which passed the provided URL cases.
- Started the local dev server and validated redirects with `curl -I` against the PT-BR examples, confirming `301` responses and `Location` values pointing to single-trailing-slash canonical URLs (requests with duplicate slashes now redirect to the single-slash path).
- `npx prettier -w ...` failed locally due to the environment unable to resolve the `astro` parser, unrelated to the functional change.
- `npm run check` reports pre-existing TypeScript/Astro diagnostics across the repo unrelated to these changes (these errors existed prior to this PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27319d509c832f96ffec80dc9fba46)