### PR TITLE
docs: replace edge terminology in platform overview

### DIFF
--- a/src/content/docs/en/pages/main-menu/get-started/azion-platform-overview.mdx
+++ b/src/content/docs/en/pages/main-menu/get-started/azion-platform-overview.mdx
@@ -3,7 +3,7 @@ title: "Azion Web Platform Overview"
 description: >-
   This documentation introduces the Azion Web Platform, which unifies app development, security, and observability on a global infrastructure so you can ship faster with performance and control.
 meta_tags: >-
-  Azion, application, Azion Web Platform, edge-native platform, developer platform, application platform, modern application platform, global web platform, serverless platform, serverless computing, serverless functions, functions, application development, application security, API security, web application firewall, WAF, DDoS protection, DDoS mitigation
+  Azion, application, Azion Web Platform, developer platform, application platform, modern application platform, global web platform, serverless platform, serverless computing, serverless functions, functions, application development, application security, API security, web application firewall, WAF, DDoS protection, DDoS mitigation
 namespace: documentation_azion_platform_overview
 permalink: /documentation/products/azion-platform-overview/
 ---
@@ -28,8 +28,8 @@ Use Azion to:
 
 ## Core Concepts
 
-### Distributed computing (and where “edge” fits)
-Azion runs workloads across multiple locations worldwide to reduce latency and improve reliability. This approach is often associated with **edge computing**, where compute and data are placed closer to where they’re needed.
+### Distributed computing
+Azion runs workloads across multiple locations worldwide to reduce latency and improve reliability. This approach places compute and data closer to where they're needed—near your users on a global network of points of presence.
 
 ### Platform characteristics
 A platform designed for distributed workloads should provide:
@@ -88,7 +88,7 @@ Manage **Azion Web Platform** via UI, APIs, and automation tools:
 - [Azion API](https://api.azion.com/): REST API over HTTPS for integration and automation
 - [Azion Terraform Provider](/en/documentation/products/terraform-provider/): manage Azion resources as code
 
-Tip: For fundamentals on distributed architectures, watch the [Introduction to Edge Foundations](https://www.youtube.com/watch?v=ZBC8h-0l1FQ&list=PL02NW2s3y10N0SQ-2mWL9WN-RWHE8atMp) playlist.
+Tip: For fundamentals on distributed architectures, watch the [Introduction to Platform Foundations](https://www.youtube.com/watch?v=ZBC8h-0l1FQ&list=PL02NW2s3y10N0SQ-2mWL9WN-RWHE8atMp) playlist.
 
 ## FAQ 
 ### What is Azion Web Platform?

--- a/src/content/docs/pt-br/pages/menu-principal/ponto-de-partida/visao-geral-da-azion.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/ponto-de-partida/visao-geral-da-azion.mdx
@@ -1,7 +1,7 @@
 ---
 title: Visão geral da Azion Web Platform
 description: >-
-  Esta documentação apresenta a Azion Web Platform e conceitos-chave para ajudar a entender melhor a edge computing.
+  Esta documentação apresenta a Azion Web Platform e conceitos-chave para ajudar a entender melhor a arquitetura distribuída.
 meta_tags: 'Azion, application, jornada, onboarding, templates, domínios, tráfego'
 namespace: documentation_azion_platform_overview
 permalink: /documentacao/produtos/visao-geral-da-plataforma-da-azion/
@@ -17,16 +17,16 @@ A Azion é a plataforma web líder que permite que empresas construam, protejam 
 
 ## Conceitos básicos
 
-### O que é edge computing?
+### O que é arquitetura distribuída?
 
-**Edge computing** é um paradigma de computação altamente distribuída que visa aproximar a computação e o armazenamento de dados do local onde é necessário, normalmente perto do edge, ou borda, da rede.
+**Arquitetura distribuída** é um paradigma de computação altamente distribuída que visa aproximar a computação e o armazenamento de dados do local onde é necessário, normalmente próximo aos usuários, em pontos de presença globais.
 
 Esse paradigma permite a construção e o gerenciamento de [aplicações modernas](/pt-br/documentacao/produtos/guias/build/criar-uma-aplicacao/), capazes de atender à crescente demanda por processamento em tempo real, latência reduzida, melhor privacidade de dados e a capacidade de lidar com a enorme quantidade de dados gerados hoje em dia.
 
 
-## O que é uma plataforma nativa de edge?
+## O que é uma plataforma com arquitetura distribuída?
 
-Uma **plataforma nativa de edge** deve ser projetada para operar de forma eficiente direitamente no edge de uma rede. A plataforma deve possuir várias características e funcionalidades importantes para atender aos desafios e requisitos exclusivos que demanda a edge computing:
+Uma **plataforma com arquitetura distribuída** deve ser projetada para operar de forma eficiente em uma rede global de pontos de presença. A plataforma deve possuir várias características e funcionalidades importantes para atender aos desafios e requisitos exclusivos que demanda a computação distribuída:
 
 - Experiência superior para desenvolvimento de aplicações, segurança, orquestração e observabilidade.
 - NoOps e uma abordagem de autoatendimento.
@@ -47,17 +47,17 @@ A plataforma da Azion funciona, em alto nível, da seguinte forma:
 
 ![Gráfico sobre como a Azion funciona](/assets/docs/images/uploads/request_flow.png)
 
-1. Uma requisição é enviada para um serviço web em execução na **Azion Web Platform**. A plataforma define, usando roteamento definido por software, o melhor caminho para a requisição e a redireciona para a edge location *mais próxima*.
-- Neste contexto, *mais próxima* refere-se ao **edge node** que pode atender a requisição do usuário mais rapidamente, com base em uma variedade de fatores, como localização geográfica, condições de rede, carga do servidor, entre outros.
-2. Dentro do **edge node**, a requisição é processada por vários módulos funcionais antes de enviar de volta uma resposta apropriada ao usuário. Isso ocorre para aplicar toda a lógica de negócios, configurações e parâmetros adequados à requisição. Através dos [produtos Azion](/pt-br/documentacao/), os clientes podem implementar, controlar, monitorar, dimensionar e automatizar recursos no edge, em tempo real.
-- A requisição é redirecionada para a origem apenas no caso de o edge node não ter uma resposta apropriada.
+1. Uma requisição é enviada para um serviço web em execução na **Azion Web Platform**. A plataforma define, usando roteamento definido por software, o melhor caminho para a requisição e a redireciona para o data center *mais próximo*.
+- Neste contexto, *mais próximo* refere-se ao **ponto de presença** que pode atender a requisição do usuário mais rapidamente, com base em uma variedade de fatores, como localização geográfica, condições de rede, carga do servidor, entre outros.
+2. Dentro do **ponto de presença**, a requisição é processada por vários módulos funcionais antes de enviar de volta uma resposta apropriada ao usuário. Isso ocorre para aplicar toda a lógica de negócios, configurações e parâmetros adequados à requisição. Através dos [produtos Azion](/pt-br/documentacao/), os clientes podem implementar, controlar, monitorar, dimensionar e automatizar recursos na plataforma, em tempo real.
+- A requisição é redirecionada para a origem apenas no caso de o ponto de presença não ter uma resposta apropriada.
 3. A resposta é enviada para o usuário ou dispositivo.
 
 ---
 
 ## O quê você pode fazer com a Azion?
 
-A Azion fornece diferentes produtos e módulos baseados em edge computing, agrupados em categorias principais que refletem cada etapa no processo de criação e gerenciamento de applications:
+A Azion fornece diferentes produtos e módulos baseados em arquitetura distribuída, agrupados em categorias principais que refletem cada etapa no processo de criação e gerenciamento de applications:
 
 - [Build](/pt-br/documentacao/produtos/guias/build/visao-geral/)
 - [Store](/pt-br/documentacao/produtos/store/visao-geral/)
@@ -67,7 +67,7 @@ A Azion fornece diferentes produtos e módulos baseados em edge computing, agrup
 
 Isto inclui poder completar tarefas como:
 
-- Criação e implantação de [aplicações](/pt-br/documentacao/produtos/build/applications/) que são executadas diretamente no edge da rede.
+- Criação e implantação de [aplicações](/pt-br/documentacao/produtos/build/applications/) que são executadas diretamente na rede global.
 - Uso de [templates e integrações](/pt-br/documentacao/produtos/marketplace/visao-geral-templates-e-integracoes/) para acelerar seu desenvolvimento e testar soluções pré-construídas.
 - Criação de [arquiteturas zero trust](/pt-br/documentacao/arquiteturas/) para proteger seu conteúdo e aplicações.
 - Melhora da entrega de conteúdo confiando em uma [rede altamente distribuída](https://www.azion.com/pt-br/produtos/nossa-rede/).
@@ -75,14 +75,14 @@ Isto inclui poder completar tarefas como:
 - Monitoramento de applications com [dados em tempo real](/pt-br/documentacao/produtos/observe/real-time-metrics/).
 - Melhora no [desempenho](/pt-br/documentacao/arquiteturas/edge-application/content-delivery/), com menor latência e uso de largura de banda, ao mesmo tempo em que reduz os custos operacionais.
 - Desenvolvimento com diferentes [frameworks e linguagens suportadas](/pt-br/documentacao/produtos/build/develop-with-azion/frameworks-specific/visao-geral/).
-- [Migração de sua arquitetura e conteúdo](/pt-br/documentacao/produtos/migrar-para-a-azion/) para o edge.
+- [Migração de sua arquitetura e conteúdo](/pt-br/documentacao/produtos/migrar-para-a-azion/) para a plataforma da Azion.
 - Cumprimentos das [leis de conformidade](https://www.azion.com/pt-br/compliance/).
 
 ---
 
 ## Gestão da plataforma
 
-A Azion desenvolveu um painel de controle e um conjunto de APIs usadas pelos clientes e pela equipe da Azion para gerenciar a **Azion Web Platform**. Isso é executado no edge e aproveita uma arquitetura de microsserviços e uma estrutura de front-end proprietária, garantindo segurança e alta disponibilidade.
+A Azion desenvolveu um painel de controle e um conjunto de APIs usadas pelos clientes e pela equipe da Azion para gerenciar a **Azion Web Platform**. Isso é executado na plataforma e aproveita uma arquitetura de microsserviços e uma estrutura de front-end proprietária, garantindo segurança e alta disponibilidade.
 
 Você pode acessá-lo e obter uma experiência de usuário simples e rápida através de:
 
@@ -92,5 +92,5 @@ Você pode acessá-lo e obter uma experiência de usuário simples e rápida atr
 - [Azion Terraform Provider](/pt-br/documentacao/produtos/terraform-provider/): o Terraform se comunica com as APIs da Azion, para que você possa gerenciar sua infraestrutura hospedada na plataforma da Azion, localmente, como código.
 
 :::tip[dica]
-Para obter mais detalhes sobre os fundamentos da edge computing e da Azion Web Platform, assista essa playlist com os [fundamentos do edge](https://www.youtube.com/watch?v=7OihCEBhqDQ&list=PL02NW2s3y10NCJ2LrrDyeFPUFB6VD4ywh).
+Para obter mais detalhes sobre os fundamentos da arquitetura distribuída e da Azion Web Platform, assista essa playlist com os [fundamentos da plataforma](https://www.youtube.com/watch?v=7OihCEBhqDQ&list=PL02NW2s3y10NCJ2LrrDyeFPUFB6VD4ywh).
 :::


### PR DESCRIPTION
Update the Azion platform overview documentation in both English and Portuguese to use "distributed architecture" terminology instead of "edge computing" references. Changes include updating headings, descriptions, meta tags, and in-text references to align with current terminology guidelines.

<!--
Thank you for contributing to Azion Docs! Please fill out the information below.
Use the conventional commits standard to categorize the type of change in the PR title. We recommend:
- feat: adding new content
- refactor: making minor changes
- fix: fixing errors

Don't forget to add the Jira issue code to the PR title or the GitHub issue hash.
For example: 
- [EDU-3000] refactor: modify origins page to include load balancer
- [#34] feat: add new application CLI commands
- [NO-ISSUE] fix: fix broken link in Orch doc
-->

NO-ISSUE] fix: Update the Azion platform overview documentation in both English and Portuguese to use "distributed architecture" terminology instead of "edge computing" references. Changes include updating headings, descriptions, meta tags, and in-text references to align with current terminology guidelines.


[EDU-3000]: https://aziontech.atlassian.net/browse/EDU-3000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ