### PR TITLE
docs(storage): update s3 endpoint to include region in url

### DIFF
--- a/src/content/docs/en/pages/guides/cloudflare-to-azion/cf-to-azion-comprehensive-guide.mdx
+++ b/src/content/docs/en/pages/guides/cloudflare-to-azion/cf-to-azion-comprehensive-guide.mdx
@@ -1731,7 +1731,7 @@ Data Stream supports 10+ destinations:
 | **Redirects not working** | Verify regex patterns are correct; check Rules Engine criteria syntax |
 | **Functions return errors** | Update function signature to `fetch(request)`; verify `Azion.env.get()` for variables |
 | **KV data missing** | Re-export from Cloudflare; verify import completed without errors |
-| **Object Storage access denied** | Check S3 credentials are correct; verify endpoint is `s3.azionstorage.net` |
+| **Object Storage access denied** | Check S3 credentials are correct; verify endpoint is `s3.us-east-005.azionstorage.net` |
 | **Database queries fail** | Confirm schema imported correctly; verify `new Database('name')` syntax |
 | **DNS not resolving** | Check CNAME or nameserver configuration; allow time for propagation |
 | **Certificate not active** | Verify domain ownership; check certificate provisioning status |

--- a/src/content/docs/en/pages/store-journey/storage/use-s3.mdx
+++ b/src/content/docs/en/pages/store-journey/storage/use-s3.mdx
@@ -90,9 +90,9 @@ To use s3cmd to manage your Object Storage bucket, follow these steps:
 1. Download and install s3cmd package through the [official website](https://s3tools.org/download).
 2. Make sure `s3cmd` is added to your system's PATH.
 3. Run `s3cmd --configure` and enter the access key and secret key.
-4. Enter the default region for the Object Storage region: `us-east`.
-5. Enter the endpoint URL for Object Storage: `s3.azionstorage.net`.
-6. Use the default DNS template: `%(bucket).s3.azionstorage.net`.
+4. Enter the default region for the Object Storage region: `us-east-005`.
+5. Enter the endpoint URL for Object Storage: `s3.us-east-005.azionstorage.net`.
+6. Use the default DNS template: `%(bucket).s3.us-east-005.azionstorage.net`.
 7. Inform an encryption password and a path to GPG program if needed.
 
 :::note

--- a/src/content/docs/pt-br/pages/guias/cloudflare-to-azion/cf-to-azion-comprehensive-guide.mdx
+++ b/src/content/docs/pt-br/pages/guias/cloudflare-to-azion/cf-to-azion-comprehensive-guide.mdx
@@ -1731,7 +1731,7 @@ Data Stream suporta mais de 10 destinos:
 | **Redirecionamentos não funcionam** | Verifique se padrões regex estão corretos; verifique sintaxe de critérios do Rules Engine |
 | **Functions retornam erros** | Atualize assinatura da função para `fetch(request)`; verifique `Azion.env.get()` para variáveis |
 | **Dados KV ausentes** | Re-exporte da Cloudflare; verifique se importação completou sem erros |
-| **Acesso negado ao Object Storage** | Verifique se credenciais S3 estão corretas; verifique se endpoint é `s3.azionstorage.net` |
+| **Acesso negado ao Object Storage** | Verifique se credenciais S3 estão corretas; verifique se endpoint é `s3.us-east-005.azionstorage.net` |
 | **Consultas de banco de dados falham** | Confirme se schema foi importado corretamente; verifique sintaxe `new Database('name')` |
 | **DNS não resolve** | Verifique configuração CNAME ou nameserver; permita tempo para propagação |
 | **Certificado não ativo** | Verifique propriedade do domínio; verifique status de provisionamento do certificado |

--- a/src/content/docs/pt-br/pages/store-jornada/storage/usar-s3.mdx
+++ b/src/content/docs/pt-br/pages/store-jornada/storage/usar-s3.mdx
@@ -89,9 +89,9 @@ Para usar o s3cmd para gerenciar seu bucket do Object Storage, siga estes passos
 1. Baixe e instale o pacote s3cmd através do [site oficial](https://s3tools.org/download).
 2. Certifique-se de que `s3cmd` está adicionado ao PATH do seu sistema.
 3. Execute `s3cmd --configure` e insira a `access_key` e a `secret_key`.
-4. Insira a região padrão para a região do Object Storage: `us-east`.
-5. Insira a URL do endpoint para o Object Storage: `s3.azionstorage.net`.
-6. Use o template DNS padrão: `%(bucket).s3.azionstorage.net`.
+4. Insira a região padrão para a região do Object Storage: `us-east-005`.
+5. Insira a URL do endpoint para o Object Storage: `s3.us-east-005.azionstorage.net`.
+6. Use o template DNS padrão: `%(bucket).s3.us-east-005.azionstorage.net`.
 7. Informe uma senha de criptografia e um caminho para o programa GPG se necessário.
 
 :::note


### PR DESCRIPTION
Update Object Storage S3 endpoint configuration from s3.azionstorage.net to s3.us-east-005.azionstorage.net and region from us-east to us-east-005 across English and Portuguese documentation for s3cmd setup and troubleshooting guides.

<!--
Thank you for contributing to Azion Docs! Please fill out the information below.
Use the conventional commits standard to categorize the type of change in the PR title. We recommend:
- feat: adding new content
- refactor: making minor changes
- fix: fixing errors

Don't forget to add the Jira issue code to the PR title or the GitHub issue hash.
For example: 
- [EDU-3000] refactor: modify origins page to include load balancer
- [#34] feat: add new application CLI commands
- [NO-ISSUE] fix: fix broken link in Orch doc
-->

### Related issue: EDU-6896- Update Object Storage S3 endpoint configuration from s3.azionstorage.net to s3.us-east-005.azionstorage.net and region from us-east to us-east-005 across English and Portuguese documentation for s3cmd setup and troubleshooting guides.



[EDU-3000]: https://aziontech.atlassian.net/browse/EDU-3000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ