### PR TITLE
docs(s3): add capability-to-operation mapping table

### DIFF
--- a/src/content/docs/en/pages/main-menu/reference/store/object-storage/index.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/store/object-storage/index.mdx
@@ -430,7 +430,8 @@ The following table maps each S3 capability to its associated operations:
 | `listBuckets` | HeadBucket, ListMultipartUploads, ListParts |
 
 :::note
-The `deleteFiles` capability requires `writeFiles` to be enabled. Multipart upload operations (CreateMultipartUpload, UploadPart, CompleteMultipartUpload, AbortMultipartUpload, ListParts, ListMultipartUploads) are all associated with `writeFiles` capability, as they're part of the upload process for large files.
+* The `deleteFiles` capability requires `writeFiles` to be enabled.
+* Multipart upload operations (CreateMultipartUpload, UploadPart, CompleteMultipartUpload, AbortMultipartUpload, ListParts, ListMultipartUploads) are all associated with `writeFiles` capability, as they're part of the upload process for large files.
 :::
 
 ---

--- a/src/content/docs/en/pages/main-menu/reference/store/object-storage/index.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/store/object-storage/index.mdx
@@ -403,7 +403,7 @@ To [create a S3 credential](/en/documentation/products/store/storage/s3-protocol
 
 Once a credential is created, an *access key* and a *secret key* are generated, which can be used to set up access to the bucket through the S3 protocol. For security reasons, the *secret key* won't be available after the credential is created. Existing credentials can't be modified in any way.
 
-Once a user's access is verified, they're allowed to make operations depending on the capabilities and permissions set for the credential. 
+Once a user's access is verified, they're allowed to make operations depending on the capabilities and permissions set for the credential.
 
 #### Capabilities
 
@@ -415,6 +415,23 @@ You can assign the following capabilities to S3 credentials:
 - `deleteFiles`: equivalent to [DeleteObject](#deleteobject), allows object deletion through the object key.
 - `listAllBucketNames`: equivalent to [ListBuckets](#listbuckets), allows you to list all buckets associated with the account.
 - `listBuckets`: if enabled, returns the proper `404 Not Found` response when attempting to retrieve files that aren't in the bucket using the credential.
+
+#### Capability-to-operation mapping
+
+The following table maps each S3 capability to its associated operations:
+
+| Capability | S3 operations |
+|------------|---------------|
+| `listFiles` | ListObjects, ListObjectsV2 |
+| `readFiles` | GetObject, HeadObject |
+| `writeFiles` | PutObject, CreateMultipartUpload, UploadPart, CompleteMultipartUpload, CopyObject |
+| `deleteFiles` | DeleteObject, DeleteObjects, AbortMultipartUpload |
+| `listAllBucketNames` | ListBuckets |
+| `listBuckets` | HeadBucket, ListMultipartUploads, ListParts |
+
+:::note
+The `deleteFiles` capability requires `writeFiles` to be enabled. Multipart upload operations (CreateMultipartUpload, UploadPart, CompleteMultipartUpload, AbortMultipartUpload, ListParts, ListMultipartUploads) are all associated with `writeFiles` capability, as they're part of the upload process for large files.
+:::
 
 ---
 

--- a/src/content/docs/pt-br/pages/menu-principal/referencia/store/edge-storage/index.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/referencia/store/edge-storage/index.mdx
@@ -438,7 +438,8 @@ A tabela a seguir mapeia cada capability S3 para suas operações associadas:
 | `listBuckets` | HeadBucket, ListMultipartUploads, ListParts |
 
 :::note
-A capability `deleteFiles` requer que `writeFiles` esteja habilitada. As operações de multipart upload (CreateMultipartUpload, UploadPart, CompleteMultipartUpload, AbortMultipartUpload, ListParts, ListMultipartUploads) estão todas associadas à capability `writeFiles`, pois fazem parte do processo de upload de arquivos grandes.
+* A capability `deleteFiles` requer que `writeFiles` esteja habilitada.
+* As operações de multipart upload (CreateMultipartUpload, UploadPart, CompleteMultipartUpload, AbortMultipartUpload, ListParts, ListMultipartUploads) estão todas associadas à capability `writeFiles`, pois fazem parte do processo de upload de arquivos grandes.
 :::
 
 ---

--- a/src/content/docs/pt-br/pages/menu-principal/referencia/store/edge-storage/index.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/referencia/store/edge-storage/index.mdx
@@ -424,6 +424,23 @@ Você pode atribuir as seguintes capabilities às credenciais S3:
 - `listAllBucketNames`: equivalente a [ListBuckets](#listbuckets), permite que você liste todos os buckets associados à conta.
 - `listBuckets`: se habilitado, retorna a resposta de status `404 Not Found` correta ao tentar recuperar arquivos que não estão no bucket usando a credencial.
 
+#### Mapeamento de capability para operação
+
+A tabela a seguir mapeia cada capability S3 para suas operações associadas:
+
+| Capability | Operações S3 |
+|------------|--------------|
+| `listFiles` | ListObjects, ListObjectsV2 |
+| `readFiles` | GetObject, HeadObject |
+| `writeFiles` | PutObject, CreateMultipartUpload, UploadPart, CompleteMultipartUpload, CopyObject |
+| `deleteFiles` | DeleteObject, DeleteObjects, AbortMultipartUpload |
+| `listAllBucketNames` | ListBuckets |
+| `listBuckets` | HeadBucket, ListMultipartUploads, ListParts |
+
+:::note
+A capability `deleteFiles` requer que `writeFiles` esteja habilitada. As operações de multipart upload (CreateMultipartUpload, UploadPart, CompleteMultipartUpload, AbortMultipartUpload, ListParts, ListMultipartUploads) estão todas associadas à capability `writeFiles`, pois fazem parte do processo de upload de arquivos grandes.
+:::
+
 ---
 
 ## Compatibilidade com protocolo S3


### PR DESCRIPTION
Add a reference table documenting how each S3 capability maps to specific S3 operations. Includes notes on capability dependencies (deleteFiles requires writeFiles) and multipart upload operation associations.

Updates both English and Portuguese-Brazilian documentation for the object-storage/edge-storage reference pages.

<!--
Thank you for contributing to Azion Docs! Please fill out the information below.
Use the conventional commits standard to categorize the type of change in the PR title. We recommend:
- feat: adding new content
- refactor: making minor changes
- fix: fixing errors

Don't forget to add the Jira issue code to the PR title or the GitHub issue hash.
For example: 
- [EDU-3000] refactor: modify origins page to include load balancer
- [#34] feat: add new application CLI commands
- [NO-ISSUE] fix: fix broken link in Orch doc
-->

### Related issue: EDU-4553 s3-doc-update
Add a reference table documenting how each S3 capability maps to specific S3 operations. Includes notes on capability dependencies (deleteFiles requires writeFiles) and multipart upload operation associations.

[EDU-3000]: https://aziontech.atlassian.net/browse/EDU-3000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ