### PR TITLE
docs: add Brotli compression note and expand DDoS mitigation list

### DIFF
--- a/src/content/docs/en/pages/guides/edge-application/ea-enable-gzip.mdx
+++ b/src/content/docs/en/pages/guides/edge-application/ea-enable-gzip.mdx
@@ -10,6 +10,10 @@ permalink: /documentation/products/guides/gzip-compression/
 
 Gzip is the standard method for lossless file compression for web applications. By using the Deflate algorithm to reduce the size of files before they're sent to browsers, gzip compression ensures faster page rendering and downloads for your users.
 
+:::note
+**Brotli compression** is also available for Applications. Brotli typically achieves better compression ratios than gzip, resulting in smaller file sizes and faster delivery. To enable Brotli compression for your application, contact [Azion Support](https://www.azion.com/en/documentation/services/support/).
+:::
+
 When you enable gzip compression for Azion **Applications**, the following events take place during a request for content from your application:
 
 1. At the edge node, Azion verifies the cache for a compressed version of the file.

--- a/src/content/docs/en/pages/main-menu/reference/secure/edge-firewall/ddos-protection/ddos-mitigation.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/secure/edge-firewall/ddos-protection/ddos-mitigation.mdx
@@ -48,8 +48,11 @@ This is a **non-exhaustive list** of some DDoS attacks that can be mitigated by 
 * MALFORMED ICMP Flood (Ping of death)
 * MIXED Floods (TCP+UDP, ICMP+UDP, etc.)
 * Nuke
+* NTP Amplification
 * OWASP top 10
 * Reflected ICMP / UDP
+* SSDP Amplification
+* CLDAP Amplification
 * Slowloris
 * Smurf
 * Spoofing

--- a/src/content/docs/en/pages/main-menu/reference/secure/edge-firewall/ddos-protection/ddos-mitigation.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/secure/edge-firewall/ddos-protection/ddos-mitigation.mdx
@@ -36,6 +36,7 @@ This is a **non-exhaustive list** of some DDoS attacks that can be mitigated by 
 * Bogons
 * Botnet attacks
 * Brute force attacks
+* CLDAP Amplification
 * Connection flood attacks
 * DNS flood (including well-formed DNS Queries)
 * HTTP floods (including HTTP well-formed POST / GET URL requests)
@@ -52,7 +53,6 @@ This is a **non-exhaustive list** of some DDoS attacks that can be mitigated by 
 * OWASP top 10
 * Reflected ICMP / UDP
 * SSDP Amplification
-* CLDAP Amplification
 * Slowloris
 * Smurf
 * Spoofing

--- a/src/content/docs/pt-br/pages/guias/edge-application/ea-enable-gzip.mdx
+++ b/src/content/docs/pt-br/pages/guias/edge-application/ea-enable-gzip.mdx
@@ -10,6 +10,10 @@ permalink: /documentacao/produtos/guias/gzip-compression/
 
 Gzip é o método padrão de compressão *lossless* de arquivos para aplicações web. Por usar o algoritmo Deflate para reduzir o tamanho de arquivos antes de serem enviados a navegadores, a compressão gzip proporciona renderização de página e downloads mais rápidos para seus usuários.
 
+:::note
+A **compressão Brotli** também está disponível para Applications. O Brotli geralmente alcança melhores taxas de compressão que o gzip, resultando em arquivos menores e entregas mais rápidas. Para habilitar a compressão Brotli para sua aplicação, entre em contato com o [Suporte Azion](https://www.azion.com/pt-br/documentacao/servicos/suporte/).
+:::
+
 Ao habilitar a compressão gzip para Azion **Applications**, os seguintes eventos acontecem durante uma requisição por conteúdo de sua aplicação:
 
 1. No edge node, a Azion verifica o cache por uma versão comprimida do arquivo.

--- a/src/content/docs/pt-br/pages/menu-principal/referencia/secure/edge-firewall/ddos-protection/ddos-mitigation.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/referencia/secure/edge-firewall/ddos-protection/ddos-mitigation.mdx
@@ -48,8 +48,11 @@ Esta é uma **lista não exaustiva** de alguns ataques DDoS que podem ser mitiga
 * MALFORMED ICMP Flood (Ping of death)
 * MIXED Floods (TCP+UDP, ICMP+UDP, etc.)
 * Nuke
+* NTP Amplification
 * OWASP top 10
 * Reflected ICMP / UDP
+* SSDP Amplification
+* CLDAP Amplification
 * Slowloris
 * Smurf
 * Spoofing

--- a/src/content/docs/pt-br/pages/menu-principal/referencia/secure/edge-firewall/ddos-protection/ddos-mitigation.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/referencia/secure/edge-firewall/ddos-protection/ddos-mitigation.mdx
@@ -36,6 +36,7 @@ Esta é uma **lista não exaustiva** de alguns ataques DDoS que podem ser mitiga
 * Bogons
 * Botnet attacks
 * Brute force attacks
+* CLDAP Amplification
 * Connection flood attacks
 * DNS flood (including well formed DNS Queries)
 * HTTP floods (including HTTP well formed POST / GET URL requests)
@@ -52,7 +53,6 @@ Esta é uma **lista não exaustiva** de alguns ataques DDoS que podem ser mitiga
 * OWASP top 10
 * Reflected ICMP / UDP
 * SSDP Amplification
-* CLDAP Amplification
 * Slowloris
 * Smurf
 * Spoofing


### PR DESCRIPTION
- Add note about Brotli compression availability in gzip guides (EN/PT-BR)
- Add NTP, SSDP, and CLDAP amplification attacks to DDoS mitigation documentation (EN/PT-BR)

<!--
Thank you for contributing to Azion Docs! Please fill out the information below.
Use the conventional commits standard to categorize the type of change in the PR title. We recommend:
- feat: adding new content
- refactor: making minor changes
- fix: fixing errors

Don't forget to add the Jira issue code to the PR title or the GitHub issue hash.
For example: 
- [EDU-3000] refactor: modify origins page to include load balancer
- [#34] feat: add new application CLI commands
- [NO-ISSUE] fix: fix broken link in Orch doc
-->

### Related issue: MM-15683

Note: This issue was transitioned from MM-15682 to MM-15683, but the branch was created using the previous number.
Documentation updates. The following changes were made:

## DDoS Mitigation Documentation

Added three new attack types to the mitigated attacks list in both languages:

**Files modified:**
- [`ddos-mitigation.mdx`](src/content/docs/en/pages/main-menu/reference/secure/edge-firewall/ddos-protection/ddos-mitigation.mdx:51) (EN)
- [`ddos-mitigation.mdx`](src/content/docs/pt-br/pages/menu-principal/referencia/secure/edge-firewall/ddos-protection/ddos-mitigation.mdx:51) (PT-BR)

**New entries added:**
- NTP Amplification
- SSDP Amplification
- CLDAP Amplification

These amplification/reflection attacks were positioned logically near the existing "Reflected ICMP / UDP" entry, maintaining alphabetical ordering.

## Compression Documentation

Added Brotli compression availability notes to the gzip compression guides in both languages:

**Files modified:**
- [`ea-enable-gzip.mdx`](src/content/docs/en/pages/guides/edge-application/ea-enable-gzip.mdx:13) (EN)
- [`ea-enable-gzip.mdx`](src/content/docs/pt-br/pages/guias/edge-application/ea-enable-gzip.mdx:13) (PT-BR)

**Content added:**
A note block informing users that Brotli compression is available for Applications upon request via Azion Support, with a link to the Support documentation page.

All changes follow the Azion brand voice guidelines: direct, technical, and solution-focused.


[EDU-3000]: https://aziontech.atlassian.net/browse/EDU-3000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ