### PR TITLE
docs(waf): add API documentation for WAF Exceptions and update termin…

### DIFF
--- a/src/content/docs/en/pages/main-menu/reference/secure/edge-firewall/web-application-firewall/custom-allowed-rule.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/secure/edge-firewall/web-application-firewall/custom-allowed-rule.mdx
@@ -1,16 +1,20 @@
 ---
-title: WAF Custom Allowed Rules
+title: WAF Exceptions
 description: >-
-  Optimize the security of your application with Custom Allowed Rules for
-  WAF.
-meta_tags: 'waf, security, edge computing'
+  Optimize the security of your application with Exceptions for
+  WAF. Create, manage, and automate exception rules via API or Console.
+meta_tags: 'waf, security, edge computing, exceptions, api'
 namespace: >-
   documentation_products_edge_firewall_web_application_firewall_custom_allowed_rules
 permalink: >-
   /documentation/products/secure/firewall/web-application-firewall/custom-allowed-rules/
 ---
 
-**Web Application Firewall (WAF) Custom Allowed Rules** are configurations that explicitly allow certain request patterns to bypass blocking, overriding the standard WAF security rules that would otherwise identify these requests as potentially malicious. They operate at a high level, analyzing specific components of HTTP requests, such as parameters (ARGS), request body contents (BODY), or the URL path (URL). Each rule is defined with a unique identifier, a match string, and an application zone, ensuring that the security filter remains effective while minimizing blocks on requests containing characteristics considered necessary or legitimate by the user, thus reducing false positives.
+**Web Application Firewall (WAF) Exceptions** are configurations that explicitly allow certain request patterns to bypass blocking, overriding the standard WAF security rules that would otherwise identify these requests as potentially malicious. They operate at a high level, analyzing specific components of HTTP requests, such as parameters (ARGS), request body contents (BODY), or the URL path (URL). Each exception is defined with a unique identifier, a match string, and an application zone, ensuring that the security filter remains effective while minimizing blocks on requests containing characteristics considered necessary or legitimate by the user, thus reducing false positives.
+
+:::note
+Exceptions were previously referred to as **Allowed Rules** in the Console interface. The API now uses the **Exceptions** terminology. Both terms refer to the same functionality.
+:::
 
 ## Prerequisites
 
@@ -162,6 +166,160 @@ See the list of all available internal rules below:
 | 1311    | Possible XSS attack: close square bracket `]` found in `Body`, `Path`, `Query String` or `Cookies`.                                        |
 | 1312    | Possible XSS attack: tilde character `~` found in `Body`, `Path`, `Query String`, or `Cookies`.                                            |
 | 1314    | Possible XSS attack: `` ` `` (*backtick*) found in `Body`, `Path`, `Query String`, or `Cookies`.                                    |
+
+---
+
+## Managing Exceptions via API
+
+You can manage WAF Exceptions programmatically using the Azion API. This enables you to automate the creation, update, and deletion of exceptions, integrate WAF calibration into CI/CD pipelines, and build custom tools for managing your security posture.
+
+### API endpoints
+
+The Exceptions API provides the following operations:
+
+| Operation | Endpoint | Description |
+|-----------|----------|-------------|
+| List | `GET /v4/edge_firewall/wafs/{waf_id}/exceptions` | List all exceptions for a WAF Rule Set |
+| Create | `POST /v4/edge_firewall/wafs/{waf_id}/exceptions` | Create a new exception |
+| Retrieve | `GET /v4/edge_firewall/wafs/{waf_id}/exceptions/{exception_id}` | Get details of a specific exception |
+| Update | `PUT /v4/edge_firewall/wafs/{waf_id}/exceptions/{exception_id}` | Update an existing exception |
+| Partial update | `PATCH /v4/edge_firewall/wafs/{waf_id}/exceptions/{exception_id}` | Update specific fields of an exception |
+| Delete | `DELETE /v4/edge_firewall/wafs/{waf_id}/exceptions/{exception_id}` | Delete an exception |
+
+For complete API specifications, refer to the [Azion API reference](https://api.azion.com/v4#/operations/list_waf_exceptions).
+
+### Listing exceptions
+
+To retrieve all exceptions configured for a WAF Rule Set:
+
+```bash
+curl --request GET \
+  --url https://api.azion.com/v4/edge_firewall/wafs/{waf_id}/exceptions \
+  --header 'Accept: application/json' \
+  --header 'Authorization: Token [TOKEN VALUE]'
+```
+
+Response example:
+
+```json
+{
+  "count": 2,
+  "results": [
+    {
+      "id": 1234,
+      "rule_id": 1000,
+      "reason": "Allow legitimate API traffic",
+      "match_zone": "query_string",
+      "match_pattern": "^[a-zA-Z0-9]+$",
+      "path": "/api/v1/data",
+      "active": true
+    },
+    {
+      "id": 5678,
+      "rule_id": 1302,
+      "reason": "Allow HTML in specific endpoint",
+      "match_zone": "body",
+      "match_pattern": "<script>",
+      "path": "/api/v1/render",
+      "active": true
+    }
+  ]
+}
+```
+
+### Creating an exception
+
+To create a new exception for a WAF Rule Set:
+
+```bash
+curl --request POST \
+  --url https://api.azion.com/v4/edge_firewall/wafs/{waf_id}/exceptions \
+  --header 'Accept: application/json' \
+  --header 'Authorization: Token [TOKEN VALUE]' \
+  --header 'Content-Type: application/json' \
+  --data '{
+    "rule_id": 1000,
+    "reason": "Allow legitimate API traffic with SQL-like patterns",
+    "match_zone": "query_string",
+    "match_pattern": "^[a-zA-Z0-9\\s]+$",
+    "path": "/api/v1/search",
+    "active": true
+  }'
+```
+
+### Retrieving a specific exception
+
+To get details of a specific exception:
+
+```bash
+curl --request GET \
+  --url https://api.azion.com/v4/edge_firewall/wafs/{waf_id}/exceptions/{exception_id} \
+  --header 'Accept: application/json' \
+  --header 'Authorization: Token [TOKEN VALUE]'
+```
+
+### Updating an exception
+
+To update all fields of an existing exception:
+
+```bash
+curl --request PUT \
+  --url https://api.azion.com/v4/edge_firewall/wafs/{waf_id}/exceptions/{exception_id} \
+  --header 'Accept: application/json' \
+  --header 'Authorization: Token [TOKEN VALUE]' \
+  --header 'Content-Type: application/json' \
+  --data '{
+    "rule_id": 1000,
+    "reason": "Updated reason for the exception",
+    "match_zone": "query_string",
+    "match_pattern": "^[a-zA-Z0-9\\s\\-]+$",
+    "path": "/api/v1/search",
+    "active": true
+  }'
+```
+
+### Partially updating an exception
+
+To update specific fields without modifying the entire exception:
+
+```bash
+curl --request PATCH \
+  --url https://api.azion.com/v4/edge_firewall/wafs/{waf_id}/exceptions/{exception_id} \
+  --header 'Accept: application/json' \
+  --header 'Authorization: Token [TOKEN VALUE]' \
+  --header 'Content-Type: application/json' \
+  --data '{
+    "active": false,
+    "reason": "Temporarily disabled for investigation"
+  }'
+```
+
+### Deleting an exception
+
+To delete an exception:
+
+```bash
+curl --request DELETE \
+  --url https://api.azion.com/v4/edge_firewall/wafs/{waf_id}/exceptions/{exception_id} \
+  --header 'Accept: application/json' \
+  --header 'Authorization: Token [TOKEN VALUE]'
+```
+
+### Exception object fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | integer | Unique identifier of the exception (read-only) |
+| `rule_id` | integer | The WAF internal rule ID to create an exception for. See the [WAF internal rules table](#waf-internal-rules) for available IDs |
+| `reason` | string | A description explaining why this exception was created |
+| `match_zone` | string | The part of the request to match against. See [Match Zone options](/en/documentation/products/secure/firewall/web-application-firewall/#match-zone-dropdown-options) |
+| `match_pattern` | string | The pattern to match in the specified zone |
+| `path` | string | The URL path where the exception applies |
+| `active` | boolean | Whether the exception is active (`true`) or inactive (`false`) |
+
+:::tip
+Use the API to automate WAF calibration workflows. For example, you can create a script that analyzes WAF Tuning data and automatically creates exceptions for verified false positives, or integrate exception management into your CI/CD pipeline to deploy security configurations alongside your application.
+:::
 | 1400    | Possible trick to evade protection: UTF7/8 encoding `&#` found in `Body`, `Path`, `Query String` or `Cookies`.                             |
 | 1401    | Possible trick to evade protection: M$ encoding `%U` found in `Body`, `Path`, `Query String` or `Cookies`.                                 |
 | 1500    | Possible File Upload attempt: `asp/php` or `.ph`, `.asp`, `.ht` found in filename in a multipart POST containing a file.                   |

--- a/src/content/docs/en/pages/main-menu/reference/secure/edge-firewall/web-application-firewall/web-application-firewall.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/secure/edge-firewall/web-application-firewall/web-application-firewall.mdx
@@ -118,7 +118,11 @@ By clicking the **Apply filter** button, a list of **Possible Attacks** will be 
 
 ## Allowed Rules
 
-This tab allows you to create, edit, and delete *Allowed Rules*.
+This tab allows you to create, edit, and delete *Allowed Rules* (also referred to as **Exceptions** in the API).
+
+:::note
+**Exceptions** is the terminology used in the Azion API. In the Console interface, you'll see **Allowed Rules**. Both terms refer to the same functionality.
+:::
 
 The Allowed Rules are composed of the fields:
 
@@ -161,6 +165,17 @@ Options starting with **Specific** require you to provide a value in the **Name*
 :::note
 The `Last Editor` and `Last Modified` fields are only available through the [API](https://api.azion.com).
 :::
+
+### Managing Exceptions via API
+
+You can manage Allowed Rules (Exceptions) programmatically using the Azion API. This enables you to:
+
+- Automate exception creation based on WAF Tuning analysis
+- Integrate WAF calibration into CI/CD pipelines
+- Build custom tools for managing security configurations
+- Bulk update or deactivate exceptions across multiple WAF Rule Sets
+
+For complete API specifications and examples, see the [WAF Exceptions documentation](/en/documentation/products/secure/firewall/web-application-firewall/custom-allowed-rules/#managing-exceptions-via-api) and the [Azion API reference](https://api.azion.com/v4#/operations/list_waf_exceptions).
 
 ---
 

--- a/src/content/docs/pt-br/pages/menu-principal/referencia/secure/edge-firewall/web-application-firewall/waf-custom-allowed-rules.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/referencia/secure/edge-firewall/web-application-firewall/waf-custom-allowed-rules.mdx
@@ -1,15 +1,19 @@
 ---
-title: WAF Custom Allowed Rules
+title: Exceções do WAF
 description: >-
-  Otimize a segurança de suas applications com Custom Allowed Rules para
-  WAF.
+  Otimize a segurança de suas applications com Exceções para
+  WAF. Crie, gerencie e automatize regras de exceção via API ou Console.
 namespace: >-
   documentation_products_edge_firewall_web_application_firewall_custom_allowed_rules
 permalink: >-
   /documentacao/produtos/secure/firewall/web-application-firewall/custom-allowed-rules/
 ---
 
-**Web Application Firewall (WAF) Custom Allowed Rules** são configurações que explicitamente permitem certos padrões de requisições não serem bloqueados, sobrepondo a definição das regras de segurança do WAF padrão que identificariam essas requisições como potencialmente maliciosas. Operam em alto nível, analisando componentes específicos das requisições HTTP, como parâmetros (ARGS), conteúdos do corpo da requisição (BODY) ou o caminho da URL (URL). A regra é definida com um identificador único, um string de correspondência e uma zona de aplicação, assegurando que o filtro de segurança permaneça eficaz ao minimizar bloqueios de requisições que contenham características consideradas necessárias ou legítimas pelo usuário, ou seja, falsos positivos.
+**Web Application Firewall (WAF) Exceções** são configurações que explicitamente permitem que certos padrões de requisições não sejam bloqueados, sobrepondo a definição das regras de segurança do WAF padrão que identificariam essas requisições como potencialmente maliciosas. Operam em alto nível, analisando componentes específicos das requisições HTTP, como parâmetros (ARGS), conteúdos do corpo da requisição (BODY) ou o caminho da URL (URL). A exceção é definida com um identificador único, um string de correspondência e uma zona de aplicação, assegurando que o filtro de segurança permaneça eficaz ao minimizar bloqueios de requisições que contenham características consideradas necessárias ou legítimas pelo usuário, ou seja, falsos positivos.
+
+:::note
+Exceções eram anteriormente referenciadas como **Allowed Rules** na interface do Console. A API agora utiliza a terminologia **Exceptions**. Ambos os termos se referem à mesma funcionalidade.
+:::
 
 ## Pré-requisitos
 
@@ -164,6 +168,160 @@ Veja, abaixo, a lista de todas as regras internas disponíveis:
 | 1400 | Possível truque para evitar a proteção: codificação UTF7/8 `&#` encontrado no `Body`, `Path`, `Query String` ou `Cookies` |
 | 1401 | Possível truque para evitar a proteção: codificação M$ `%U` encontrada no `Body`, `Path`, `Query String` ou `Cookies` |
 | 1500 | Possible File Upload attempt: `asp/php` ou `.ph`, `.asp`, `.ht` encontrados no nome de um arquivo em um `POST` de múltiplas partes contendo um arquivo |
+
+---
+
+## Gerenciando Exceções via API
+
+Você pode gerenciar as Exceções do WAF programaticamente usando a API da Azion. Isso permite automatizar a criação, atualização e remoção de exceções, integrar a calibração do WAF em pipelines de CI/CD e construir ferramentas personalizadas para gerenciar sua postura de segurança.
+
+### Endpoints da API
+
+A API de Exceções fornece as seguintes operações:
+
+| Operação | Endpoint | Descrição |
+|----------|----------|-----------|
+| Listar | `GET /v4/edge_firewall/wafs/{waf_id}/exceptions` | Lista todas as exceções de um WAF Rule Set |
+| Criar | `POST /v4/edge_firewall/wafs/{waf_id}/exceptions` | Cria uma nova exceção |
+| Recuperar | `GET /v4/edge_firewall/wafs/{waf_id}/exceptions/{exception_id}` | Obtém detalhes de uma exceção específica |
+| Atualizar | `PUT /v4/edge_firewall/wafs/{waf_id}/exceptions/{exception_id}` | Atualiza uma exceção existente |
+| Atualização parcial | `PATCH /v4/edge_firewall/wafs/{waf_id}/exceptions/{exception_id}` | Atualiza campos específicos de uma exceção |
+| Deletar | `DELETE /v4/edge_firewall/wafs/{waf_id}/exceptions/{exception_id}` | Remove uma exceção |
+
+Para especificações completas da API, consulte a [referência da API da Azion](https://api.azion.com/v4#/operations/list_waf_exceptions).
+
+### Listando exceções
+
+Para recuperar todas as exceções configuradas para um WAF Rule Set:
+
+```bash
+curl --request GET \
+  --url https://api.azion.com/v4/edge_firewall/wafs/{waf_id}/exceptions \
+  --header 'Accept: application/json' \
+  --header 'Authorization: Token [TOKEN VALUE]'
+```
+
+Exemplo de resposta:
+
+```json
+{
+  "count": 2,
+  "results": [
+    {
+      "id": 1234,
+      "rule_id": 1000,
+      "reason": "Permitir tráfego legítimo da API",
+      "match_zone": "query_string",
+      "match_pattern": "^[a-zA-Z0-9]+$",
+      "path": "/api/v1/data",
+      "active": true
+    },
+    {
+      "id": 5678,
+      "rule_id": 1302,
+      "reason": "Permitir HTML em endpoint específico",
+      "match_zone": "body",
+      "match_pattern": "<script>",
+      "path": "/api/v1/render",
+      "active": true
+    }
+  ]
+}
+```
+
+### Criando uma exceção
+
+Para criar uma nova exceção para um WAF Rule Set:
+
+```bash
+curl --request POST \
+  --url https://api.azion.com/v4/edge_firewall/wafs/{waf_id}/exceptions \
+  --header 'Accept: application/json' \
+  --header 'Authorization: Token [TOKEN VALUE]' \
+  --header 'Content-Type: application/json' \
+  --data '{
+    "rule_id": 1000,
+    "reason": "Permitir tráfego legítimo da API com padrões similares a SQL",
+    "match_zone": "query_string",
+    "match_pattern": "^[a-zA-Z0-9\\s]+$",
+    "path": "/api/v1/search",
+    "active": true
+  }'
+```
+
+### Recuperando uma exceção específica
+
+Para obter detalhes de uma exceção específica:
+
+```bash
+curl --request GET \
+  --url https://api.azion.com/v4/edge_firewall/wafs/{waf_id}/exceptions/{exception_id} \
+  --header 'Accept: application/json' \
+  --header 'Authorization: Token [TOKEN VALUE]'
+```
+
+### Atualizando uma exceção
+
+Para atualizar todos os campos de uma exceção existente:
+
+```bash
+curl --request PUT \
+  --url https://api.azion.com/v4/edge_firewall/wafs/{waf_id}/exceptions/{exception_id} \
+  --header 'Accept: application/json' \
+  --header 'Authorization: Token [TOKEN VALUE]' \
+  --header 'Content-Type: application/json' \
+  --data '{
+    "rule_id": 1000,
+    "reason": "Motivo atualizado para a exceção",
+    "match_zone": "query_string",
+    "match_pattern": "^[a-zA-Z0-9\\s\\-]+$",
+    "path": "/api/v1/search",
+    "active": true
+  }'
+```
+
+### Atualizando parcialmente uma exceção
+
+Para atualizar campos específicos sem modificar a exceção inteira:
+
+```bash
+curl --request PATCH \
+  --url https://api.azion.com/v4/edge_firewall/wafs/{waf_id}/exceptions/{exception_id} \
+  --header 'Accept: application/json' \
+  --header 'Authorization: Token [TOKEN VALUE]' \
+  --header 'Content-Type: application/json' \
+  --data '{
+    "active": false,
+    "reason": "Temporariamente desativada para investigação"
+  }'
+```
+
+### Deletando uma exceção
+
+Para remover uma exceção:
+
+```bash
+curl --request DELETE \
+  --url https://api.azion.com/v4/edge_firewall/wafs/{waf_id}/exceptions/{exception_id} \
+  --header 'Accept: application/json' \
+  --header 'Authorization: Token [TOKEN VALUE]'
+```
+
+### Campos do objeto Exceção
+
+| Campo | Tipo | Descrição |
+|-------|------|-----------|
+| `id` | integer | Identificador único da exceção (somente leitura) |
+| `rule_id` | integer | O ID da regra interna do WAF para criar uma exceção. Veja a [tabela de regras internas do WAF](#regras-internas-do-waf) para os IDs disponíveis |
+| `reason` | string | Uma descrição explicando por que esta exceção foi criada |
+| `match_zone` | string | A parte da requisição para correspondência. Veja as [opções de Match Zone](/pt-br/documentacao/produtos/secure/firewall/web-application-firewall/#match-zone-dropdown-options) |
+| `match_pattern` | string | O padrão para correspondência na zona especificada |
+| `path` | string | O caminho da URL onde a exceção se aplica |
+| `active` | boolean | Se a exceção está ativa (`true`) ou inativa (`false`) |
+
+:::tip
+Use a API para automatizar fluxos de trabalho de calibração do WAF. Por exemplo, você pode criar um script que analisa dados do WAF Tuning e cria automaticamente exceções para falsos positivos verificados, ou integrar o gerenciamento de exceções no seu pipeline de CI/CD para implantar configurações de segurança junto com sua aplicação.
+:::
 
 
 

--- a/src/content/docs/pt-br/pages/menu-principal/referencia/secure/edge-firewall/web-application-firewall/web-application-firewall.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/referencia/secure/edge-firewall/web-application-firewall/web-application-firewall.mdx
@@ -117,7 +117,11 @@ Ao clicar no botão **Apply filter**, uma lista de **Possible Attacks** será ex
 
 ## Allowed Rules
 
-Essa aba permite a criação, edição e deleção de *Allowed Rules*.
+Essa aba permite a criação, edição e deleção de *Allowed Rules* (também referenciadas como **Exceções** na API).
+
+:::note
+**Exceções** é a terminologia utilizada na API da Azion. Na interface do Console, você verá **Allowed Rules**. Ambos os termos se referem à mesma funcionalidade.
+:::
 
 Allowed Rules são compostas pelos seguintes campos:
 
@@ -161,6 +165,16 @@ As opções que começam com **Specific** requerem que você informe um valor no
 Os campos `Last Editor` e `Last Modified` estão disponíveis apenas pela [API](https://api.azion.com).
 :::
 
+### Gerenciando Exceções via API
+
+Você pode gerenciar Allowed Rules (Exceções) programaticamente usando a API da Azion. Isso permite:
+
+- Automatizar a criação de exceções com base na análise do WAF Tuning
+- Integrar a calibração do WAF em pipelines de CI/CD
+- Construir ferramentas personalizadas para gerenciar configurações de segurança
+- Atualizar ou desativar exceções em massa em múltiplos WAF Rule Sets
+
+Para especificações completas da API e exemplos, consulte a [documentação de Exceções do WAF](/pt-br/documentacao/produtos/secure/firewall/web-application-firewall/custom-allowed-rules/#gerenciando-excecoes-via-api) e a [referência da API da Azion](https://api.azion.com/v4#/operations/list_waf_exceptions).
 
 ---
 


### PR DESCRIPTION
…ology

- Rename "Custom Allowed Rules" to "Exceptions" to align with API terminology
- Add comprehensive API documentation for managing WAF Exceptions programmatically
- Include endpoints for listing, creating, retrieving, updating, and deleting exceptions
- Add note clarifying that "Exceptions" (API) and "Allowed Rules" (Console) refer to the same functionality
- Update both English and Portuguese documentation

<!--
Thank you for contributing to Azion Docs! Please fill out the information below.
Use the conventional commits standard to categorize the type of change in the PR title. We recommend:
- feat: adding new content
- refactor: making minor changes
- fix: fixing errors

Don't forget to add the Jira issue code to the PR title or the GitHub issue hash.
For example: 
- [EDU-3000] refactor: modify origins page to include load balancer
- [#34] feat: add new application CLI commands
- [NO-ISSUE] fix: fix broken link in Orch doc
-->

### Related issue: EDU-6664
I've updated the WAF documentation to include the new Exceptions API endpoints. Here's a summary of the changes:

## Files Modified

### English Documentation

1. **[`custom-allowed-rule.mdx`](src/content/docs/en/pages/main-menu/reference/secure/edge-firewall/web-application-firewall/custom-allowed-rule.mdx)**
   - Updated title from "WAF Custom Allowed Rules" to "WAF Exceptions"
   - Added note explaining the terminology change (Allowed Rules in Console = Exceptions in API)
   - Added comprehensive "Managing Exceptions via API" section with:
     - API endpoint table (List, Create, Retrieve, Update, Partial update, Delete)
     - Code examples for each operation
     - Exception object fields reference table
     - Tip about automation use cases

2. **[`web-application-firewall.mdx`](src/content/docs/en/pages/main-menu/reference/secure/edge-firewall/web-application-firewall/web-application-firewall.mdx)**
   - Added note about Exceptions terminology in the Allowed Rules section
   - Added "Managing Exceptions via API" subsection with links to detailed documentation

### Portuguese Documentation (PT-BR)

3. **[`waf-custom-allowed-rules.mdx`](src/content/docs/pt-br/pages/menu-principal/referencia/secure/edge-firewall/web-application-firewall/waf-custom-allowed-rules.mdx)**
   - Updated title from "WAF Custom Allowed Rules" to "Exceções do WAF"
   - Added note explaining the terminology change
   - Added comprehensive "Gerenciando Exceções via API" section with all API examples translated

4. **[`web-application-firewall.mdx`](src/content/docs/pt-br/pages/menu-principal/referencia/secure/edge-firewall/web-application-firewall/web-application-firewall.mdx)**
   - Added note about Exceções terminology in the Allowed Rules section
   - Added "Gerenciando Exceções via API" subsection with links to detailed documentation

## API Endpoints Documented

| Operation | Endpoint |
|-----------|----------|
| List | `GET /v4/edge_firewall/wafs/{waf_id}/exceptions` |
| Create | `POST /v4/edge_firewall/wafs/{waf_id}/exceptions` |
| Retrieve | `GET /v4/edge_firewall/wafs/{waf_id}/exceptions/{exception_id}` |
| Update | `PUT /v4/edge_firewall/wafs/{waf_id}/exceptions/{exception_id}` |
| Partial update | `PATCH /v4/edge_firewall/wafs/{waf_id}/exceptions/{exception_id}` |
| Delete | `DELETE /v4/edge_firewall/wafs/{waf_id}/exceptions/{exception_id}` |

All documentation links point to the official API reference at `https://api.azion.com/v4#/operations/list_waf_exceptions`.

### Changes

<!-- List and describe the major changes that this PR will implement. -->

### Additional links

<!-- You may add any links you believe relevant here, like message threads, external documentation, other issues, etc. -->


[EDU-3000]: https://aziontech.atlassian.net/browse/EDU-3000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ