### PR TITLE
docs(runtime-apis): add WinterTC compliance section

### DIFF
--- a/src/content/docs/en/pages/devtools/azion-edge-runtime/runtime-apis/index.mdx
+++ b/src/content/docs/en/pages/devtools/azion-edge-runtime/runtime-apis/index.mdx
@@ -15,6 +15,16 @@ You can deploy projects using the Azion Edge Infrastructure, and automatically p
 
 ---
 
+## WinterTC Compliance
+
+Azion participates in [WinterTC (TC55)](https://wintertc.org/), an Ecma International Technical Committee that standardizes a [minimum common API](https://min-common-api.proposal.wintertc.org) for web-interoperable server-side JavaScript runtimes. This participation ensures:
+
+- **API interoperability**: Code written for Azion Runtime follows the same standards as other major runtimes.
+- **Standards alignment**: Azion collaborates with WHATWG, W3C, and other standards bodies.
+- **Portability**: Functions built on WinterTC-compliant APIs work consistently across platforms.
+
+---
+
 ## Network APIs
 
 [addEventListener](/en/documentation/products/applications/functions/runtime-apis/javascript/add-eventlistener/)

--- a/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/runtime-apis/index.mdx
+++ b/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/runtime-apis/index.mdx
@@ -15,6 +15,16 @@ Você pode realizar o deploy de projetos usando a infraestrutura de Edge da Azio
 
 ---
 
+## Conformidade com WinterTC
+
+A Azion participa do [WinterTC (TC55)](https://wintertc.org/), um Comitê Técnico da Ecma International que padroniza uma [API mínima comum](https://min-common-api.proposal.wintertc.org) para runtimes JavaScript server-side com interoperabilidade web. Essa participação garante:
+
+- **Interoperabilidade de APIs**: Código escrito para o Azion Runtime segue os mesmos padrões que outros runtimes principais.
+- **Alinhamento com padrões**: A Azion colabora com WHATWG, W3C e outros órgãos de padronização.
+- **Portabilidade**: Functions construídas com APIs compatíveis com WinterTC funcionam de forma consistente entre plataformas.
+
+---
+
 ## Network APIs
 
 [addEventListener](/pt-br/documentacao/produtos/applications/functions/runtime-apis/javascript/add-eventlistener/)


### PR DESCRIPTION
Add documentation about Azion's participation in WinterTC (TC55) and the benefits for API interoperability, standards alignment, and portability across platforms. Includes both English and Portuguese versions.

<!--
Thank you for contributing to Azion Docs! Please fill out the information below.
Use the conventional commits standard to categorize the type of change in the PR title. We recommend:
- feat: adding new content
- refactor: making minor changes
- fix: fixing errors

Don't forget to add the Jira issue code to the PR title or the GitHub issue hash.
For example: 
- [EDU-3000] refactor: modify origins page to include load balancer
- [#34] feat: add new application CLI commands
- [NO-ISSUE] fix: fix broken link in Orch doc
-->

### Related issue: EDU-5219
Added WinterTC compliance section to the Web APIs index page in both English and Portuguese.

**Files modified:**

1. [`src/content/docs/en/pages/devtools/azion-edge-runtime/runtime-apis/index.mdx`](src/content/docs/en/pages/devtools/azion-edge-runtime/runtime-apis/index.mdx) - Added English version
2. [`src/content/docs/pt-br/pages/devtools/azion-edge-runtime/runtime-apis/index.mdx`](src/content/docs/pt-br/pages/devtools/azion-edge-runtime/runtime-apis/index.mdx) - Added Portuguese version

**Content added:**

A new "WinterTC Compliance" section positioned right after the introduction, before the API categories. The section includes:

- Link to WinterTC official website
- Link to the Minimum Common API specification
- Three key benefits: API interoperability, standards alignment, and portability

This placement highlights Azion's commitment to open standards at the entry point of the Web APIs documentation, establishing credibility before developers explore specific APIs.


[EDU-3000]: https://aziontech.atlassian.net/browse/EDU-3000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ