### PR TITLE
Add billDetail dataset to Billing GraphQL API documentation

### DIFF
--- a/src/content/docs/en/pages/devtools/api-graphql/features/billing-fields.mdx
+++ b/src/content/docs/en/pages/devtools/api-graphql/features/billing-fields.mdx
@@ -42,3 +42,22 @@ See each available field and their descriptions below.
 | paymentDate | Date for the client payment in year-month-day format. Example: `2023-07-10` |
 | cardBrand | Brand of the card used by the client for payment. Example: `VISA` |
 | cardLast4Digits | Last 4 (four) digits from the client card. Example: `4456` |
+
+---
+
+## billDetail (Bill Details)
+
+| Field | Description |
+| ----- | ----------- |
+| clientId | Client unique identifier. Example: `0001a` |
+| periodFrom | Start date of the accounted data in year-month-day format. Example: `2023-07-01` |
+| periodTo | End date of the accounted data in year-month-day format. Example: `2023-07-31` |
+| productSlug | Identifier of the product. Example: `edge_functions` |
+| metricSlug | Identifier of the metric. Example: `invocations` |
+| regionName | Region where the metric was accounted. Example: `Brazil` |
+| accounted | Total amount of utilization accounted for the bill detail. Example: `1767504904` |
+| billId | Unique identifier of the bill. Example: `1000` |
+| billDetailId | Unique identifier of the bill detail. Example: `100000` |
+| createdDate | Creation date of the bill in year-month-day format. Example: `2023-07-01` |
+| temporaryBill | Indicates whether the bill is for the current month (temporary). Example: `false` |
+| invoiceNumber | Unique identifier for the generated invoice regarding the client bill. Example: `BRLTDA-2769z072023` |

--- a/src/content/docs/en/pages/devtools/api-graphql/features/features.mdx
+++ b/src/content/docs/en/pages/devtools/api-graphql/features/features.mdx
@@ -84,6 +84,7 @@ The Billing GraphQL API is only available for *Online Sales* accounts.
 | ------- | ----------- |
 | balanceFinancialEntry | Logs regarding types of financial entries and monetary values |
 | paymentsClientDebt | Logs regarding client's debts and payments and monetary values |
+| billDetail | Logs regarding detailed billing data per product, metric, and region for each billing period |
 
 <LinkButton link="/en/documentation/devtools/graphql-api/features/gql-billing-fields/" label="Go to Billing GraphQL API fields descriptions" severity="secondary" />
 

--- a/src/content/docs/pt-br/pages/devtools/api-graphql/recursos/billing-campos.mdx
+++ b/src/content/docs/pt-br/pages/devtools/api-graphql/recursos/billing-campos.mdx
@@ -48,3 +48,22 @@ Veja cada campo disponível e suas descrições abaixo.
 | paymentDate | Data para o pagamento do cliente no formato ano-mês-dia. Exemplo: `2023-07-10` |
 | cardBrand | Marca do cartão utilizado pelo cliente para o pagamento. Exemplo: `VISA` |
 | cardLast4Digits | Últimos 4 (quatro) dígitos do cartão do cliente. Exemplo: `4456` |
+
+---
+
+## billDetail (Detalhes da Fatura)
+
+| Campo | Descrição |
+| ----- | --------- |
+| clientId | Identificador único do cliente. Exemplo: `0001a` |
+| periodFrom | Data de início dos dados contabilizados no formato ano-mês-dia. Exemplo: `2023-07-01` |
+| periodTo | Data de término dos dados contabilizados no formato ano-mês-dia. Exemplo: `2023-07-31` |
+| productSlug | Identificador do produto. Exemplo: `edge_functions` |
+| metricSlug | Identificador da métrica. Exemplo: `invocations` |
+| regionName | Região onde a métrica foi contabilizada. Exemplo: `Brazil` |
+| accounted | Quantidade total de utilização contabilizada para o detalhe da fatura. Exemplo: `1767504904` |
+| billId | Identificador único da fatura. Exemplo: `1000` |
+| billDetailId | Identificador único do detalhe da fatura. Exemplo: `100000` |
+| createdDate | Data de criação da fatura no formato ano-mês-dia. Exemplo: `2023-07-01` |
+| temporaryBill | Indica se a fatura é referente ao mês atual (temporária). Exemplo: `false` |
+| invoiceNumber | Identificador único da nota fiscal gerada para a fatura do cliente. Exemplo: `BRLTDA-2769z072023` |

--- a/src/content/docs/pt-br/pages/devtools/api-graphql/recursos/recursos-gql.mdx
+++ b/src/content/docs/pt-br/pages/devtools/api-graphql/recursos/recursos-gql.mdx
@@ -82,6 +82,7 @@ A Billing GraphQL API está disponível apenas para contas do tipo *Online Sales
 | ----------------- | --------- |
 | balanceFinancialEntry | Registros relacionados aos tipos de entradas financeiras e valores monetários |
 | paymentsClientDebt | Registros relacionados aos débitos de clientes e pagamentos e valores monetários |
+| billDetail | Registros detalhados de faturamento por produto, métrica e região para cada período de cobrança |
 
 <LinkButton link="/pt-br/documentacao/devtools/graphql-api/recursos/campos-gql-billing/" label="veja as descrições dos Campos da API GraphQL de Billing" severity="secondary" />
 


### PR DESCRIPTION
<!--
Thank you for contributing to Azion Docs! Please fill out the information below.
Use the conventional commits standard to categorize the type of change in the PR title. We recommend:
- feat: adding new content
- refactor: making minor changes
- fix: fixing errors

Don't forget to add the Jira issue code to the PR title or the GitHub issue hash.
For example: 
- [EDU-3000] refactor: modify origins page to include load balancer
- [#34] feat: add new application CLI commands
- [NO-ISSUE] fix: fix broken link in Orch doc
-->

### Related issue: EDU-4475
The `billDetail` dataset has been added to the Billing GraphQL API documentation across all four affected files:

---

### Files modified

**English**

1. [`src/content/docs/en/pages/devtools/api-graphql/features/billing-fields.mdx`](src/content/docs/en/pages/devtools/api-graphql/features/billing-fields.mdx) — Added a new `## billDetail (Bill Details)` section with a full field reference table (12 fields).

2. [`src/content/docs/en/pages/devtools/api-graphql/features/features.mdx`](src/content/docs/en/pages/devtools/api-graphql/features/features.mdx) — Added `billDetail` row to the **Billing GraphQL API** datasets table under the `### Billing GraphQL API` section.

**Portuguese (PT-BR)**

3. [`src/content/docs/pt-br/pages/devtools/api-graphql/recursos/billing-campos.mdx`](src/content/docs/pt-br/pages/devtools/api-graphql/recursos/billing-campos.mdx) — Added a new `## billDetail (Detalhes da Fatura)` section with the full translated field reference table.

4. [`src/content/docs/pt-br/pages/devtools/api-graphql/recursos/recursos-gql.mdx`](src/content/docs/pt-br/pages/devtools/api-graphql/recursos/recursos-gql.mdx) — Added `billDetail` row to the **Billing GraphQL API** datasets table.

---

### Fields documented for `billDetail`

| Field | Description |
|---|---|
| `clientId` | Client unique identifier |
| `periodFrom` | Start date of the accounted data |
| `periodTo` | End date of the accounted data |
| `productSlug` | Identifier of the product |
| `metricSlug` | Identifier of the metric |
| `regionName` | Region where the metric was accounted |
| `accounted` | Total utilization accounted for the bill detail |
| `billId` | Unique identifier of the bill |
| `billDetailId` | Unique identifier of the bill detail |
| `createdDate` | Creation date of the bill |
| `temporaryBill` | Indicates if the bill is for the current month |
| `invoiceNumber` | Unique identifier for the generated invoice |

Field names were converted from `snake_case` (source code) to `camelCase` to match the existing documentation convention used by `balanceFinancialEntry` and `paymentsClientDebt`.

[EDU-3000]: https://aziontech.atlassian.net/browse/EDU-3000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ