### PR TITLE
Add detailed descriptions and increase limits section for edge functions

### DIFF
--- a/src/content/docs/en/pages/main-menu/reference/build/edge-application/edge-functions.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/build/edge-application/edge-functions.mdx
@@ -258,15 +258,25 @@ Learn more about the management of functions trough [the Azion Terraform Provide
 
 ## Limits
 
+:::tip
+**Increase limits** <br></br>
+You can request to increase the limits based on your plan. Contact the [technical support team](/en/documentation/services/support/) to request it.
+:::
+
 These are the **default limits**:
 
-| Scope | Limit | 
-| ----- | ----- | 
-| Arguments | 100 KB |
-| Memory per Isolate | 512 MB |
-| Code Limit (UI) | 6 MB |
-| Code Limit (API) | 50 MB |
-| Environment variable size | 32 KB |
-| Sub-Requests | 50 Sub-Req |
-| Max CPU Execution Time | 2s |
+| Scope | Limit | Description |
+| ----- | ----- | ----------- |
+| Arguments | 100 KB | Maximum size of the JSON args object passed to a function instance. Exceeding this limit causes the function to fail at instantiation. |
+| Memory per Isolate | 512 MB | Maximum memory available to a single function execution context (V8 isolate). This includes heap, stack, and all runtime allocations. |
+| Code Limit (UI) | 6 MB | Maximum size of the function source code when created or edited through Azion Console. |
+| Code Limit (API) | 20 MB | Maximum size of the function source code when deployed via the Azion API. |
+| Environment variable size | 32 KB | Maximum total size of all environment variables combined for a single function. |
+| Sub-Requests | 50 Sub-Req | Maximum number of outbound `fetch()` calls a function can make during a single invocation. |
+| Max CPU Execution Time | 2s | Maximum CPU time a function can consume per invocation. This measures active computation time, not wall-clock time. Functions exceeding this limit are terminated. |
+| Max Execution Time | 5 min | Maximum wall-clock time (total elapsed time) allowed for a function invocation, including I/O wait, `fetch()` calls, and async operations. |
+| Max Cold Start | 2s | Maximum time allowed for a function to initialize before handling its first request. Azion Runtime is designed to minimize cold starts across the global network. |
+| URL Size | 16 KB | Maximum size of the request URL that a function can process, including the path and query string. |
+| Header Size | 64 KB | Maximum total size of all HTTP request headers combined that a function can read or write. |
+| Body Size | 100 MB (Developer plan)<br />200 MB (Business plan)<br />500 MB (Enterprise and Mission Critical plans) | Maximum size of the HTTP request or response body that a function can process. Limits vary by service plan. |
 

--- a/src/content/docs/en/pages/main-menu/reference/build/edge-application/edge-functions.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/build/edge-application/edge-functions.mdx
@@ -269,7 +269,7 @@ These are the **default limits**:
 | ----- | ----- | ----------- |
 | Arguments | 100 KB | Maximum size of the JSON args object passed to a function instance. Exceeding this limit causes the function to fail at instantiation. |
 | Memory per Isolate | 512 MB | Maximum memory available to a single function execution context (V8 isolate). This includes heap, stack, and all runtime allocations. |
-| Code Limit (UI) | 6 MB | Maximum size of the function source code when created or edited through Azion Console. |
+| Code Limit (UI) | 6 MB | Maximum size of the function source code when created or edited through Azion Console |
 | Code Limit (API) | 20 MB | Maximum size of the function source code when deployed via the Azion API. |
 | Environment variable size | 32 KB | Maximum total size of all environment variables combined for a single function. |
 | Sub-Requests | 50 Sub-Req | Maximum number of outbound `fetch()` calls a function can make during a single invocation. |

--- a/src/content/docs/pt-br/pages/menu-principal/referencia/build/edge-application/edge-functions-edge-app.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/referencia/build/edge-application/edge-functions-edge-app.mdx
@@ -258,15 +258,25 @@ Saiba mais sobre o gerenciamento de functions através do [Azion Terraform Provi
 
 ## Limites
 
+:::tip
+**Aumentar limites** <br></br>
+Você pode solicitar o aumento dos limites com base no seu plano. Entre em contato com a [equipe de suporte técnico](/pt-br/documentacao/servicos/suporte/) para solicitar.
+:::
+
 Estes são os **limites default**:
 
-| Escopo | Limite|
-| - | - |
-| Argumentos | 100 KB |
-| Memória por Isolate | 512 MB |
-| Limite de código (UI) | 6 MB |
-| Limite de código (API) | 50 MB |
-| Tamanho da variável de ambiente | 32 KB |
-| Sub-Requests | 50 Sub-Req |
-| Max CPU Execution Time | 2s |
+| Escopo | Limite | Descrição |
+| ----- | ----- | ----------- |
+| Argumentos | 100 KB | Tamanho máximo do objeto JSON args passado para uma instância de function. Exceder esse limite causa falha na instanciação da function. |
+| Memória por Isolate | 512 MB | Memória máxima disponível para um único contexto de execução de function (V8 isolate). Inclui heap, stack e todas as alocações em runtime. |
+| Limite de código (UI) | 6 MB | Tamanho máximo do código-fonte da function ao criar ou editar pelo Azion Console. |
+| Limite de código (API) | 20 MB | Tamanho máximo do código-fonte da function ao fazer deploy via Azion API. |
+| Tamanho da variável de ambiente | 32 KB | Tamanho total máximo de todas as variáveis de ambiente combinadas para uma única function. |
+| Sub-Requests | 50 Sub-Req | Número máximo de chamadas `fetch()` de saída que uma function pode realizar durante uma única invocação. |
+| Max CPU Execution Time | 2s | Tempo máximo de CPU que uma function pode consumir por invocação. Mede o tempo de computação ativa, não o tempo de relógio. Functions que excedem esse limite são encerradas. |
+| Max Execution Time | 5 min | Tempo máximo de relógio (tempo total decorrido) permitido para uma invocação de function, incluindo espera de I/O, chamadas `fetch()` e operações assíncronas. |
+| Max Cold Start | 2s | Tempo máximo permitido para uma function inicializar antes de processar sua primeira requisição. O Azion Runtime é projetado para minimizar cold starts na rede global. |
+| Tamanho da URL | 16 KB | Tamanho máximo da URL de requisição que uma function pode processar, incluindo o path e a query string. |
+| Tamanho do Header | 64 KB | Tamanho total máximo de todos os headers HTTP de requisição combinados que uma function pode ler ou escrever. |
+| Tamanho do Body | 100 MB (plano Developer)<br />200 MB (plano Business)<br />500 MB (planos Enterprise e Mission Critical) | Tamanho máximo do body de requisição ou resposta HTTP que uma function pode processar. Os limites variam conforme o plano de serviço. |
 


### PR DESCRIPTION
<!--
Thank you for contributing to Azion Docs! Please fill out the information below.
Use the conventional commits standard to categorize the type of change in the PR title. We recommend:
- feat: adding new content
- refactor: making minor changes
- fix: fixing errors

Don't forget to add the Jira issue code to the PR title or the GitHub issue hash.
For example: 
- [EDU-3000] refactor: modify origins page to include load balancer
- [#34] feat: add new application CLI commands
- [NO-ISSUE] fix: fix broken link in Orch doc
-->

### Related issue: EDU-5225

## Functions Limits Table — Update Complete

Both EN and PT-BR documentation files have been updated with the following changes:

---

### Files modified

- **EN:** [`src/content/docs/en/pages/main-menu/reference/build/edge-application/edge-functions.mdx`](src/content/docs/en/pages/main-menu/reference/build/edge-application/edge-functions.mdx:259)
- **PT-BR:** [`src/content/docs/pt-br/pages/menu-principal/referencia/build/edge-application/edge-functions-edge-app.mdx`](src/content/docs/pt-br/pages/menu-principal/referencia/build/edge-application/edge-functions-edge-app.mdx:259)

---

### What changed

**1. Standard `:::tip` banner added** (consistent with all other Limits sections in the docs):
```
:::tip
**Increase limits**
You can request to increase the limits based on your plan. Contact the technical support team to request it.
:::
```

**2. New `Description` column added** — each limit now explains what it controls and its practical impact, following the Cloudflare benchmark pattern.

**3. Table updated with new limits from Platform Limits source:**

| Scope | Old Value | New Value | Status |
|---|---|---|---|
| Code Limit (API) | 50 MB | **20 MB** | ✏️ Corrected |
| Max Execution Time | — | **5 min** | ➕ Added |
| Max Cold Start | — | **2s** | ➕ Added |
| URL Size | — | **16 KB** | ➕ Added |
| Header Size | — | **64 KB** | ➕ Added |
| Body Size | — | **100/200/500 MB (by plan)** | ➕ Added |

---


[EDU-3000]: https://aziontech.atlassian.net/browse/EDU-3000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ