### PR TITLE
docs: enhance DNSSEC activation guide with detailed prerequisites and…

### DIFF
--- a/src/content/docs/en/pages/secure-journey/zone-advanced-configurations/activate-dnssec.mdx
+++ b/src/content/docs/en/pages/secure-journey/zone-advanced-configurations/activate-dnssec.mdx
@@ -8,8 +8,26 @@ namespace: docs_secure_activate_dnssec
 permalink: /documentation/products/guides/secure/activate-dnssec/
 ---
 
-
 **Domain Name System Security Extensions (DNSSEC)** provide an extra layer of security to verify the authenticity and integrity of an IP address response. Azion provides [DNSSEC compatibility](/en/documentation/products/secure/edge-dns/dnssec-compatibility/) as long as your top-level domain (TLD) registry supports it and [your zone is configured](/en/documentation/products/guides/secure/edge-dns-configure-main-settings/) with DNSSEC-related resource records on [Edge DNS](/en/documentation/products/guides/secure/add-records/).
+
+---
+
+## Prerequisites
+
+Before activating DNSSEC, you need an Azion **Personal Token** to authenticate API calls.
+
+To create a Personal Token:
+
+1. Access [Azion Console](https://console.azion.com).
+2. In the right sidebar menu, click **Personal Tokens**.
+3. Click the **Add Personal Token** button.
+4. Set the token name, expiration time, and optionally a description.
+5. Click **Create Token**.
+6. Copy and save the generated token value — you'll need it in the next steps.
+
+:::tip
+To simplify Azion API usage, you can import the official Postman collection available at [api.azion.com](https://api.azion.com). Replace the `[TOKEN VALUE]` variable with your Personal Token.
+:::
 
 ---
 
@@ -17,79 +35,188 @@ permalink: /documentation/products/guides/secure/activate-dnssec/
 
 DNSSEC activation is available via [Azion API](https://api.azion.com/#ea46919a-7130-426d-b38b-dc416b6c4c32):
 
-1. Run the following `GET` request in your terminal, replacing [TOKEN VALUE] with your [personal token](/en/documentation/products/guides/personal-tokens/) to retrieve your `<zoneId>`:
+1. Run the following `GET` request in your terminal, replacing `[TOKEN VALUE]` with your [personal token](/en/documentation/products/guides/personal-tokens/) to retrieve your `{zone_id}`:
 
 ```bash
 curl --request GET \
-  --url https://api.azion.com/v4/dns/zones \
+  --url 'https://api.azion.com/v4/workspace/dns/zones?page_size=100' \
   --header 'Accept: application/json' \
-  --header 'Authorization: [TOKEN VALUE]'
+  --header 'Authorization: Bearer [TOKEN VALUE]'
 ```
 
-2. You’ll receive a response similar to this:
+:::tip
+Use the `page_size=100` parameter to list up to 100 zones per page. If you have more zones, use the `page` parameter to navigate between pages.
+:::
+
+2. You'll receive a response similar to this:
 
 ```json
 {
   "count": 1,
-  "links": {
-    "previous": null,
-    "next": null
-  },
   "total_pages": 1,
+  "page": 1,
+  "page_size": 100,
+  "next": null,
+  "previous": null,
   "results": [
     {
-      "domain": "youdomain.com",
+      "domain": "yourdomain.com",
       "is_active": true,
       "name": "A hosted zone",
       "id": 1234
     }
-  ],
-  "schema_version": 3
+  ]
 }
 ```
 
-3. Copy the `<id>` value of the specific zone in which you want to activate DNSSEC. In this example, it's `1234`.
-4. Run the following `PATCH` request in your terminal, replacing [TOKEN VALUE] with your [personal token](/en/documentation/products/guides/personal-tokens/):
+3. Copy the `id` value of the specific zone in which you want to activate DNSSEC. In this example, it's `1234`.
+4. Run the following `PATCH` request to activate DNSSEC on the zone and trigger cryptographic key generation. Replace `[TOKEN VALUE]` with your [personal token](/en/documentation/products/guides/personal-tokens/) and `{zone_id}` with the ID collected in the previous step:
 
 ```bash
 curl --request PATCH \
-  --url https://api.azion.com/v4/dns/zones/<zoneId>/dnssec \
+  --url https://api.azion.com/v4/workspace/dns/zones/{zone_id}/dnssec \
   --header 'Accept: application/json' \
-  --header 'Authorization: [TOKEN VALUE]' \
+  --header 'Authorization: Bearer [TOKEN VALUE]' \
   --header 'Content-Type: application/json' \
   --data '{
   "enabled": true
 }'
 ```
 
-5. You’ll receive a response similar to this:
+5. You'll receive a response similar to this:
 
 ```json
 {
-  "results": {
-    "is_enabled": true,
-    "status": "waiting"
-  },
-  "schema_version": 3
+  "data": {
+    "enabled": true,
+    "status": "unconfigured",
+    "delegation_signer": null
+  }
 }
 ```
 
-6. Run the following `GET` request to retrieve the `digest` and `key_tag` replacing [TOKEN VALUE] with your [personal token](/en/documentation/products/guides/personal-tokens/) and `<zoneId>`, you'll need these to configure DNSSEC in your domain Registrar.
+:::note
+The `unconfigured` status means DNSSEC has been activated on Azion but hasn't been configured at your domain Registrar yet. The cryptographic keys (`digest` and `key_tag`) are generated at this point and will be available in the next request.
+:::
+
+6. Run the following `GET` request to retrieve the generated `digest` and `key_tag` values. Replace `[TOKEN VALUE]` with your [personal token](/en/documentation/products/guides/personal-tokens/) and `{zone_id}`. You'll need these values to configure DNSSEC at your domain Registrar.
 
 ```bash
 curl --request GET \
-  --url https://api.azion.com/v4/dns/zones/<zoneId>/dnssec \
+  --url https://api.azion.com/v4/workspace/dns/zones/{zone_id}/dnssec \
   --header 'Accept: application/json' \
-  --header 'Authorization: [TOKEN VALUE]'
+  --header 'Authorization: Bearer [TOKEN VALUE]'
+```
+
+7. You'll receive a response similar to this:
+
+```json
+{
+  "data": {
+    "enabled": true,
+    "status": "unconfigured",
+    "delegation_signer": {
+      "algorithm_type": {
+        "id": 1,
+        "slug": "string"
+      },
+      "digest": "string",
+      "digest_type": {
+        "id": 1,
+        "slug": "string"
+      },
+      "key_tag": 1
+    }
+  }
+}
 ```
 
 :::caution[warning]
 Your DNSSEC configuration is NOT complete until you finish the setup using the `digest` and `key_tag` values at your domain Registrar.
 :::
 
-:::tip
-Check the [Azion API documentation](https://api.azion.com/) and the [OpenAPI specification](https://github.com/aziontech/azionapi-openapi/) to know more about all features available via API.
+---
+
+## Configure DNSSEC at your domain Registrar
+
+After retrieving the `digest` and `key_tag` values via API, you must register them at your domain Registrar to establish the chain of trust.
+
+The example below uses [Registro.br](https://registro.br) as a reference, but the process is similar for other registrars.
+
+1. Access your domain Registrar and log in with your domain administration credentials.
+2. In the domain list, click the domain for which you want to activate DNSSEC.
+3. Expand the **Change DNS Servers** section.
+4. Click **+DNSSEC** and enter the `key_tag` and `digest` values obtained in the previous step.
+5. Click **Save Changes** to apply the settings.
+
+:::note
+DNSSEC propagation time may vary depending on the zone TTL and the TLD registry publication schedule. Wait for the new publication before validating.
 :::
 
 ---
 
+## Validate DNSSEC activation
+
+After configuring DNSSEC at your registrar, validate the activation using the methods below.
+
+### Using the dig command
+
+Run the following command, replacing `<domain>` with the activated domain:
+
+```bash
+dig <domain> +dnssec
+```
+
+In the response, verify the presence of the `RRSIG` entry. Its absence indicates that DNSSEC is not yet active or that propagation hasn't completed.
+
+To validate the resolution of a specific record within the zone:
+
+```bash
+dig <record>.<domain> +dnssec
+```
+
+The response should include both the record value and the corresponding `RRSIG` entry.
+
+### Using an online tool
+
+Access [https://dnssec-analyzer.verisignlabs.com/](https://dnssec-analyzer.verisignlabs.com/) and enter the activated domain. All validations must return successfully to confirm that the chain of trust is correctly established.
+
+---
+
+## Rollback
+
+If you need to undo DNSSEC activation, follow the steps below in the indicated order.
+
+### 1. Remove DNSSEC information from your domain Registrar
+
+1. Access your domain Registrar (for example, [registro.br](https://registro.br)).
+2. Navigate to the domain and expand the **Change DNS Servers** section.
+3. Remove the DNSSEC information.
+4. Click **Save Changes** to apply the settings.
+
+### 2. Disable DNSSEC via API
+
+After removing the information from the registrar, disable DNSSEC on Azion:
+
+```bash
+curl --request PATCH \
+  --url https://api.azion.com/v4/workspace/dns/zones/{zone_id}/dnssec \
+  --header 'Accept: application/json' \
+  --header 'Authorization: Bearer [TOKEN VALUE]' \
+  --header 'Content-Type: application/json' \
+  --data '{
+  "enabled": false
+}'
+```
+
+:::caution[warning]
+Always remove DNSSEC information from your Registrar **before** disabling DNSSEC on Azion. Reversing the order may cause DNS resolution failures for the domain.
+:::
+
+---
+
+:::tip
+Check the [Azion API documentation](https://api.azion.com/) and the [OpenAPI specification](https://github.com/aziontech/api-schemas/) to know more about all features available via API.
+:::
+
+---

--- a/src/content/docs/pt-br/pages/secure-jornada/zona-configuracoes-avancadas/ativar-dnssec.mdx
+++ b/src/content/docs/pt-br/pages/secure-jornada/zona-configuracoes-avancadas/ativar-dnssec.mdx
@@ -8,8 +8,26 @@ namespace: docs_secure_activate_dnssec
 permalink: /documentacao/produtos/guias/secure/ativar-dnssec/
 ---
 
-
 **Domain Name System Security Extensions (DNSSEC)** fornecem uma camada extra de segurança para verificar a autenticidade e a integridade de uma resposta de endereço IP. A Azion fornece [compatibilidade com DNSSEC](/pt-br/documentacao/produtos/secure/edge-dns/compatibilidade-dnssec/), desde que o registro do seu domínio de nível superior (TLD) suporte o recurso e [sua zona esteja configurada](/pt-br/documentacao/produtos/guias/secure/edge-dns-definir-main-settings/) com registros de recursos relacionados ao DNSSEC no [Edge DNS](/pt-br/documentacao/produtos/guias/secure/adicionar-registros/).
+
+---
+
+## Pré-requisitos
+
+Antes de ativar o DNSSEC, você precisa de um **Personal Token** da Azion para autenticar as chamadas de API.
+
+Para criar um Personal Token:
+
+1. Acesse o [Azion Console](https://console.azion.com).
+2. No menu lateral direito, clique em **Personal Tokens**.
+3. Clique no botão **Add Personal Token**.
+4. Defina o nome do token, o tempo de expiração e, opcionalmente, uma descrição.
+5. Clique em **Create Token**.
+6. Copie e salve o valor do token gerado — ele será necessário nas próximas etapas.
+
+:::tip
+Para facilitar o uso da API da Azion, você pode importar a collection oficial do Postman disponível em [api.azion.com](https://api.azion.com). Substitua a variável `[TOKEN VALUE]` pelo Personal Token gerado.
+:::
 
 ---
 
@@ -17,45 +35,48 @@ permalink: /documentacao/produtos/guias/secure/ativar-dnssec/
 
 A ativação do DNSSEC está disponível via [API da Azion](https://api.azion.com/#ea46919a-7130-426d-b38b-dc416b6c4c32):
 
-1. Execute a seguinte requisição `GET` no seu terminal, substituindo `[TOKEN VALUE]` pelo seu [personal token](/pt-br/documentacao/produtos/guias/personal-tokens/) para buscar seu `<zoneId>`:
+1. Execute a seguinte requisição `GET` no seu terminal, substituindo `[TOKEN VALUE]` pelo seu [personal token](/pt-br/documentacao/produtos/guias/personal-tokens/) para buscar seu `<zone_id>`:
 
 ```bash
 curl --request GET \
-  --url https://api.azion.com/v4/dns/zones \
+  --url 'https://api.azion.com/v4/workspace/dns/zones?page_size=100' \
   --header 'Accept: application/json' \
-  --header 'Authorization: [TOKEN VALUE]'
+  --header 'Authorization: Bearer [TOKEN VALUE]'
 ```
+
+:::tip
+Use o parâmetro `page_size=100` para listar até 100 zonas por página. Se você tiver mais zonas, utilize o parâmetro `page` para navegar entre as páginas.
+:::
 
 2. Você receberá uma resposta semelhante a esta:
 
 ```json
 {
-"count": 1,
-"links": {
-"previous": null,
-"next": null
-},
-"total_pages": 1,
-"results": [
-{
-"domain": "seudominio.com",
-"is_active": true,
-"name": "Uma zona hospedada",
-"id": 1234
-}
-],
-"schema_version": 3
+  "count": 1,
+  "total_pages": 1,
+  "page": 1,
+  "page_size": 100,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "domain": "seudominio.com",
+      "is_active": true,
+      "name": "Uma zona hospedada",
+      "id": 1234
+    }
+  ]
 }
 ```
 
-3. Copie o valor `<id>` da zona específica na qual você deseja ativar o DNSSEC. Neste exemplo, é `1234`.
-4. Execute a seguinte requisição `PATCH` no seu terminal, substituindo `[TOKEN VALUE]` pelo seu [personal token](/pt-br/documentacao/produtos/guias/personal-tokens/):
+3. Copie o valor `id` da zona específica na qual você deseja ativar o DNSSEC. Neste exemplo, é `1234`.
+4. Execute a seguinte requisição `PATCH` para ativar o DNSSEC na zona e iniciar a geração das chaves criptográficas. Substitua `[TOKEN VALUE]` pelo seu [personal token](/pt-br/documentacao/produtos/guias/personal-tokens/) e `{zone_id}` pelo ID coletado no passo anterior:
 
 ```bash
 curl --request PATCH \
-  --url https://api.azion.com/v4/dns/zones/<zoneId>/dnssec \
+  --url https://api.azion.com/v4/workspace/dns/zones/{zone_id}/dnssec \
   --header 'Accept: application/json' \
-  --header 'Authorization: [TOKEN VALUE]' \
+  --header 'Authorization: Bearer [TOKEN VALUE]' \
   --header 'Content-Type: application/json' \
   --data '{
   "enabled": true
@@ -66,30 +87,136 @@ curl --request PATCH \
 
 ```json
 {
-"results": {
-"is_enabled": true,
-"status": "waiting"
-},
-"schema_version": 3
+  "data": {
+    "enabled": true,
+    "status": "unconfigured",
+    "delegation_signer": null
+  }
 }
 ```
 
-6. Execute a seguinte requisição `GET` no seu terminal, substituindo `[TOKEN VALUE]` pelo seu [personal token](/pt-br/documentacao/produtos/guias/personal-tokens/) e `<zoneId>` para buscar `digest` e `key_tag`. Você vai precisar deles para configurar DNSSEC no seu Registrar.
+:::note
+O status `unconfigured` indica que o DNSSEC foi ativado na Azion, mas ainda não foi configurado no Registrador de domínios. As chaves criptográficas (`digest` e `key_tag`) são geradas neste momento e estarão disponíveis na próxima requisição.
+:::
+
+6. Execute a seguinte requisição `GET` para recuperar os valores de `digest` e `key_tag` gerados. Substitua `[TOKEN VALUE]` pelo seu [personal token](/pt-br/documentacao/produtos/guias/personal-tokens/) e `{zone_id}`. Você vai precisar deles para configurar o DNSSEC no seu Registrador de domínios.
 
 ```bash
 curl --request GET \
-  --url https://api.azion.com/v4/dns/zones/<zoneId>/dnssec \
+  --url https://api.azion.com/v4/workspace/dns/zones/{zone_id}/dnssec \
   --header 'Accept: application/json' \
-  --header 'Authorization: [TOKEN VALUE]'
+  --header 'Authorization: Bearer [TOKEN VALUE]'
+```
+
+7. Você receberá uma resposta semelhante a esta:
+
+```json
+{
+  "data": {
+    "enabled": true,
+    "status": "unconfigured",
+    "delegation_signer": {
+      "algorithm_type": {
+        "id": 1,
+        "slug": "string"
+      },
+      "digest": "string",
+      "digest_type": {
+        "id": 1,
+        "slug": "string"
+      },
+      "key_tag": 1
+    }
+  }
+}
 ```
 
 :::caution[Atenção]
 Sua configuração de DNSSEC NÃO está completa até você terminar o setup utilizando os valores de `digest` e `key_tag` no seu Registrador de domínios.
 :::
 
-:::tip
-Confira a [documentação da API da Azion](https://api.azion.com/) e a [especificação OpenAPI](https://github.com/aziontech/azionapi-openapi/) para saber mais sobre todos os recursos disponíveis via API.
+---
+
+## Configure o DNSSEC no seu Registrador de domínios
+
+Após obter os valores de `digest` e `key_tag` via API, você precisa registrá-los no seu Registrador de domínios para estabelecer a cadeia de confiança.
+
+O exemplo abaixo utiliza o [Registro.br](https://registro.br) como referência, mas o processo é similar em outros registradores.
+
+1. Acesse [registro.br](https://registro.br) e faça login com as credenciais de administração do domínio.
+2. Na lista de domínios, clique no domínio no qual deseja ativar o DNSSEC.
+3. Expanda a seção **Alterar Servidores DNS**.
+4. Clique em **+DNSSEC** e insira os valores de `key_tag` e `digest` obtidos na etapa anterior.
+5. Clique em **Salvar Alterações** para aplicar as configurações.
+
+:::note
+O tempo de propagação das configurações de DNSSEC pode variar de acordo com o TTL da zona e o tempo de publicação do TLD responsável. Aguarde a nova publicação antes de validar.
 :::
 
 ---
 
+## Valide a ativação do DNSSEC
+
+Após configurar o DNSSEC no registrador, valide a ativação utilizando os métodos abaixo.
+
+### Via comando dig
+
+Execute o comando abaixo substituindo `<domínio>` pelo domínio ativado:
+
+```bash
+dig <domínio> +dnssec
+```
+
+No retorno, verifique a presença da entrada `RRSIG`. Sua ausência indica que o DNSSEC ainda não está ativo ou que a propagação ainda não foi concluída.
+
+Para validar a resolução de um registro específico dentro da zona:
+
+```bash
+dig <registro>.<domínio> +dnssec
+```
+
+O retorno deve apresentar tanto o valor do registro quanto a entrada `RRSIG` correspondente.
+
+### Via ferramenta online
+
+Acesse [https://dnssec-analyzer.verisignlabs.com/](https://dnssec-analyzer.verisignlabs.com/) e insira o domínio ativado. Todas as validações devem retornar com sucesso para confirmar que a cadeia de confiança está estabelecida corretamente.
+
+---
+
+## Rollback
+
+Caso seja necessário desfazer a ativação do DNSSEC, siga os passos abaixo na ordem indicada.
+
+### 1. Remova as informações no Registrador de domínios
+
+1. Acesse o seu Registrador de domínios (por exemplo, [registro.br](https://registro.br)).
+2. Navegue até o domínio e expanda a seção **Alterar Servidores DNS**.
+3. Remova as informações referentes ao DNSSEC.
+4. Clique em **Salvar Alterações** para aplicar as configurações.
+
+### 2. Desative o DNSSEC via API
+
+Após remover as informações no registrador, desative o DNSSEC na Azion:
+
+```bash
+curl --request PATCH \
+  --url https://api.azion.com/v4/workspace/dns/zones/{zone_id}/dnssec \
+  --header 'Accept: application/json' \
+  --header 'Authorization: Bearer [TOKEN VALUE]' \
+  --header 'Content-Type: application/json' \
+  --data '{
+  "enabled": false
+}'
+```
+
+:::caution[Atenção]
+Sempre remova as informações do DNSSEC no Registrador **antes** de desativar o DNSSEC na Azion. Inverter a ordem pode causar falhas de resolução DNS para o domínio.
+:::
+
+---
+
+:::tip
+Confira a [documentação da API da Azion](https://api.azion.com/) e a [especificação OpenAPI](https://github.com/aziontech/api-schemas/) para saber mais sobre todos os recursos disponíveis via API.
+:::
+
+---


### PR DESCRIPTION
… API usage instructions

<!--
Thank you for contributing to Azion Docs! Please fill out the information below.
Use the conventional commits standard to categorize the type of change in the PR title. We recommend:
- feat: adding new content
- refactor: making minor changes
- fix: fixing errors

Don't forget to add the Jira issue code to the PR title or the GitHub issue hash.
For example: 
- [EDU-3000] refactor: modify origins page to include load balancer
- [#34] feat: add new application CLI commands
- [NO-ISSUE] fix: fix broken link in Orch doc
-->

### Related issue: EDU-5462
Here's the branch description text for GitHub:

---

**docs: improve DNSSEC activation guide with end-to-end procedure (EN + PT-BR)**

Expands the DNSSEC activation guides (`activate-dnssec` / `ativar-dnssec`) based on a client-facing procedure document. The guides now cover the full activation lifecycle — from Personal Token creation to registrar configuration, validation, and rollback.

**Changes:**
- Added **Prerequisites** section with step-by-step instructions to create a Personal Token via Azion Console
- Added tip about importing the official Postman collection from `api.azion.com`
- Updated API endpoint to the correct path: `/v4/workspace/dns/zones/{zone_id}/dnssec`
- Updated auth header to `Authorization: Bearer [TOKEN VALUE]`
- Added `page_size=100` parameter to the zones list request with pagination guidance
- Updated zones list response to match the actual API v4 format
- Updated PATCH response to include `"delegation_signer": null` (initial state after enabling)
- Added `:::note` callout explaining the `unconfigured` status and key generation flow
- Updated GET DNSSEC response to include the full `delegation_signer` object with `digest`, `digest_type`, `algorithm_type`, and `key_tag`
- Added **Configure DNSSEC at your domain Registrar** section (using Registro.br as reference)
- Added **Validate DNSSEC activation** section with `dig +dnssec` command and Verisign DNSSEC Analyzer
- Added **Rollback** section with the correct order: remove from registrar first, then disable via API
- Updated OpenAPI spec link to `github.com/aziontech/api-schemas/`

**Files changed:**
- `src/content/docs/pt-br/pages/secure-jornada/zona-configuracoes-avancadas/ativar-dnssec.mdx`
- `src/content/docs/en/pages/secure-journey/zone-advanced-configurations/activate-dnssec.mdx`

[EDU-3000]: https://aziontech.atlassian.net/browse/EDU-3000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ