### PR TITLE
docs: specify query limits for GraphQL API and enhance error response…

### DIFF
--- a/src/content/docs/en/pages/devtools/api-graphql/error-responses/error-responses.mdx
+++ b/src/content/docs/en/pages/devtools/api-graphql/error-responses/error-responses.mdx
@@ -28,6 +28,7 @@ You can receive the following status codes and error messages in a query format:
 | 401         | The authorization token has expired.                                                                                            | The informed token has expired.                                                      |
 | 404         | The following resource could not be found.                                                                                      | The client_id isn't allowed to access the specific API resource.                     |
 | 429         | You have reached the request rate limit!                                                                                        | The request rate limit for the IP address has been exceeded.                         |
+| 500         | An error occured while performing the requested operation.: Limit for rows or bytes to read exceeded, max rows: 10.00 billion, current rows: [value] billion | The internal **10-billion row read limit** was reached. This occurs when a query spans a broad time range (for example, 7 days) with no additional filter parameters. Reduce the time range or add specific filters in the **Filter by** field to narrow the query. |
 
 If you receive any of the described error responses, see the rest of the [GraphQL API documentation](/en/documentation/devtools/graphql-api/) to find specifications and correct your request.
 

--- a/src/content/docs/en/pages/main-menu/reference/observe/real-time-events/real-time-events.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/observe/real-time-events/real-time-events.mdx
@@ -336,3 +336,12 @@ These are the **default limits**:
 | GraphQL API maximum fields | 10 fields |
 | GraphQL API maximum payload | 5 GB |
 | GraphQL API queries | 120 requests per minute |
+| Internal query rows read | 10 billion rows |
+
+:::note
+The **10-billion row read limit** is enforced internally by the log database. Queries with broad time ranges (for example, 7 days) and no additional filter parameters may hit this limit and return the error:
+
+`A query limit was exceeded. Try to refine your filter parameters or query a smaller period for a more precise search.`
+
+To avoid this error, reduce the query time range or add specific filters in the **Filter by** field, such as a host, IP address, HTTP status code, or another parameter relevant to your use case.
+:::

--- a/src/content/docs/pt-br/pages/devtools/api-graphql/mensagens-de-erro/mensagens-erro-gql.mdx
+++ b/src/content/docs/pt-br/pages/devtools/api-graphql/mensagens-de-erro/mensagens-erro-gql.mdx
@@ -28,12 +28,9 @@ A tabela a seguir lista os códigos de status e as mensagens de erro em formato 
 | 401         | The authorization token has expired.                                                                                            | O token informado expirou.                                                      |
 | 404         | The following resource could not be found.                                                                                      | O client_id não possui acesso ao recurso sendo consultado na API.                     |
 | 429         | You have reached the request rate limit!                                                                                        | O limite de requisições para o endereço de IP foi excedido.                         |
+| 500         | An error occured while performing the requested operation.: Limit for rows or bytes to read exceeded, max rows: 10.00 billion, current rows: [value] billion | O limite interno de **10 bilhões de linhas lidas** foi atingido. Isso ocorre quando a consulta abrange um intervalo de tempo amplo (por exemplo, 7 dias) sem parâmetros de filtro adicionais. Reduza o intervalo de tempo ou adicione filtros específicos no campo **Filter by** para refinar a consulta. |
 
 Se você recebeu alguma das mensagens de erro detalhadas acima, consulte a [documentação da API GraphQL](/pt-br/documentacao/devtools/graphql-api/) para encontrar as especificações necessárias e corrigir a sua requisição.
-
-
-
-
 
 ---
 

--- a/src/content/docs/pt-br/pages/menu-principal/referencia/observe/real-time-events/real-time-events.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/referencia/observe/real-time-events/real-time-events.mdx
@@ -339,3 +339,12 @@ Estes são os **limites default**:
 | API GraphQL máximo de campos | 10 campos |
 | API GraphQL payload máximo | 5 GB |
 | API GraphQL consultas | 120 requisições por minuto |
+| Linhas lidas por consulta interna | 10 bilhões de linhas |
+
+:::note
+O limite de **10 bilhões de linhas lidas por consulta** é aplicado internamente pelo banco de dados de logs. Consultas com intervalos de tempo amplos (por exemplo, 7 dias) sem parâmetros de filtro adicionais podem atingir esse limite e retornar a seguinte mensagem de erro (exibida em inglês):
+
+`A query limit was exceeded. Try to refine your filter parameters or query a smaller period for a more precise search.`
+
+Para evitar esse erro, reduza o intervalo de tempo da consulta ou adicione filtros específicos no campo **Filter by**, como um host, IP, status HTTP ou outro parâmetro relevante para o seu caso de uso.
+:::


### PR DESCRIPTION
… documentation

<!--
Thank you for contributing to Azion Docs! Please fill out the information below.
Use the conventional commits standard to categorize the type of change in the PR title. We recommend:
- feat: adding new content
- refactor: making minor changes
- fix: fixing errors

Don't forget to add the Jira issue code to the PR title or the GitHub issue hash.
For example: 
- [EDU-3000] refactor: modify origins page to include load balancer
- [#34] feat: add new application CLI commands
- [NO-ISSUE] fix: fix broken link in Orch doc
-->

### Related issue: EDU-5564
Four files were updated to document the 10-billion row internal query limit. Here is a summary of all changes:

---

### 1. Real-Time Events — `## Limits` / `## Limites`

**EN:** [`src/content/docs/en/pages/main-menu/reference/observe/real-time-events/real-time-events.mdx`](src/content/docs/en/pages/main-menu/reference/observe/real-time-events/real-time-events.mdx)  
**PT-BR:** [`src/content/docs/pt-br/pages/menu-principal/referencia/observe/real-time-events/real-time-events.mdx`](src/content/docs/pt-br/pages/menu-principal/referencia/observe/real-time-events/real-time-events.mdx)

Added a new row to the limits table:

| EN | PT-BR |
|---|---|
| Internal query rows read: **10 billion rows** | Linhas lidas por consulta interna: **10 bilhões de linhas** |

Added a `:::note` callout explaining:
- The limit is enforced internally by the log database
- It triggers on broad time ranges (e.g., 7 days) with no filter parameters
- The exact UI error message: `A query limit was exceeded. Try to refine your filter parameters or query a smaller period for a more precise search.`
- Mitigation: reduce the time range or add specific filters in the **Filter by** field

---

### 2. GraphQL API Error Messages

**EN:** [`src/content/docs/en/pages/devtools/api-graphql/error-responses/error-responses.mdx`](src/content/docs/en/pages/devtools/api-graphql/error-responses/error-responses.mdx)  
**PT-BR:** [`src/content/docs/pt-br/pages/devtools/api-graphql/mensagens-de-erro/mensagens-erro-gql.mdx`](src/content/docs/pt-br/pages/devtools/api-graphql/mensagens-de-erro/mensagens-erro-gql.mdx)

Added a new row to the error table with:
- **Status code:** `500`
- **Error message:** `An error occured while performing the requested operation.: Limit for rows or bytes to read exceeded, max rows: 10.00 billion, current rows: [N] billion` (exact message from the database engine)
- **Motive:** The internal 10-billion row read limit was reached due to a broad time range query with no filter parameters. Resolution: reduce the time range or add specific filters.

---

### Design decisions

- The error message is documented verbatim (including the typo `occured`) to match what users actually see in their API responses, making it searchable and recognizable.
- The `[N]` placeholder in `current rows: [N] billion` represents the variable row count that varies per query.
- The status code `500` reflects the internal server error returned by the database engine when the limit is exceeded at the infrastructure level — distinct from the `400` client-side limit errors already documented.


[EDU-3000]: https://aziontech.atlassian.net/browse/EDU-3000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ