### PR TITLE
docs: update mTLS documentation to include details on Permissive mode…

### DIFF
--- a/src/content/docs/en/pages/main-menu/reference/secure/edge-firewall/mtls.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/secure/edge-firewall/mtls.mdx
@@ -54,6 +54,10 @@ The default configuration of **mTLS** blocks accesses whose user identity can't 
 
 If your application needs special access, it is necessary to configure a permissive check (*Permissive mTLS*). Permissive checking can be configured on the *Domains* page.
 
+In **Permissive** mode, you can use the [**Client Certificate Validation**](/en/documentation/products/secure/firewall/rules-engine/) variable in the **Rules Engine for Firewall** to restrict access based on client certificate identity. This variable evaluates whether the client certificate presented in the request is valid against the configured Trusted CA. A common pattern is to deny requests where `Client Certificate Validation` is not equal to `true`, returning a `403 Forbidden` response.
+
+<LinkButton link="/en/documentation/products/guides/mtls/#adding-specific-rules-for-using-permissive-mtls" label="go to configuring Permissive mTLS rules guide" severity="secondary" />
+
 You can also change and specify the *header variables* of your **mTLS** to meet Open Banking requirements. This can be done in the **Application** configuration page, within [Azion Console](https://console.azion.com).
 
 > The list of accepted variables is available on the [Rules Engine for Application](/en/documentation/products/build/applications/rules-engine/) page.

--- a/src/content/docs/pt-br/pages/menu-principal/referencia/secure/edge-firewall/mtls.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/referencia/secure/edge-firewall/mtls.mdx
@@ -48,11 +48,15 @@ Quando temos requisições sem SNI para um Domain com mTLS no modo *Enforce*, a 
 
 > Certifique-se que suas Applications sempre usem SNI nas solicitações.
 
-## Como funciona o mTLS na Azion 
+## Como funciona o mTLS na Azion
 
 A configuração padrão do **mTLS** bloqueia os acessos cuja identidade do usuário não puder ser verificada.
 
 Se sua aplicação precisa de necessidades de acesso especiais, é necessário configurar uma verificação permissiva (*Permissive mTLS*). A verificação permissiva pode ser configurada na página *Domains*.
+
+No modo **Permissive**, você pode usar a variável [**Client Certificate Validation**](/pt-br/documentacao/produtos/secure/firewall/rules-engine/) no **Rules Engine for Firewall** para restringir o acesso com base na identidade do certificado do cliente. Essa variável avalia se o certificado do cliente apresentado na requisição é válido em relação à Trusted CA configurada. Um padrão comum é negar requisições em que `Client Certificate Validation` não seja igual a `true`, retornando uma resposta `403 Forbidden`.
+
+<LinkButton link="/pt-br/documentacao/produtos/guias/mtls/#adicione-regras-especificas-para-uso-do-permissive-mtls" label="consulte o guia de configuração de regras para Permissive mTLS" severity="secondary" />
 
 Você também pode alterar e especificar as *header variables* do seu **mTLS** para atender aos requisitos do Open Banking. Isso pode ser feito na página de configuração do **Application**, dentro do **Azion Console**.
 


### PR DESCRIPTION
… and Client Certificate Validation

<!--
Thank you for contributing to Azion Docs! Please fill out the information below.
Use the conventional commits standard to categorize the type of change in the PR title. We recommend:
- feat: adding new content
- refactor: making minor changes
- fix: fixing errors

Don't forget to add the Jira issue code to the PR title or the GitHub issue hash.
For example: 
- [EDU-3000] refactor: modify origins page to include load balancer
- [#34] feat: add new application CLI commands
- [NO-ISSUE] fix: fix broken link in Orch doc
-->

### Related issue: EDU-6447
Modificação aplicada em ambas as versões do documento de referência mTLS.

### Arquivos modificados

**EN** — [`mtls.mdx`](src/content/docs/en/pages/main-menu/reference/secure/edge-firewall/mtls.mdx:57)
**PT-BR** — [`mtls.mdx`](src/content/docs/pt-br/pages/menu-principal/referencia/secure/edge-firewall/mtls.mdx:57)

### O que foi adicionado em cada arquivo

Na seção **"How mTLS works at Azion"** / **"Como funciona o mTLS na Azion"**, após a menção ao modo Permissive:

1. **Parágrafo explicativo** sobre o uso da variável [`Client Certificate Validation`](/en/documentation/products/secure/firewall/rules-engine/) no Rules Engine for Firewall — explica que a variável avalia se o certificado do cliente é válido contra a Trusted CA configurada, e descreve o padrão comum de negar requisições onde a validação não é `true` com resposta `403 Forbidden`.

2. **`LinkButton`** com anchor preciso apontando para a seção de configuração de regras Permissive no guia correspondente:
   - EN: [`configure-mtls.mdx#adding-specific-rules-for-using-permissive-mtls`](src/content/docs/en/pages/guides/mtls/configure-mtls.mdx:67)
   - PT-BR: [`configurar-mtls.mdx#adicione-regras-especificas-para-uso-do-permissive-mtls`](src/content/docs/pt-br/pages/guias/mtls/configurar-mtls.mdx:67)

Nenhum conteúdo de configuração foi duplicado — os passos detalhados permanecem exclusivamente nos guias how-to correspondentes.

[EDU-3000]: https://aziontech.atlassian.net/browse/EDU-3000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ