### PR TITLE
docs: enhance origin configuration guide with detailed Host Header in…

### DIFF
--- a/src/content/docs/en/pages/build-journey/edit-edge-app/edit-origins/origins.mdx
+++ b/src/content/docs/en/pages/build-journey/edit-edge-app/edit-origins/origins.mdx
@@ -85,6 +85,16 @@ To implement load balancing algorithm for multiple origins, see the [guide on mu
 7. Under **Protocol Policy**, select **Enforce HTTPS**.
 8. Under **Address**, add `httpbin.org`
 9. Under **Host Header**, add `customhost.com`.
+
+:::tip[Choosing the right Host Header value]
+The **Host Header** controls which value Azion sends in the `Host` HTTP header when connecting to your origin.
+
+- **Specific domain** (e.g., `customhost.com`): Azion always sends this fixed value to the origin, regardless of the domain the user requested. Use this when your origin serves a single virtualhost or requires a specific hostname to route requests correctly.
+- **`${host}` variable**: Azion forwards the `Host` header received from the user's request directly to the origin. Use this when your origin serves multiple virtualhosts from the same address.
+
+**Important**: if your origin enforces Host-based access controls, IP allowlists tied to a specific hostname, or CDN configurations that validate the `Host` header, changing this value may cause the origin to reject requests. Verify your origin's virtualhost configuration before modifying this field.
+:::
+
 10. Leave **Path** blank.
 11. Click the **Save** button.
 
@@ -171,7 +181,7 @@ curl --request POST \
   | `type` | Sets the new Connector type to `http`. For more information on load balancing, check [Work with multiple origins](/en/documentation/products/guides/build/multiple-origins/). |
   | `addresses` | Takes a list of objects for each address of the origin. Since this is an entry of the single origin type, you may only send one object with the `address` value in the array. |
   | `transport_policy` | When `https`, enforces an HTTPS connection with the origin, not affecting the protocol from user requests. |
-  | `host` | Sets the string in value as the value of the `Host` header sent to the origin. |
+  | `host` | Sets the value of the `Host` header sent to the origin. Use a specific FQDN (e.g., `customhost.com`) when your origin serves a single virtualhost. Use `${host}` to forward the `Host` header received from the user's request, which is useful when your origin serves multiple virtualhosts. If your origin enforces Host-based access controls, ensure this value matches what the origin expects. |
 
 2. You'll receive a response similar to this:
 
@@ -288,7 +298,7 @@ curl --location 'https://api.azionapi.net/edge_applications/<application_id>/ori
   | `origin_type` | Sets the new origin type to `single_origin`. For more information on load balancing, check [Work with multiple origins](/en/documentation/products/guides/build/multiple-origins/). |
   | `addresses` | Takes a list of objects for each address of the origin. Since this is an entry of the single origin type, you may only send one object with the `address` value in the array. |
   | `origin_protocol_policy` | When `https`, enforces an HTTPS connection with the origin, not affecting the protocol from user requests. |
-  | `host_header` | Sets the string in value as the value of the `Host` header sent to the origin. |
+  | `host_header` | Sets the value of the `Host` header sent to the origin. Use a specific FQDN (e.g., `customhost.com`) when your origin serves a single virtualhost. Use `${host}` to forward the `Host` header received from the user's request, which is useful when your origin serves multiple virtualhosts. If your origin enforces Host-based access controls, ensure this value matches what the origin expects. |
 
 2. You'll receive a response similar to this:
 

--- a/src/content/docs/pt-br/pages/build-jornada/edite-edge-app/origins.mdx
+++ b/src/content/docs/pt-br/pages/build-jornada/edite-edge-app/origins.mdx
@@ -84,6 +84,16 @@ Para implementar algoritmos de balanceamento de carga para múltiplas origens, c
 7. Em **Protocol Policy**, selecione **Enforce HTTPS**.
 8. Em **Address**, adicione `httpbin.org`.
 9. Em **Host Header**, adicione `customhost.com`.
+
+:::tip[Escolhendo o valor correto para o Host Header]
+O **Host Header** controla qual valor a Azion envia no cabeçalho HTTP `Host` ao se conectar à sua origem.
+
+- **Domínio específico** (ex.: `customhost.com`): a Azion sempre envia esse valor fixo para a origem, independentemente do domínio solicitado pelo usuário. Use quando sua origem serve um único virtualhost ou exige um hostname específico para rotear as requisições corretamente.
+- **Variável `${host}`**: a Azion repassa o cabeçalho `Host` recebido da requisição do usuário diretamente para a origem. Use quando sua origem serve múltiplos virtualhosts a partir do mesmo endereço.
+
+**Importante**: se sua origem aplica controles de acesso baseados no Host, allowlists de IP vinculadas a um hostname específico ou configurações de CDN que validam o cabeçalho `Host`, alterar esse valor pode fazer com que a origem rejeite as requisições. Verifique a configuração de virtualhost da sua origem antes de modificar este campo.
+:::
+
 10. Deixe **Path** em branco.
 11. Clique no botão **Save**.
 
@@ -170,7 +180,7 @@ curl --request POST \
 | `type` | Define o novo tipo de Connector como `http`. Para mais informações sobre balanceamento de carga, confira [como configurar múltiplas origens](/pt-br/documentacao/produtos/guias/build/configure-multiplas-origens/). |
 | `addresses` | Recebe uma lista de objetos para cada endereço da origem. Como esta é uma entrada do tipo origem única, você pode enviar apenas um objeto com o valor de `address` dentro do array. |
 | `transport_policy` | Quando `https`, força uma conexão HTTPS com a origem, não afetando o protocolo das requisições do usuário. |
-| `host` | Define a string como o valor do cabeçalho `Host` enviado para a origem. |
+| `host` | Define o valor do cabeçalho `Host` enviado para a origem. Use um FQDN específico (ex.: `customhost.com`) quando sua origem serve um único virtualhost. Use `${host}` para repassar o cabeçalho `Host` recebido da requisição do usuário, o que é útil quando sua origem serve múltiplos virtualhosts. Se sua origem aplica controles de acesso baseados no Host, certifique-se de que este valor corresponde ao que a origem espera. |
 
 2. Você receberá uma resposta semelhante a esta:
 
@@ -283,7 +293,7 @@ curl --location 'https://api.azionapi.net/edge_applications/<application_id>/ori
 | `origin_type` | Define o novo tipo de origem para `single_origin`. Para mais informações sobre balanceamento de carga, confira [como configurar múltiplas origens com Load Balancer](/pt-br/documentacao/produtos/guias/build/configure-multiplas-origens/). |
 | `addresses` | Recebe uma lista de objetos para cada endereço da origem. Como esta é uma entrada do tipo origem única, você pode enviar apenas um objeto com o valor de `address` dentro do array. |
 | `origin_protocol_policy` | Quando `https`, força uma conexão HTTPS com a origem, não afetando o protocolo das requisições do usuário. |
-| `host_header` | Define a string como o valor do cabeçalho `Host` enviado para a origem. |
+| `host_header` | Define o valor do cabeçalho `Host` enviado para a origem. Use um FQDN específico (ex.: `customhost.com`) quando sua origem serve um único virtualhost. Use `${host}` para repassar o cabeçalho `Host` recebido da requisição do usuário, o que é útil quando sua origem serve múltiplos virtualhosts. Se sua origem aplica controles de acesso baseados no Host, certifique-se de que este valor corresponde ao que a origem espera. |
 
 2. Você receberá uma resposta semelhante a esta:
 


### PR DESCRIPTION
…structions

<!--
Thank you for contributing to Azion Docs! Please fill out the information below.
Use the conventional commits standard to categorize the type of change in the PR title. We recommend:
- feat: adding new content
- refactor: making minor changes
- fix: fixing errors

Don't forget to add the Jira issue code to the PR title or the GitHub issue hash.
For example: 
- [EDU-3000] refactor: modify origins page to include load balancer
- [#34] feat: add new application CLI commands
- [NO-ISSUE] fix: fix broken link in Orch doc
-->

### Related issue: EDU-6450


---

## Files Modified

### EN — [`src/content/docs/en/pages/build-journey/edit-edge-app/edit-origins/origins.mdx`](src/content/docs/en/pages/build-journey/edit-edge-app/edit-origins/origins.mdx:89)

### PT-BR — [`src/content/docs/pt-br/pages/build-jornada/edite-edge-app/origins.mdx`](src/content/docs/pt-br/pages/build-jornada/edite-edge-app/origins.mdx:88)

---

## Changes Applied (identical structure in both languages)

### 1. Console - Origins tab — `:::tip` callout after step 9

Added a contextual tip block **"Choosing the right Host Header value"** / **"Escolhendo o valor correto para o Host Header"** explaining:

- **Specific domain** / **Domínio específico**: Azion sends a fixed hostname — use for single-virtualhost origins.
- **`${host}` variable** / **Variável `${host}`**: Azion forwards the user's `Host` header — use for multi-virtualhost origins.
- **Risk warning**: if the origin enforces Host-based access controls, IP allowlists, or CDN validation tied to a specific hostname, changing this value may cause the origin to reject requests.

### 2. API v4 (Connectors) tab — `host` field description enriched

The `host` key now explains both usage patterns and the access-control implication, replacing the generic "Sets the string in value as the value of the `Host` header sent to the origin."

### 3. API v3 tab — `host_header` field description enriched

Same enrichment applied to the `host_header` key in the legacy API v3 parameter table.


[EDU-3000]: https://aziontech.atlassian.net/browse/EDU-3000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ