### PR TITLE
docs: correct comparison operator and add mTLS forwarding tip in Rule…

### DIFF
--- a/src/content/docs/en/pages/secure-journey/edit-edge-firewall/work-with-rules-engine.mdx
+++ b/src/content/docs/en/pages/secure-journey/edit-edge-firewall/work-with-rules-engine.mdx
@@ -35,7 +35,7 @@ To create a rule:
 4. Click the **+ Rule** button.
 5. Give your rule a name and, optionally, a description.
 6. In the **Criteria** section, select the `SSL Verification Status` variable.
-7. As a comparison operator, select `is esqual`.
+7. As a comparison operator, select `is equal`.
 8. As an argument, select `Missing Client Certificate`.
 9. In the **Behaviors** section, select **Set Custom Response**.
 10. As arguments:
@@ -132,5 +132,10 @@ Check the [Azion API documentation](https://api.azion.com/) to know more about a
 </Fragment>
 
 </Tabs>
+
 ---
+
+:::tip
+If you need to forward the authenticated client's identity to your origin server using mTLS — for example, passing the client certificate Common Name (CN) via the `client_cn` header — use [Rules Engine for Applications](/en/documentation/products/build/applications/rules-engine/) with the `${ssl_client_s_dn_parsed}` variable and the **Add Request Header** behavior. See [Specifying mTLS variables in HTTP headers](/en/documentation/products/guides/secure/mtls/#specifying-mtls-variables-in-http-headers) for a complete guide.
+:::
 

--- a/src/content/docs/pt-br/pages/secure-jornada/editar-edge-firewall/trabalhar-com-rules-engine.mdx
+++ b/src/content/docs/pt-br/pages/secure-jornada/editar-edge-firewall/trabalhar-com-rules-engine.mdx
@@ -132,5 +132,11 @@ Consulte a [documentação da API Azion](https://api.azion.com/) para saber mais
 </Fragment>
 
 </Tabs>
+
+---
+
+:::tip
+Se você precisa encaminhar a identidade do cliente autenticado para o servidor de origem via mTLS — por exemplo, passando o Common Name (CN) do certificado do cliente pelo header `client_cn` — use o [Rules Engine para Applications](/pt-br/documentacao/produtos/build/applications/rules-engine/) com a variável `${ssl_client_s_dn_parsed}` e o behavior **Add Request Header**. Consulte [Especificando variáveis mTLS nos headers HTTP](/pt-br/documentacao/produtos/guias/mtls/#especificando-variaveis-mtls-no-header-da-aplicacao) para um guia completo.
+:::
 ---
 


### PR DESCRIPTION
…s Engine guide

<!--
Thank you for contributing to Azion Docs! Please fill out the information below.
Use the conventional commits standard to categorize the type of change in the PR title. We recommend:
- feat: adding new content
- refactor: making minor changes
- fix: fixing errors

Don't forget to add the Jira issue code to the PR title or the GitHub issue hash.
For example: 
- [EDU-3000] refactor: modify origins page to include load balancer
- [#34] feat: add new application CLI commands
- [NO-ISSUE] fix: fix broken link in Orch doc
-->

### Related issue: EDU-6451


The revised approach — replacing the full section with a `:::tip` cross-reference — is technically correct and the right solution for this document. Two additional fixes were applied directly to the file:

---

### Fix 1 — Removed redundant trailing `---` separator

The tip block was followed by a stray `---` horizontal rule with no content after it. Removed to keep the file clean.

### Fix 2 — Fixed pre-existing typo in Console steps

Line 37 had `is esqual` → corrected to `is equal`.

---

### Final state of [`work-with-rules-engine.mdx`](src/content/docs/en/pages/secure-journey/edit-edge-firewall/work-with-rules-engine.mdx)

The document now:
- Keeps the Firewall Rules Engine guide technically accurate (no incorrect behaviors or variables introduced)
- Answers the user's question from the ticket via a `:::tip` that points to [`${ssl_client_s_dn_parsed}`](src/content/docs/en/pages/main-menu/reference/build/edge-application/rules-engine.mdx:130) and the **Add Request Header** behavior in Rules Engine for Applications
- Links directly to the anchor [`#specifying-mtls-variables-in-http-headers`](src/content/docs/en/pages/secure-journey/transport-layer-security/mtls.mdx:460) in the mTLS guide, which already contains the full Console + API walkthrough for this use case
- Avoids duplicating content that already exists in the correct document


[EDU-3000]: https://aziontech.atlassian.net/browse/EDU-3000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ