### PR TITLE
docs: enhance Upstash Rate Limit template documentation with rate lim…

### DIFF
--- a/src/content/docs/en/pages/guides/marketplace/templates/upstash-rate-limiting.mdx
+++ b/src/content/docs/en/pages/guides/marketplace/templates/upstash-rate-limiting.mdx
@@ -77,9 +77,19 @@ The link to the application allows you to see it on the browser. However, it tak
 
 ### Key configurations
 
-The **Upstash Rate Limit** template creates a new Azion application and its domain. It also creates a function, to provide the arguments for the rate limiting, and a new repository in your GitHub account based on a [public template](https://github.com/aziontech/), including a GitHub Action to enable continuous depployment.
+The **Upstash Rate Limit** template creates a new Azion application and its domain. It also creates a function, to provide the arguments for the rate limiting, and a new repository in your GitHub account based on a [public template](https://github.com/aziontech/), including a GitHub Action to enable continuous deployment.
 
 In this function, the `upstash/redis` and `upstash/ratelimit` libraries are integrated, connecting to your Upstash Global Database and checking in the `/login` route if it's within the configured **Window** and **Limit**. The key for limits is metadata `["remote_addr"]`.
+
+#### Rate limiting behavior
+
+When a client exceeds the configured **Request Limit** within the defined **Window Limit**, the function returns an `HTTP 429 Too Many Requests` response. The client isn't permanently blocked — the limitation is temporary and tied directly to the **Window Limit** you set.
+
+Once the time window resets, the request counter clears and the client can make requests again up to the configured limit. For example, if you set a limit of `6` requests per `10 s`, a client that exceeds 6 requests within any 10-second window will receive `429` responses until that window expires. After the window resets, requests are served normally.
+
+:::tip
+Adjust the **Window Limit** and **Request Limit** values in your function's arguments to fine-tune the rate limiting behavior for your use case. You can update these settings at any time through [Azion Console](https://console.azion.com).
+:::
 
 ___
 

--- a/src/content/docs/pt-br/pages/guias/marketplace/templates/upstash-rate-limiting.mdx
+++ b/src/content/docs/pt-br/pages/guias/marketplace/templates/upstash-rate-limiting.mdx
@@ -78,9 +78,19 @@ Ao clicar no link da application, você pode ver como ela fica no navegador. No 
 
 ### Principais configurações
 
-O template **Upstash Rate Limit** cria uma nova application e seu domínio na Azion. Ele também cria uma function, para fornecer os argumentos do rate limiting, e um novo repositório em sua conta do GitHub com base em um [template público](https://github.com/aziontech/) que inclui uma GitHUb action para facilitar um continuous depployment.
+O template **Upstash Rate Limit** cria uma nova application e seu domínio na Azion. Ele também cria uma function, para fornecer os argumentos do rate limiting, e um novo repositório em sua conta do GitHub com base em um [template público](https://github.com/aziontech/) que inclui uma GitHub Action para facilitar um continuous deployment.
 
-Nesta função, as bibliotecas `upstash/redis` e `upstash/ratelimit` são integradas, conectando-se ao seu Banco de Dados Global Upstash e verificando na rota`/login` se está dentro dos **Window** e **Limit** configurados. A chave para os limites são os metadados `["remote_addr"]`.
+Nesta função, as bibliotecas `upstash/redis` e `upstash/ratelimit` são integradas, conectando-se ao seu Banco de Dados Global Upstash e verificando na rota `/login` se está dentro dos **Window** e **Limit** configurados. A chave para os limites são os metadados `["remote_addr"]`.
+
+#### Comportamento do rate limiting
+
+Quando um cliente excede o **Request Limit** configurado dentro do **Window Limit** definido, a função retorna uma resposta `HTTP 429 Too Many Requests`. O cliente não é bloqueado permanentemente — a limitação é temporária e está diretamente vinculada ao **Window Limit** configurado.
+
+Quando a janela de tempo é reiniciada, o contador de requisições é zerado e o cliente pode fazer requisições novamente até o limite configurado. Por exemplo, se você definir um limite de `6` requisições por `10 s`, um cliente que exceder 6 requisições em qualquer janela de 10 segundos receberá respostas `429` até que essa janela expire. Após a reinicialização da janela, as requisições são atendidas normalmente.
+
+:::tip
+Ajuste os valores de **Window Limit** e **Request Limit** nos argumentos da sua function para ajustar o comportamento do rate limiting ao seu caso de uso. Você pode atualizar essas configurações a qualquer momento pelo [Azion Console](https://console.azion.com).
+:::
 
 ___
 


### PR DESCRIPTION
…iting behavior and configuration tips

<!--
Thank you for contributing to Azion Docs! Please fill out the information below.
Use the conventional commits standard to categorize the type of change in the PR title. We recommend:
- feat: adding new content
- refactor: making minor changes
- fix: fixing errors

Don't forget to add the Jira issue code to the PR title or the GitHub issue hash.
For example: 
- [EDU-3000] refactor: modify origins page to include load balancer
- [#34] feat: add new application CLI commands
- [NO-ISSUE] fix: fix broken link in Orch doc
-->

### Related issue: EDU-6455

clarify rate limiting behavior and duration in Upstash Rate Limit template`

---

**Description:**

Adds a new subsection — **Rate limiting behavior** / **Comportamento do rate limiting** — to the Upstash Rate Limit template guide (EN and PT-BR), addressing a recurring support question about how long an IP remains limited after exceeding the request threshold.

**Context:**
Users were confused about whether exceeding the request limit results in a permanent IP block. Support clarified that the Rate Limit feature does not block IPs — it throttles requests by returning `HTTP 429 Too Many Requests` until the configured time window resets.

**Changes:**

- `src/content/docs/en/pages/guides/marketplace/templates/upstash-rate-limiting.mdx`
  - Added `#### Rate limiting behavior` subsection under `### Key configurations`
  - Explains that clients are **not permanently blocked** — the limitation is temporary and tied to the **Window Limit**
  - Includes a concrete example using the default values (`6` requests per `10 s`)
  - Adds a `:::tip` directing users to adjust parameters via Azion Console
  - Fixed typo: `continuous depployment` → `continuous deployment`

- `src/content/docs/pt-br/pages/guias/marketplace/templates/upstash-rate-limiting.mdx`
  - Added equivalent `#### Comportamento do rate limiting` subsection (PT-BR translation)
  - Fixed typos: `continuous depployment` → `continuous deployment`, `GitHUb action` → `GitHub Action`, missing space before `` `/login` ``

**Type:** `docs improvement` · `support-driven`

**Related:** Support ticket — Upstash Rate Limiting duration clarification


[EDU-3000]: https://aziontech.atlassian.net/browse/EDU-3000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ