### PR TITLE
docs: add section on searching by request ID in Real-Time Events logs

### DIFF
--- a/src/content/docs/en/pages/observe-journey/real-time-events/analyze-logs/understand-logs.mdx
+++ b/src/content/docs/en/pages/observe-journey/real-time-events/analyze-logs/understand-logs.mdx
@@ -32,5 +32,16 @@ For example, if you notice your application isn't properly exhibiting what you c
 You can query a filtered search to receive specific variables and values according to what you're analyzing. This could be the ideal choice if you already know what type of information you're going to analyze.
 
 For example, if you suspect there may be malicious users trying to access your application, you can query the **Applications** data source and analyze variables such as `$city`, `$host`, `$http_referrer`, `$remote_addr`, `$request_uri`, and so on.
-<br /><br />
+
+---
+
+## Searching by request ID
+
+The `requestId` field stores a unique identifier for each request. Example: `5f222ae5938482c32a822dbf15e19f0f`.
+
+When you retrieve a request ID from an HTTP response header (such as `X-Request-Id`), it may include a numeric suffix separated by a hyphen. For example: `5f222ae5938482c32a822dbf15e19f0f-1234`. This suffix is appended at the network layer and isn't stored in the log.
+
+To search for a request in **Real-Time Events** or via the **GraphQL API**, use only the base identifier without the suffix. Searching with the full string, including the suffix, may return no results or a `400` error.
+
+For example, if the header returns `5f222ae5938482c32a822dbf15e19f0f-1234`, filter by `5f222ae5938482c32a822dbf15e19f0f`.
 

--- a/src/content/docs/pt-br/pages/observe-jornada/real-time-events/analise-logs/entenda-logs.mdx
+++ b/src/content/docs/pt-br/pages/observe-jornada/real-time-events/analise-logs/entenda-logs.mdx
@@ -32,6 +32,16 @@ Por exemplo, se você perceber que sua aplicação não está exibindo corretame
 Você pode realizar uma consulta filtrada para receber variáveis e valores específicos de acordo com o que está analisando. Isso pode ser a escolha ideal se você já sabe que tipo de informação vai analisar.
 
 Por exemplo, se você suspeitar que pode haver usuários maliciosos tentando acessar sua edge applicatiom, pode consultar o data source **Applications** e analisar variáveis como `$city`, `$host`, `$http_referrer`, `$remote_addr`, `$request_uri`, e assim por diante.
-<br /><br />
+
 ---
+
+## Pesquisar por request ID
+
+O campo `requestId` armazena um identificador único para cada requisição. Exemplo: `5f222ae5938482c32a822dbf15e19f0f`.
+
+Ao recuperar um request ID de um header de resposta HTTP (como `X-Request-Id`), ele pode incluir um sufixo numérico separado por hífen. Por exemplo: `5f222ae5938482c32a822dbf15e19f0f-1234`. Esse sufixo é adicionado na camada de rede e não é armazenado no log.
+
+Para pesquisar uma requisição no **Real-Time Events** ou via **GraphQL API**, use apenas o identificador base, sem o sufixo. Pesquisar com a string completa, incluindo o sufixo, pode retornar nenhum resultado ou um erro `400`.
+
+Por exemplo, se o header retornar `5f222ae5938482c32a822dbf15e19f0f-1234`, filtre por `5f222ae5938482c32a822dbf15e19f0f`.
 


### PR DESCRIPTION
<!--
Thank you for contributing to Azion Docs! Please fill out the information below.
Use the conventional commits standard to categorize the type of change in the PR title. We recommend:
- feat: adding new content
- refactor: making minor changes
- fix: fixing errors

Don't forget to add the Jira issue code to the PR title or the GitHub issue hash.
For example: 
- [EDU-3000] refactor: modify origins page to include load balancer
- [#34] feat: add new application CLI commands
- [NO-ISSUE] fix: fix broken link in Orch doc
-->

### Related issue: EDU-6456

Texto para a descrição da branch no GitHub:

**docs: add request ID search guidance to understand-logs (EN/PT-BR)**

Adds a new section "Searching by request ID" to the understand-logs guide (EN and PT-BR) explaining that the `-XXXX` suffix appended to request IDs in HTTP response headers is not stored in logs. Users must search using only the base identifier to avoid 400 errors or empty results in Real-Time Events and the GraphQL API.


[EDU-3000]: https://aziontech.atlassian.net/browse/EDU-3000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ