### PR TITLE
docs: update reCAPTCHA integration guide with enhanced meta tags and …

### DIFF
--- a/src/content/docs/en/pages/guides/marketplace/integrations/recaptcha.mdx
+++ b/src/content/docs/en/pages/guides/marketplace/integrations/recaptcha.mdx
@@ -1,7 +1,7 @@
 ---
 title: "How to Install the reCAPTCHA Integration"
 description: 'reCAPTCHA is an integration to block attacks from bots, SPAM and others.'
-meta_tags: 'recaptcha, bots, spam, edge computing'
+meta_tags: 'recaptcha, bots, spam, captcha, bot protection, domain configuration, troubleshooting'
 namespace: docs_use_case_recaptcha
 permalink: /documentation/products/guides/recaptcha/
 ---
@@ -46,7 +46,7 @@ To do so, follow these steps:
     - The version of reCAPTCHA you want to use (you can choose from v2 or v3).
         - If you choose v2, you'll be prompted to choose what kind of test you want to apply on your website. The options are: "*I'm not a robot checkbox*", "*Invisible reCaptcha*", and "*reCaptcha Android*".
         - **Important**: Azion reCAPTCHA integration was conceived to work with the v2 invisible option.
-    - The domain you want to run the reCAPTCHA. Remember to ignore the `http://` or `https://` for the domain name.
+    - The domain you want to run the reCAPTCHA. Remember to ignore the `http://` or `https://` for the domain name. If you're testing through an Azion hostname, add it here as well (see [Troubleshooting](#recaptcha-not-working-on-azion-domain)).
     - You have to accept the reCAPTCHA terms of service.
     - You have to choose if you want to receive alerts from Google about your site, such as misconfigurations and others.
 4. Once you fill in all the information, click the **Submit** button.
@@ -152,5 +152,30 @@ Done. Now the **reCAPTCHA** integration is running for every request made to the
 Watch a video about how to install the reCAPTCHA integration through Azion Marketplace on Azion’s YouTube channel:
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/X-S1qDdVVbg?si=J7dzeymFxJH0P_Zs" loading="lazy" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+---
+
+## Troubleshooting
+
+### reCAPTCHA not working on Azion domain
+
+**Symptom**: reCAPTCHA fails to load or returns an error when accessing your application through an Azion hostname (for example, `xxxx.map.azionedge.net`).
+
+**Cause**: Google reCAPTCHA validates requests against a list of authorized domains. If the Azion hostname isn't registered in your reCAPTCHA settings, Google will reject the challenge, causing the integration to fail.
+
+**Solution**: Add your Azion domain to the list of authorized domains in the Google reCAPTCHA admin console.
+
+1. Go to the [Google reCAPTCHA admin console](https://www.google.com/recaptcha/admin).
+2. Select the site you registered for this integration.
+3. Under **Domains**, click **Add a domain**.
+4. Enter your Azion hostname. For example: `xxxx.map.azionedge.net`.
+   - If you're using a custom domain, add that domain as well.
+5. Click **Save**.
+
+After saving, reCAPTCHA will recognize requests coming from the Azion hostname and the integration will work as expected.
+
+:::tip
+During development and testing, add your Azion internal hostname (`*.map.azionedge.net`) to the authorized domains list. Once you point your custom domain to Azion, add that domain too and remove the internal hostname if it's no longer needed.
+:::
 
 ---

--- a/src/content/docs/pt-br/pages/guias/marketplace/integrations/recaptcha.mdx
+++ b/src/content/docs/pt-br/pages/guias/marketplace/integrations/recaptcha.mdx
@@ -3,7 +3,7 @@ title: "Use a integração reCAPTCHA no Marketplace"
 description: >-
   A integração reCaptcha protege contra ataques mal intencionados de bots, SPAM
   e outros.
-meta_tags: 'edge computing, recaptcha, captcha, spam, bots'
+meta_tags: 'recaptcha, captcha, spam, bots, proteção contra bots, configuração de domínio, troubleshooting'
 namespace: docs_use_case_recaptcha
 permalink: /documentacao/produtos/guias/recaptcha/
 ---
@@ -47,7 +47,7 @@ Para fazer isso, siga os passos:
    - A versão do reCAPTCHA que você deseja usar (você pode escolher entre v2 ou v3).
       - Se você escolher a v2, será solicitado que escolha o tipo de teste que deseja aplicar em seu site. As opções são: "*I'm not a robot checkbox*", "*Invisible reCaptcha*" e "*reCaptcha Android*".
       - **Importante**: a integração reCAPTCHA da Azion foi concebida para funcionar com a opção v2 invisível.
-   - O domínio onde você deseja executar o reCAPTCHA. Lembre-se de ignorar o `http://`ou `https://` para adicionar o nome de domínio.
+   - O domínio onde você deseja executar o reCAPTCHA. Lembre-se de ignorar o `http://`ou `https://` para adicionar o nome de domínio. Se você estiver testando por meio de um hostname da Azion, adicione-o aqui também (consulte [Troubleshooting](#recaptcha-nao-funciona-no-dominio-da-azion)).
    - Você precisa aceitar os termos de serviço.
    - Você tem que escolher se deseja receber alertas do Google sobre seu site, como erros de configuração e outros.
 4. Depois de preencher todas as informações, clique no botão **Submit**.
@@ -149,5 +149,30 @@ Agora, no Console, você deve configurar seu domínio para que ele seja protegid
 10. Clique no botão **Save**.
 
 Pronto. Agora a integração **reCAPTCHA** está em execução para cada requisição feita ao domínio que você indicou.
+
+---
+
+## Troubleshooting
+
+### reCAPTCHA não funciona no domínio da Azion
+
+**Sintoma**: o reCAPTCHA falha ao carregar ou retorna um erro ao acessar sua aplicação por meio de um hostname da Azion (por exemplo, `xxxx.map.azionedge.net`).
+
+**Causa**: o Google reCAPTCHA valida as requisições em relação a uma lista de domínios autorizados. Se o hostname da Azion não estiver registrado nas configurações do reCAPTCHA, o Google rejeitará o desafio, fazendo com que a integração falhe.
+
+**Solução**: adicione seu domínio da Azion à lista de domínios autorizados no painel de administração do Google reCAPTCHA.
+
+1. Acesse o [painel de administração do Google reCAPTCHA](https://www.google.com/recaptcha/admin).
+2. Selecione o site que você registrou para esta integração.
+3. Em **Domains**, clique em **Add a domain**.
+4. Insira seu hostname da Azion. Por exemplo: `xxxx.map.azionedge.net`.
+   - Se você estiver usando um domínio personalizado, adicione-o também.
+5. Clique em **Save**.
+
+Após salvar, o reCAPTCHA reconhecerá as requisições provenientes do hostname da Azion e a integração funcionará conforme esperado.
+
+:::tip
+Durante o desenvolvimento e os testes, adicione seu hostname interno da Azion (`*.map.azionedge.net`) à lista de domínios autorizados. Quando você apontar seu domínio personalizado para a Azion, adicione esse domínio também e remova o hostname interno se ele não for mais necessário.
+:::
 
 ---


### PR DESCRIPTION
…troubleshooting section

<!--
Thank you for contributing to Azion Docs! Please fill out the information below.
Use the conventional commits standard to categorize the type of change in the PR title. We recommend:
- feat: adding new content
- refactor: making minor changes
- fix: fixing errors

Don't forget to add the Jira issue code to the PR title or the GitHub issue hash.
For example: 
- [EDU-3000] refactor: modify origins page to include load balancer
- [#34] feat: add new application CLI commands
- [NO-ISSUE] fix: fix broken link in Orch doc
-->

### Related issue: EDU-6457

Changes replicated to both EN and PT-BR versions. Here's a full summary of all modifications:

---

## EN — [`recaptcha.mdx`](src/content/docs/en/pages/guides/marketplace/integrations/recaptcha.mdx)

| Change | Location | Detail |
|---|---|---|
| `meta_tags` updated | Line 4 | Removed deprecated `edge computing`; added `captcha, bot protection, domain configuration, troubleshooting` |
| Cross-reference added | Line 49 (domain registration step) | `(see Troubleshooting if using an Azion hostname)` with anchor link |
| New `## Troubleshooting` section | End of file | Symptom / Cause / Solution / Tip callout |

---

## PT-BR — [`recaptcha.mdx`](src/content/docs/pt-br/pages/guias/marketplace/integrations/recaptcha.mdx)

| Change | Location | Detail |
|---|---|---|
| `meta_tags` updated | Line 6 | Removed deprecated `edge computing`; added `proteção contra bots, configuração de domínio, troubleshooting` |
| Cross-reference added | Line 50 (domain registration step) | `(consulte Troubleshooting)` with anchor link `#recaptcha-nao-funciona-no-dominio-da-azion` |
| New `## Troubleshooting` section | End of file | Sintoma / Causa / Solução / Tip callout — fully translated to PT-BR following Azion localization rules (UI labels kept in English, technical terms preserved) |


[EDU-3000]: https://aziontech.atlassian.net/browse/EDU-3000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ