### PR TITLE
Update HTTP error status codes documentation with versioned image URL…

### DIFF
--- a/src/content/docs/en/pages/main-menu/reference/services/support/http-error-status-codes.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/services/support/http-error-status-codes.mdx
@@ -10,7 +10,7 @@ While using third-party web services implemented and hosted on Azion you may enc
 
 To inform you of these errors, you'll receive a message similar to this:
 
-![Example - HTTP Error Status Codes](/assets/docs/images/uploads/http-error-status-codes.png)
+![Example - HTTP Error Status Codes](/assets/docs/images/uploads/http-error-status-codes.png?v=2)
 
 - The **Title** is a textual representation of the received HTTP status code. Example: `Page not Found`, `Forbidden`, or `Internal Server Error`.
 - The **Error Details** section provides you the information related to the error, including:
@@ -151,6 +151,10 @@ When a 500 error page is returned by Azion, the **Edge Location** field displays
 A 500 Internal Server Error usually requires action on the server's end to be fixed. In this case, you can refresh the page, clear browser cache and cookies, wait for a while, and check for updates from the website's support or status page as options while the server is able to process your requests adequately.
 
 If the issue persists, contact the site owner to confirm that the system is stable or lacking exception handling.
+
+:::note
+If you're the site owner and migrating to Azion, a protocol mismatch between your origin and the Rules Engine can cause 500 errors. Check the **Protocol Policy** settings in [Connectors](/documentation/products/secure/connectors/) to ensure the protocol used to connect to your origin matches your application's requirements.
+:::
 
 ### 502 Bad Gateway
 

--- a/src/content/docs/pt-br/pages/menu-principal/referencia/servicos/http-error-status-codes.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/referencia/servicos/http-error-status-codes.mdx
@@ -10,7 +10,7 @@ Ao utilizar serviços web de terceiros implementados e hospedados na Azion, voc�
 
 Para lhe informar sobre esses erros, você receberá uma mensagem semelhante a esta:
 
-![Exemplo - Códigos de Status de Erro HTTP](/assets/docs/images/uploads/http-error-status-codes.png)
+![Exemplo - Códigos de Status de Erro HTTP](/assets/docs/images/uploads/http-error-status-codes.png?v=2)
 
 - O **título** é uma representação textual do código de status HTTP recebido. Exemplo: `Page not Found`, `Forbidden`, or `Internal Server Error`.
 - A seção **Error Details** fornece informações relacionadas ao erro, incluindo:
@@ -151,6 +151,10 @@ Quando a Azion retorna uma página de erro 500, o campo **Edge Location** exibe 
 Um 500 Internal Server Error geralmente requer ação no servidor para ser corrigido. Neste caso, você pode atualizar a página, limpar o cache e os cookies do navegador, esperar um pouco e verificar as atualizações na página de suporte ou status do site como opções enquanto o servidor é capaz de processar suas requisições adequadamente.
 
 Se o problema persistir, entre em contato com o proprietário do site para confirmar que o sistema está estável ou falta tratamento de exceção.
+
+:::note
+Se você é o proprietário do site e está migrando para a Azion, uma incompatibilidade de protocolo entre sua origem e o Rules Engine pode causar erros 500. Verifique as configurações de **Protocol Policy** em [Connectors](/documentacao/produtos/secure/connectors/) para garantir que o protocolo usado para se conectar à sua origem corresponde aos requisitos da sua aplicação.
+:::
 
 ### 502 Bad Gateway
 


### PR DESCRIPTION
…s and additional note for site owners migrating to Azion

<!--
Thank you for contributing to Azion Docs! Please fill out the information below.
Use the conventional commits standard to categorize the type of change in the PR title. We recommend:
- feat: adding new content
- refactor: making minor changes
- fix: fixing errors

Don't forget to add the Jira issue code to the PR title or the GitHub issue hash.
For example: 
- [EDU-3000] refactor: modify origins page to include load balancer
- [#34] feat: add new application CLI commands
- [NO-ISSUE] fix: fix broken link in Orch doc
-->

### Related issue: EDU-6458


## docs: sync HTTP error status codes with EN and PT-BR updates

Replicates two changes from the EN version to the PT-BR counterpart of the HTTP Error Status Codes reference page.

**Changes:**
- Updated image URL with `?v=2` cache-bust parameter to match EN version.
- Added a `:::note` callout after the 500 Internal Server Error "How to solve it" section, informing site owners that a protocol mismatch between the origin and Rules Engine can cause 500 errors during migration to Azion, with a link to the Connectors documentation.

**Files changed:**
- `src/content/docs/pt-br/pages/menu-principal/referencia/servicos/http-error-status-codes.mdx`
- `src/content/docs/en/pages/main-menu/reference/services/support/http-error-status-codes.mdx`


[EDU-3000]: https://aziontech.atlassian.net/browse/EDU-3000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ