### PR TITLE
Add note about IPv6 policy search limitations in conditional access d…

### DIFF
--- a/src/content/docs/en/pages/guides/accounts/conditional-access-by-ip.mdx
+++ b/src/content/docs/en/pages/guides/accounts/conditional-access-by-ip.mdx
@@ -28,6 +28,8 @@ This policy is available to customers with **Enterprise** and **Mission-Critical
 To configure a conditional access by IP address policy, you must be **Account Owner** or have *managing policies* privileges. If you aren't an **Account Owner** or have these privileges, the system returns an Error 403.
 
 Currently, an account can have only *1 configuration for this policy*, containing up to 200 rules. The IP Addresses can be either IPv4 or IPv6.
+
+Searching or filtering policies by IPv6 address isn't supported yet. This capability is currently under development.
 :::
 
 1. Run the following `POST` request in your terminal, replacing `[Token]` with your [personal token](/en/documentation/products/guides/personal-tokens/) to configure your policy.

--- a/src/content/docs/pt-br/pages/guias/contas/conditional-access-by-ip.mdx
+++ b/src/content/docs/pt-br/pages/guias/contas/conditional-access-by-ip.mdx
@@ -28,6 +28,8 @@ Esta política está disponível para clientes com o [suporte](https://www.azion
 Para configurar uma política de acesso condicional por endereço IP, você deve ser **Account Owner** ou ter privilégios de *managing policies*. Se você não for um **Account Owner** ou não tiver esses privilégios, o sistema retornará um Erro 403.
 
 Atualmente, uma conta pode ter apenas *1 política configurada*, contendo até 200 regras. Os endereços IP podem ser tanto IPv4 quanto IPv6.
+
+A busca ou filtragem de políticas por endereço IPv6 ainda não é suportada. Essa funcionalidade está atualmente em desenvolvimento.
 :::
 
 1. Execute a seguinte requisição `POST` no seu terminal, substituindo `[Token]` pelo seu [personal token](/en/documentation/products/guides/personal-tokens/) para configurar sua política.


### PR DESCRIPTION
…ocumentation

<!--
Thank you for contributing to Azion Docs! Please fill out the information below.
Use the conventional commits standard to categorize the type of change in the PR title. We recommend:
- feat: adding new content
- refactor: making minor changes
- fix: fixing errors

Don't forget to add the Jira issue code to the PR title or the GitHub issue hash.
For example: 
- [EDU-3000] refactor: modify origins page to include load balancer
- [#34] feat: add new application CLI commands
- [NO-ISSUE] fix: fix broken link in Orch doc
-->

### Related issue: EDU-6460


### Arquivos modificados

**EN:** [`src/content/docs/en/pages/guides/accounts/conditional-access-by-ip.mdx`](src/content/docs/en/pages/guides/accounts/conditional-access-by-ip.mdx:27)

Adicionado ao `:::note` da seção de configuração:
```
Searching or filtering policies by IPv6 address isn't supported yet. This capability is currently under development.
```

**PT-BR:** [`src/content/docs/pt-br/pages/guias/contas/conditional-access-by-ip.mdx`](src/content/docs/pt-br/pages/guias/contas/conditional-access-by-ip.mdx:27)

Adicionado ao `:::note` da seção de configuração:
```
A busca ou filtragem de políticas por endereço IPv6 ainda não é suportada. Essa funcionalidade está atualmente em desenvolvimento.
```




[EDU-3000]: https://aziontech.atlassian.net/browse/EDU-3000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ