### PR TITLE
Update firewall module activation instructions in documentation

### DIFF
--- a/src/content/docs/en/pages/main-menu/reference/secure/edge-firewall/edge-firewall.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/secure/edge-firewall/edge-firewall.mdx
@@ -59,7 +59,7 @@ An firewall consists in an identification name, all your application domains whe
 <LinkButton link="/en/documentation/products/guides/secure/firewall-configure-main-settings/" label="go to configure main settings guide" severity="secondary" />
 
 :::note
-You need to activate at least one of the following modules for the firewall to work: **Edge Functions**, **Web Application Firewall**, or **Network Shield**.
+You need to activate at least one of the following modules for the firewall to work: **Functions**, **Web Application Firewall**, or **Network Shield**.
 :::
 
 ### Rules Engine for Firewall

--- a/src/content/docs/en/pages/main-menu/reference/secure/edge-firewall/edge-firewall.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/secure/edge-firewall/edge-firewall.mdx
@@ -59,7 +59,7 @@ An firewall consists in an identification name, all your application domains whe
 <LinkButton link="/en/documentation/products/guides/secure/firewall-configure-main-settings/" label="go to configure main settings guide" severity="secondary" />
 
 :::note
-You need to activate at least one for the firewall to work.
+You need to activate at least one of the following modules for the firewall to work: **Edge Functions**, **Web Application Firewall**, or **Network Shield**.
 :::
 
 ### Rules Engine for Firewall

--- a/src/content/docs/pt-br/pages/menu-principal/referencia/secure/edge-firewall/edge-firewall.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/referencia/secure/edge-firewall/edge-firewall.mdx
@@ -58,7 +58,7 @@ Um firewall consiste em um nome de identificação, uma lista de domínios que e
 <LinkButton link="/pt-br/documentacao/produtos/guias/secure/firewall-definir-main-settings/" label="consulte o guia definir main settings" severity="secondary" />
 
 :::note[nota]
-Você precisa ativar pelo menos um módulo para que seu firewall funcione.
+Você precisa ativar pelo menos um dos módulos a seguir para que seu firewall funcione: **Edge Functions**, **Web Application Firewall** ou **Network Shield**.
 :::
 
 ### Rules Engine para Firewall

--- a/src/content/docs/pt-br/pages/menu-principal/referencia/secure/edge-firewall/edge-firewall.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/referencia/secure/edge-firewall/edge-firewall.mdx
@@ -58,7 +58,7 @@ Um firewall consiste em um nome de identificação, uma lista de domínios que e
 <LinkButton link="/pt-br/documentacao/produtos/guias/secure/firewall-definir-main-settings/" label="consulte o guia definir main settings" severity="secondary" />
 
 :::note[nota]
-Você precisa ativar pelo menos um dos módulos a seguir para que seu firewall funcione: **Edge Functions**, **Web Application Firewall** ou **Network Shield**.
+Você precisa ativar pelo menos um dos módulos a seguir para que seu firewall funcione: **Functions**, **Web Application Firewall** ou **Network Shield**.
 :::
 
 ### Rules Engine para Firewall


### PR DESCRIPTION
<!--
Thank you for contributing to Azion Docs! Please fill out the information below.
Use the conventional commits standard to categorize the type of change in the PR title. We recommend:
- feat: adding new content
- refactor: making minor changes
- fix: fixing errors

Don't forget to add the Jira issue code to the PR title or the GitHub issue hash.
For example: 
- [EDU-3000] refactor: modify origins page to include load balancer
- [#34] feat: add new application CLI commands
- [NO-ISSUE] fix: fix broken link in Orch doc
-->

### Related issue: EDU-6556
---

**docs(secure): clarify required modules for Edge Firewall**

Updates the note in the Edge Firewall reference page to explicitly list the modules that must be activated for a firewall to work: **Edge Functions**, **Web Application Firewall**, and **Network Shield**. Previously, the note only stated that at least one module was required without naming them. Applied to both the Portuguese (pt-br) and English (en) versions.


[EDU-3000]: https://aziontech.atlassian.net/browse/EDU-3000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ