### PR TITLE
add character limit for behavior arguments in rules engine documentation

### DIFF
--- a/src/content/docs/en/pages/main-menu/reference/build/edge-application/rules-engine.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/build/edge-application/rules-engine.mdx
@@ -250,6 +250,10 @@ The `name` field may contain only letters (a-z, A-Z), numbers (0-9), hyphens (-)
 | Name         | (a-z, A-Z, 0-9), (-, _ )                              |
 | Value        | (a-z, A-Z, 0-9), (\_ :;.,\/"'?!(){}[]@&lt;&gt;=-+*#$&`\|~^%) |
 
+:::caution
+The argument value is limited to **1,600 characters**. Exceeding this limit returns an `Argument too long` error.
+:::
+
 For example, this would be a valid header:
 
 ```bash
@@ -481,6 +485,7 @@ These are the **default limits**:
 | Criteria per rule | 5 |
 | Behaviors per rule | 10 |
 | Variables per criteria | 10 |
+| Behavior argument | 1,600 characters |
 
 :::tip
 The total limit is 200 rules, distributed between **requests** and **responses**. For example, you can have 150 request rules and 50 response rules.

--- a/src/content/docs/pt-br/pages/menu-principal/referencia/build/edge-application/rules-engine-edge-app.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/referencia/build/edge-application/rules-engine-edge-app.mdx
@@ -252,6 +252,10 @@ O field `name` pode conter apenas letras (a-z, A-Z), números (0-9), hífens (-)
 | Name         | (a-z, A-Z, 0-9), (-, _ )                              |
 | Value        | (a-z, A-Z, 0-9), (\_ :;.,\/"'?!(){}[]@&lt;&gt;=-+*#$&`\|~^%) |
 
+:::caution
+O valor do argumento está limitado a **1.600 caracteres**. Exceder esse limite retorna o erro `Argument too long`.
+:::
+
 Por exemplo, este seria um cabeçalho válido:
 
 ```
@@ -497,6 +501,7 @@ Estes são os **limites default**:
 | Criteria por regra | 5 |
 | Behaviors por regra | 10 |
 | Variables por criteria | 10 |
+| Argumento de behavior | 1.600 caracteres |
 
 :::tip
 O limite total é de 200 regras, distribuídas entre **requests** e **responses**. Por exemplo, você pode ter 150 regras de request e 50 de response.


### PR DESCRIPTION
<!--
Thank you for contributing to Azion Docs! Please fill out the information below.
Use the conventional commits standard to categorize the type of change in the PR title. We recommend:
- feat: adding new content
- refactor: making minor changes
- fix: fixing errors

Don't forget to add the Jira issue code to the PR title or the GitHub issue hash.
For example: 
- [EDU-3000] refactor: modify origins page to include load balancer
- [#34] feat: add new application CLI commands
- [NO-ISSUE] fix: fix broken link in Orch doc
-->

### Related issue: EDU-6560
```
Docs: add 1,600-character limit for behavior arguments in Rules Engine

Add missing documentation for the argument character limit in Rules Engine behaviors, specifically for Add Header used in the Response Phase.

Previously, users had no indication of the 1,600-character limit, leading to unexpected `Argument too long` errors (reported via support ticket for Content-Security-Policy headers).

Changes:
- Add caution callout in the Add Header section warning about the 1,600-character limit and the resulting error message
- Add "Behavior argument" row to the Limits table

Files changed:
- `en/pages/main-menu/reference/build/edge-application/rules-engine.mdx`
- `pt-br/pages/menu-principal/referencia/build/edge-application/rules-engine-edge-app.mdx`
```


[EDU-3000]: https://aziontech.atlassian.net/browse/EDU-3000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ