### PR TITLE
Add notes on port configuration and TLS version enforcement in main s…

### DIFF
--- a/src/content/docs/en/pages/main-menu/reference/build/edge-application/v3/main-settings-v3.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/build/edge-application/v3/main-settings-v3.mdx
@@ -69,6 +69,12 @@ If you enable [HTTP/3 support](#http3-support), multiport configuration will be 
 |              | 8035          |
 |              | 8090          |
 
+:::note
+All ports listed above are open at the infrastructure level across all of Azion's data centers for all customers. This is required by the simultaneous multiport architecture. However, **your application only responds on the ports you explicitly configure**. Requests arriving on ports not selected for your application are not routed to your origin and do not expose your application's content.
+
+If a pentest or port scan reports multiple open ports on an Azion IP address, this reflects the shared infrastructure behavior — not a misconfiguration of your application.
+:::
+
 ---
 
 ## Minimum TLS version
@@ -83,6 +89,14 @@ The **Transport Layer Security (TLS)** protocol allows you to encrypt web traffi
 You can choose the minimum version of TLS that'll be supported by your application. By choosing recent versions of the protocol, older devices or browsers might not be able to access the application.
 
 Azion blocks TLS Renegotiation and TLS Resumption by default. If you want to customize this setup, [contact the Sales team](https://www.azion.com/en/contact-sales/).
+
+:::note
+A TLS scan performed against an Azion data center IP or domain returns the TLS versions accepted at the **infrastructure level** — not the minimum TLS version configured for your application. Azion's shared infrastructure accepts TLS 1.0, 1.1, 1.2, and 1.3 at the network layer.
+
+The minimum TLS version you configure is enforced at the **application layer**: your application will reject any connection that uses a TLS version lower than the one you set. For example, if you configure TLS 1.2 as the minimum, connections using TLS 1.0 or 1.1 will be refused when targeting your domain, even if the infrastructure layer accepts them.
+
+You can verify this behavior by attempting a connection with a lower TLS version using `curl --tlsv1.1 --tls-max 1.1 https://yourdomain.com`. The request will fail with a TLS handshake error if your minimum TLS version is set to 1.2 or higher.
+:::
 
 ---
 

--- a/src/content/docs/pt-br/pages/menu-principal/referencia/build/edge-application/v3/main-settings-v3.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/referencia/build/edge-application/v3/main-settings-v3.mdx
@@ -71,6 +71,12 @@ Se você habilitar [HTTP/3 support](#http3-support), a configuração multiport 
 |              | 8035          |
 |              | 8090          |
 
+:::note
+Todas as portas listadas acima ficam abertas no nível da infraestrutura em todos os data centers da Azion para todos os clientes. Isso é necessário pela arquitetura multiport simultânea. No entanto, **sua aplicação só responde nas portas que você configurar explicitamente**. Requisições que chegam em portas não selecionadas para sua aplicação não são roteadas para sua origem e não expõem o conteúdo da sua aplicação.
+
+Se um pentest ou scan de portas reportar múltiplas portas abertas em um IP da Azion, isso reflete o comportamento da infraestrutura compartilhada — não uma configuração incorreta da sua aplicação.
+:::
+
 ---
 
 ## Versão mínima de TLS
@@ -85,6 +91,14 @@ O protocolo **Transport Layer Security (TLS)** permite que você criptografe o t
 Você poderá escolher a versão mínima de TLS que será suportada para criptografar o tráfego de sua application. Ao escolher versões recentes do protocolo, dispositivos ou navegadores mais antigos podem não conseguir acessar a application.
 
 Por padrão, a Azion bloqueia *TLS Renegotiation* e *TLS Resumption*. Se você deseja personalizar essa configuração, entre em contato com nossa [equipe de Vendas](https://www.azion.com/pt-br/contato/).
+
+:::note
+Um scan de TLS realizado contra um IP ou domínio de um data center da Azion retorna as versões de TLS aceitas no **nível da infraestrutura** — não a versão mínima de TLS configurada para sua aplicação. A infraestrutura compartilhada da Azion aceita TLS 1.0, 1.1, 1.2 e 1.3 na camada de rede.
+
+A versão mínima de TLS que você configura é aplicada na **camada da aplicação**: sua aplicação rejeitará qualquer conexão que utilize uma versão de TLS inferior à configurada. Por exemplo, se você configurar TLS 1.2 como versão mínima, conexões usando TLS 1.0 ou 1.1 serão recusadas ao acessar seu domínio, mesmo que a camada de infraestrutura as aceite.
+
+Você pode verificar esse comportamento tentando uma conexão com uma versão de TLS inferior usando `curl --tlsv1.1 --tls-max 1.1 https://yourdomain.com`. A requisição falhará com um erro de handshake TLS se a versão mínima configurada for 1.2 ou superior.
+:::
 
 ---
 


### PR DESCRIPTION
…ettings documentation

<!--
Thank you for contributing to Azion Docs! Please fill out the information below.
Use the conventional commits standard to categorize the type of change in the PR title. We recommend:
- feat: adding new content
- refactor: making minor changes
- fix: fixing errors

Don't forget to add the Jira issue code to the PR title or the GitHub issue hash.
For example: 
- [EDU-3000] refactor: modify origins page to include load balancer
- [#34] feat: add new application CLI commands
- [NO-ISSUE] fix: fix broken link in Orch doc
-->

### Related issue: EDU-6621
Two `:::note` callouts were added to the existing reference pages — no new page was created, keeping the content contextual and discoverable where customers naturally look.

---

## Files modified

### EN — [`src/content/docs/en/pages/main-menu/reference/build/edge-application/v3/main-settings-v3.mdx`](src/content/docs/en/pages/main-menu/reference/build/edge-application/v3/main-settings-v3.mdx)

**Section `## Ports` → after the ports table (line 72):**
```
:::note
All ports listed above are open at the infrastructure level across all of Azion's data centers for all customers. This is required by the simultaneous multiport architecture. However, **your application only responds on the ports you explicitly configure**. Requests arriving on ports not selected for your application are not routed to your origin and do not expose your application's content.

If a pentest or port scan reports multiple open ports on an Azion IP address, this reflects the shared infrastructure behavior — not a misconfiguration of your application.
:::
```

**Section `## Minimum TLS version` → after the existing paragraph (line 93):**
```
:::note
A TLS scan performed against an Azion data center IP or domain returns the TLS versions accepted at the **infrastructure level** — not the minimum TLS version configured for your application. Azion's shared infrastructure accepts TLS 1.0, 1.1, 1.2, and 1.3 at the network layer.

The minimum TLS version you configure is enforced at the **application layer**: your application will reject any connection that uses a TLS version lower than the one you set. For example, if you configure TLS 1.2 as the minimum, connections using TLS 1.0 or 1.1 will be refused when targeting your domain, even if the infrastructure layer accepts them.

You can verify this behavior by attempting a connection with a lower TLS version using `curl --tls-max 1.1 https://yourdomain.com`. The request will fail with a TLS handshake error if your minimum TLS version is set to 1.2 or higher.
:::
```

---

### PT-BR — [`src/content/docs/pt-br/pages/menu-principal/referencia/build/edge-application/v3/main-settings-v3.mdx`](src/content/docs/pt-br/pages/menu-principal/referencia/build/edge-application/v3/main-settings-v3.mdx)

**Seção `## Portas` → após a tabela de portas (linha 74):**
```
:::note
Todas as portas listadas acima ficam abertas no nível da infraestrutura em todos os data centers da Azion para todos os clientes. Isso é necessário pela arquitetura multiport simultânea. No entanto, **sua aplicação só responde nas portas que você configurar explicitamente**. Requisições que chegam em portas não selecionadas para sua aplicação não são roteadas para sua origem e não expõem o conteúdo da sua aplicação.

Se um pentest ou scan de portas reportar múltiplas portas abertas em um IP da Azion, isso reflete o comportamento da infraestrutura compartilhada — não uma configuração incorreta da sua aplicação.
:::
```

**Seção `## Versão mínima de TLS` → após o parágrafo existente (linha 95):**
```
:::note
Um scan de TLS realizado contra um IP ou domínio de um data center da Azion retorna as versões de TLS aceitas no **nível da infraestrutura** — não a versão mínima de TLS configurada para sua aplicação. A infraestrutura compartilhada da Azion aceita TLS 1.0, 1.1, 1.2 e 1.3 na camada de rede.

A versão mínima de TLS que você configura é aplicada na **camada da aplicação**: sua aplicação rejeitará qualquer conexão que utilize uma versão de TLS inferior à configurada. Por exemplo, se você configurar TLS 1.2 como versão mínima, conexões usando TLS 1.0 ou 1.1 serão recusadas ao acessar seu domínio, mesmo que a camada de infraestrutura as aceite.

Você pode verificar esse comportamento tentando uma conexão com uma versão de TLS inferior usando `curl --tls-max 1.1 https://seudominio.com`. A requisição falhará com um erro de handshake TLS se a versão mínima configurada for 1.2 ou superior.
:::
```

---

## Rationale

- **Two distinct concepts documented separately** — multiport infrastructure behavior (ports) and TLS scan vs. application enforcement (TLS version) each get their own callout in the relevant section.
- **Actionable verification step included** — the [`curl --tls-max`](https://curl.se/docs/manpage.html) command lets customers self-validate TLS enforcement without opening a support ticket.
- **Pentest false positive explicitly named** — both notes directly address the scenario described in the ticket, reducing future support volume.

[EDU-3000]: https://aziontech.atlassian.net/browse/EDU-3000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ