### PR TITLE
Add instructions for setting up redirect in  Application for ALTCHA flow

### DIFF
--- a/src/content/docs/en/pages/guides/edge-functions/altcha-challenge.mdx
+++ b/src/content/docs/en/pages/guides/edge-functions/altcha-challenge.mdx
@@ -97,7 +97,7 @@ To finish, you have to set up the [Rules Engine](/en/documentation/products/secu
 
 For the ALTCHA flow to work correctly, you also need to create a rule in the [Application Rules Engine](/en/documentation/products/build/edge-application/rules-engine/) to redirect users to the verification endpoint when the challenge hasn't been solved yet.
 
-1. Open Azion Console > **Application**.
+1. Open Azion Console > **Applications**.
 2. Select the Application you want to protect with ALTCHA.
 3. Go to the **Rules Engine** tab and click **+ Rule**.
 4. In the **Name** field, enter a unique, descriptive name.

--- a/src/content/docs/en/pages/guides/edge-functions/altcha-challenge.mdx
+++ b/src/content/docs/en/pages/guides/edge-functions/altcha-challenge.mdx
@@ -93,12 +93,12 @@ To finish, you have to set up the [Rules Engine](/en/documentation/products/secu
 7. Keep **Status** as **Active**.
 8. Click **Save**.
 
-### Setting up the redirect in Edge Application
+### Setting up the redirect in Application
 
-For the ALTCHA flow to work correctly, you also need to create a rule in the [Edge Application Rules Engine](/en/documentation/products/build/edge-application/rules-engine/) to redirect users to the verification endpoint when the challenge hasn't been solved yet.
+For the ALTCHA flow to work correctly, you also need to create a rule in the [Application Rules Engine](/en/documentation/products/build/edge-application/rules-engine/) to redirect users to the verification endpoint when the challenge hasn't been solved yet.
 
-1. Open Azion Console > **Edge Application**.
-2. Select the Edge Application you want to protect with ALTCHA.
+1. Open Azion Console > **Application**.
+2. Select the Application you want to protect with ALTCHA.
 3. Go to the **Rules Engine** tab and click **+ Rule**.
 4. In the **Name** field, enter a unique, descriptive name.
 5. In **Phase**, select **Request**.

--- a/src/content/docs/en/pages/guides/edge-functions/altcha-challenge.mdx
+++ b/src/content/docs/en/pages/guides/edge-functions/altcha-challenge.mdx
@@ -93,6 +93,24 @@ To finish, you have to set up the [Rules Engine](/en/documentation/products/secu
 7. Keep **Status** as **Active**.
 8. Click **Save**.
 
+### Setting up the redirect in Edge Application
+
+For the ALTCHA flow to work correctly, you also need to create a rule in the [Edge Application Rules Engine](/en/documentation/products/build/edge-application/rules-engine/) to redirect users to the verification endpoint when the challenge hasn't been solved yet.
+
+1. Open Azion Console > **Edge Application**.
+2. Select the Edge Application you want to protect with ALTCHA.
+3. Go to the **Rules Engine** tab and click **+ Rule**.
+4. In the **Name** field, enter a unique, descriptive name.
+5. In **Phase**, select **Request**.
+6. In the **Criteria** section, configure the following condition:
+   - **Variable**: `${http_X_Azcaptcha_Success}`
+   - **Operator**: `does not exist`
+7. In the **Behavior** section, select **Redirect To (302 Found)** and enter `/az-request-verify` as the destination.
+8. Keep **Status** as **Active**.
+9. Click **Save**.
+
+This rule ensures that any user who accesses a protected endpoint without a valid session cookie is redirected to the ALTCHA challenge page, starting the verification flow.
+
 ### JSON Args
 
 The ALTCHA function accepts the following JSON configuration arguments.

--- a/src/content/docs/pt-br/pages/guias/edge-functions/altcha-challenge.mdx
+++ b/src/content/docs/pt-br/pages/guias/edge-functions/altcha-challenge.mdx
@@ -88,7 +88,25 @@ Para finalizar, você deve configurar o [Rules Engine](/pt-br/documentacao/produ
  - Quando a requisição for para `/form` e o header **X-Azcaptcha-Success** não existir, o redirecionamento para `/az-request-verify` iniciará o fluxo do desafio.
 6. Na seção **Behavior**, selecione **Run Function** > **ALTCHA**.
 7. Mantenha o botão **Status** como **Active**.
-8. Clique no botão **Save**. 
+8. Clique no botão **Save**.
+
+### Configure o redirect na Edge Application
+
+Para que o fluxo do ALTCHA funcione corretamente, você também precisa criar uma regra no [Rules Engine da Edge Application](/pt-br/documentacao/produtos/build/edge-application/rules-engine/) que redirecione os usuários para o endpoint de verificação quando o desafio ainda não foi resolvido.
+
+1. Acesse o Azion Console > **Edge Application**.
+2. Selecione a Edge Application que você deseja proteger com o ALTCHA.
+3. Vá até a aba **Rules Engine** e clique em **+ Rule**.
+4. Na seção **Name**, insira um nome único e descritivo.
+5. Em **Phase**, selecione **Request**.
+6. Na seção **Criteria**, configure a seguinte condição:
+   - **Variable**: `${http_X_Azcaptcha_Success}`
+   - **Operator**: `does not exist`
+7. Na seção **Behavior**, selecione **Redirect To (302 Found)** e insira `/az-request-verify` como destino.
+8. Mantenha o botão **Status** como **Active**.
+9. Clique no botão **Save**.
+
+Essa regra garante que qualquer usuário que acesse um endpoint protegido sem o cookie de sessão válido seja redirecionado para a página do desafio ALTCHA, iniciando o fluxo de verificação.
 
 ### JSON Args
 

--- a/src/content/docs/pt-br/pages/guias/edge-functions/altcha-challenge.mdx
+++ b/src/content/docs/pt-br/pages/guias/edge-functions/altcha-challenge.mdx
@@ -14,10 +14,10 @@ Diferente dos sistemas CAPTCHA tradicionais, o ALTCHA é uma alternativa gratuit
 
 As principais características da Function ALTCHA incluem:
 
-*   **Proteção nativa no edge:** A verificação é processada nos data centers distribuídos da Azion, com as ameaças mitigadas o mais próximo possível do usuário.
+*   **Proteção nativa na infraestrutura distribuída:** A verificação é processada nos data centers distribuídos da Azion, com as ameaças mitigadas o mais próximo possível do usuário.
 *   **Open-source:** Sua natureza transparente e auditável oferece maior confiança e flexibilidade para desenvolvedores.
 *   **Sem dependências externas:** Funciona independentemente de serviços de terceiros, operando dentro da infraestrutura da Azion.
-*   **Performance otimizada:** O processamento distribuído no edge assegura verificação instantânea com consumo mínimo de recursos, e latência ultrabaixa.
+*   **Performance otimizada:** O processamento distribuído assegura verificação instantânea com consumo mínimo de recursos, e latência ultrabaixa.
 *   **Integração nativa:** Como uma Function da Azion, o ALTCHA se integra perfeitamente ao seu fluxo de trabalho e à sua arquitetura de segurança existente no Firewall.
 
 Vantagens sobre CAPTCHAs tradicionais:
@@ -90,12 +90,12 @@ Para finalizar, você deve configurar o [Rules Engine](/pt-br/documentacao/produ
 7. Mantenha o botão **Status** como **Active**.
 8. Clique no botão **Save**.
 
-### Configure o redirect na Edge Application
+### Configure o redirect na Application
 
-Para que o fluxo do ALTCHA funcione corretamente, você também precisa criar uma regra no [Rules Engine da Edge Application](/pt-br/documentacao/produtos/build/edge-application/rules-engine/) que redirecione os usuários para o endpoint de verificação quando o desafio ainda não foi resolvido.
+Para que o fluxo do ALTCHA funcione corretamente, você também precisa criar uma regra no [Rules Engine da Application](/pt-br/documentacao/produtos/build/edge-application/rules-engine/) que redirecione os usuários para o endpoint de verificação quando o desafio ainda não foi resolvido.
 
-1. Acesse o Azion Console > **Edge Application**.
-2. Selecione a Edge Application que você deseja proteger com o ALTCHA.
+1. Acesse o Azion Console > **Application**.
+2. Selecione a Application que você deseja proteger com o ALTCHA.
 3. Vá até a aba **Rules Engine** e clique em **+ Rule**.
 4. Na seção **Name**, insira um nome único e descritivo.
 5. Em **Phase**, selecione **Request**.

--- a/src/content/docs/pt-br/pages/guias/edge-functions/altcha-challenge.mdx
+++ b/src/content/docs/pt-br/pages/guias/edge-functions/altcha-challenge.mdx
@@ -94,7 +94,7 @@ Para finalizar, você deve configurar o [Rules Engine](/pt-br/documentacao/produ
 
 Para que o fluxo do ALTCHA funcione corretamente, você também precisa criar uma regra no [Rules Engine da Application](/pt-br/documentacao/produtos/build/edge-application/rules-engine/) que redirecione os usuários para o endpoint de verificação quando o desafio ainda não foi resolvido.
 
-1. Acesse o Azion Console > **Application**.
+1. Acesse o Azion Console > **Applications**.
 2. Selecione a Application que você deseja proteger com o ALTCHA.
 3. Vá até a aba **Rules Engine** e clique em **+ Rule**.
 4. Na seção **Name**, insira um nome único e descritivo.


### PR DESCRIPTION
<!--
Thank you for contributing to Azion Docs! Please fill out the information below.
Use the conventional commits standard to categorize the type of change in the PR title. We recommend:
- feat: adding new content
- refactor: making minor changes
- fix: fixing errors

Don't forget to add the Jira issue code to the PR title or the GitHub issue hash.
For example: 
- [EDU-3000] refactor: modify origins page to include load balancer
- [#34] feat: add new application CLI commands
- [NO-ISSUE] fix: fix broken link in Orch doc
-->

### Related issue: EDU-6922
**Correção na documentação da Function ALTCHA**

A documentação da Function ALTCHA foi atualizada para incluir uma etapa ausente no fluxo de configuração. A seção de configuração do Rules Engine não informava que, além da regra no Firewall, é necessário criar uma regra correspondente na Edge Application para que o redirecionamento ao desafio funcione corretamente.

Sem essa regra, usuários que acessam endpoints protegidos sem um cookie de sessão válido não eram redirecionados para `/az-request-verify`, interrompendo o fluxo do desafio ALTCHA.

A nova seção, adicionada nas versões em português e inglês, orienta o usuário a criar uma regra no Rules Engine da Edge Application com a variável `${http_X_Azcaptcha_Success}` com operador `does not exist` e behavior `Redirect To (302 Found)` apontando para `/az-request-verify`.

[EDU-3000]: https://aziontech.atlassian.net/browse/EDU-3000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ