### PR TITLE
Edu 6457 azion copilot support tickets recaptcha

### DIFF
--- a/src/content/docs/en/pages/guides/marketplace/integrations/recaptcha.mdx
+++ b/src/content/docs/en/pages/guides/marketplace/integrations/recaptcha.mdx
@@ -148,11 +148,10 @@ On the Console, you must now configure your domain so your edge firewall protect
 Done. Now the **reCAPTCHA** integration is running for every request made to the domain you indicated.
 
 :::warning
-[TECHWRITER TODO: (INSERT) (EXPLANATION) ABOUT (UPDATING THE RECAPTCHA SETTINGS TO INCLUDE THE AZION DOMAIN)]
+Since requests to your application are processed through Azion's infrastructure, Google's reCAPTCHA service validates the domain from which the challenge is served — which will be your Azion domain (for example, `yourdomain.map.azionedge.net` or your custom domain). If this domain isn't registered in your Google reCAPTCHA settings, the challenge will fail.
+
+To fix this, go back to the [Google reCAPTCHA admin dashboard](https://www.google.com/recaptcha/admin), select your site, and add your Azion domain to the **Domains** list. This ensures Google accepts reCAPTCHA validations originating from your Azion-powered application.
 :::
 
-Watch a video about how to install the reCAPTCHA integration through Azion Marketplace on Azion’s YouTube channel:
-
-<iframe width="560" height="315" src="https://www.youtube.com/embed/X-S1qDdVVbg?si=J7dzeymFxJH0P_Zs" loading="lazy" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
 ---

--- a/src/content/docs/pt-br/pages/guias/marketplace/integrations/recaptcha.mdx
+++ b/src/content/docs/pt-br/pages/guias/marketplace/integrations/recaptcha.mdx
@@ -150,4 +150,10 @@ Agora, no Console, você deve configurar seu domínio para que ele seja protegid
 
 Pronto. Agora a integração **reCAPTCHA** está em execução para cada requisição feita ao domínio que você indicou.
 
+:::warning
+Como as requisições à sua aplicação são processadas pela infraestrutura da Azion, o serviço reCAPTCHA do Google valida o domínio a partir do qual o desafio é servido — que será o seu domínio Azion (por exemplo, `yourdomain.map.azionedge.net` ou seu domínio personalizado). Se esse domínio não estiver registrado nas configurações do reCAPTCHA do Google, o desafio falhará.
+
+Para corrigir isso, acesse novamente o [painel de administração do Google reCAPTCHA](https://www.google.com/recaptcha/admin), selecione seu site e adicione seu domínio Azion à lista de **Domínios**. Isso garante que o Google aceite as validações do reCAPTCHA originadas da sua aplicação hospedada na Azion.
+:::
+
 ---


### PR DESCRIPTION
<!--
Thank you for contributing to Azion Docs! Please fill out the information below.
Use the conventional commits standard to categorize the type of change in the PR title. We recommend:
- feat: adding new content
- refactor: making minor changes
- fix: fixing errors

Don't forget to add the Jira issue code to the PR title or the GitHub issue hash.
For example: 
- [EDU-3000] refactor: modify origins page to include load balancer
- [#34] feat: add new application CLI commands
- [NO-ISSUE] fix: fix broken link in Orch doc
-->

### Related issue: EDU-6457
** Em substituição o PR https://github.com/aziontech/docs/pull/1606 **

---

**docs: add warning about Azion domain registration in Google reCAPTCHA settings**

Resolves a `TECHWRITER TODO` placeholder in the reCAPTCHA integration guide.

When the reCAPTCHA integration runs on Azion, requests are processed through Azion's infrastructure. This means Google validates the Azion domain (e.g., `yourdomain.map.azionedge.net`) — not just the original domain registered during the Google reCAPTCHA setup. Without adding the Azion domain to the allowed domains list, the reCAPTCHA challenge fails silently for end users.

**Changes:**
- Added a `:::warning` block in [`en/pages/guides/marketplace/integrations/recaptcha.mdx`](src/content/docs/en/pages/guides/marketplace/integrations/recaptcha.mdx:150) explaining the issue and how to fix it via the Google reCAPTCHA admin dashboard.
- Replicated the same warning in [`pt-br/pages/guias/marketplace/integrations/recaptcha.mdx`](src/content/docs/pt-br/pages/guias/marketplace/integrations/recaptcha.mdx:153) following Azion's localization guidelines.

**Type:** `docs` | **Scope:** Marketplace integrations — reCAPTCHA

[EDU-3000]: https://aziontech.atlassian.net/browse/EDU-3000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ