### PR TITLE
Update ALTCHA flow criteria to include additional conditions for redi…

### DIFF
--- a/src/content/docs/en/pages/guides/edge-functions/altcha-challenge.mdx
+++ b/src/content/docs/en/pages/guides/edge-functions/altcha-challenge.mdx
@@ -102,9 +102,12 @@ For the ALTCHA flow to work correctly, you also need to create a rule in the [Ap
 3. Go to the **Rules Engine** tab and click **+ Rule**.
 4. In the **Name** field, enter a unique, descriptive name.
 5. In **Phase**, select **Request**.
-6. In the **Criteria** section, configure the following condition:
+6. In the **Criteria** section, configure the following conditions:
    - **Variable**: `${http_X_Azcaptcha_Success}`
    - **Operator**: `does not exist`
+   - **Variable**: `${uri}`
+   - **Operator**: `is equal`
+   - **Value**: `/form`
 7. In the **Behavior** section, select **Redirect To (302 Found)** and enter `/az-request-verify` as the destination.
 8. Keep **Status** as **Active**.
 9. Click **Save**.

--- a/src/content/docs/pt-br/pages/guias/edge-functions/altcha-challenge.mdx
+++ b/src/content/docs/pt-br/pages/guias/edge-functions/altcha-challenge.mdx
@@ -99,9 +99,12 @@ Para que o fluxo do ALTCHA funcione corretamente, você também precisa criar um
 3. Vá até a aba **Rules Engine** e clique em **+ Rule**.
 4. Na seção **Name**, insira um nome único e descritivo.
 5. Em **Phase**, selecione **Request**.
-6. Na seção **Criteria**, configure a seguinte condição:
+6. Na seção **Criteria**, configure as seguintes condições:
    - **Variable**: `${http_X_Azcaptcha_Success}`
    - **Operator**: `does not exist`
+   - **Variable**: `${uri}`
+   - **Operator**: `is equal`
+   - **Value**: `/form`
 7. Na seção **Behavior**, selecione **Redirect To (302 Found)** e insira `/az-request-verify` como destino.
 8. Mantenha o botão **Status** como **Active**.
 9. Clique no botão **Save**.


### PR DESCRIPTION
…rect

<!--
Thank you for contributing to Azion Docs! Please fill out the information below.
Use the conventional commits standard to categorize the type of change in the PR title. We recommend:
- feat: adding new content
- refactor: making minor changes
- fix: fixing errors

Don't forget to add the Jira issue code to the PR title or the GitHub issue hash.
For example: 
- [EDU-3000] refactor: modify origins page to include load balancer
- [#34] feat: add new application CLI commands
- [NO-ISSUE] fix: fix broken link in Orch doc
-->

### Related issue: EDU-6922

The `${uri}` criteria variable has been inserted at Step 6 in the "Setting up the redirect in Application" section now reads:

```
6. In the **Criteria** section, configure the following conditions:
   - **Variable**: `${http_X_Azcaptcha_Success}`
   - **Operator**: `does not exist`
   - **Variable**: `${uri}`
   - **Operator**: `is equal`
   - **Value**: `/form`
```

Both PT-BR and EN versions of the ALTCHA guide are now in sync with the same two-condition criteria block.


[EDU-3000]: https://aziontech.atlassian.net/browse/EDU-3000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ