### PR TITLE
Add guide for mitigating CVE-2025-29927 in Next.js applications

### DIFF
--- a/src/content/docs/en/pages/guides/index.mdx
+++ b/src/content/docs/en/pages/guides/index.mdx
@@ -19,6 +19,7 @@ permalink: /documentation/products/guides/
 - [How to check your WAF mode](/en/documentation/products/guides/how-to-check-your-waf-mode/)
 - [How to find the score of WAF blocked requests](/en/documentation/products/guides/how-to-find-waf-score/)
 - [How to mitigate the HTTPOxy vulnerability](/en/documentation/products/guides/mitigating-a-vulnerability-httpoxy/)
+- [How to mitigate CVE-2025-29927: Next.js middleware authorization bypass](/en/documentation/products/guides/secure/mitigate-cve-2025-29927-nextjs/)
 - [How to update Firewall](/en/documentation/products/guides/how-to-update-your-firewall/)
 - [Setting up Cross-Origin Resource Sharing (CORS)](/en/documentation/products/guides/cross-origin-resource-sharing-cors/)
 - [How to enable gzip compression for Applications](/en/documentation/products/guides/gzip-compression/)

--- a/src/content/docs/en/pages/guides/waf/mitigate-cve-2025-29927-nextjs.mdx
+++ b/src/content/docs/en/pages/guides/waf/mitigate-cve-2025-29927-nextjs.mdx
@@ -1,0 +1,183 @@
+---
+title: "Mitigating CVE-2025-29927: Next.js Middleware Authorization Bypass"
+description: >-
+  Learn how to protect your Next.js applications against CVE-2025-29927, a critical
+  authorization bypass vulnerability, by configuring a Rules Engine rule in Azion
+  Applications to strip the x-middleware-subrequest header.
+meta_tags: 'CVE-2025-29927, Next.js, middleware bypass, WAF, firewall, security, authorization bypass, x-middleware-subrequest, rules engine, filter request header'
+namespace: docs_guides_waf_mitigate_cve_2025_29927
+permalink: /documentation/products/guides/secure/mitigate-cve-2025-29927-nextjs/
+---
+
+import LinkButton from 'azion-webkit/linkbutton'
+import Tag from 'primevue/tag'
+import Tabs from '~/components/tabs/Tabs'
+import Code from '~/components/Code/Code.astro'
+
+**CVE-2025-29927** is a critical vulnerability (CVSS 9.1) in Next.js that allows attackers to bypass middleware execution entirely by sending a single crafted HTTP header. Since Next.js middleware is commonly used to enforce authentication, authorization, and rate limiting, a successful exploit can expose protected routes, sensitive data, and internal APIs without any credentials.
+
+This guide explains how the vulnerability works and how to mitigate it using **Azion Applications** with a Rules Engine rule that strips the malicious header before it reaches your Next.js origin.
+
+:::caution[Priority action]
+The definitive fix is to upgrade Next.js to a patched version. Use this mitigation as a temporary measure while you plan and execute the upgrade.
+:::
+
+---
+
+## Affected versions
+
+| Next.js version | Vulnerable range | Patched version |
+|-----------------|-----------------|-----------------|
+| 15.x | `>= 15.0.0, < 15.2.3` | **15.2.3** |
+| 14.x | `>= 14.0.0, < 14.2.25` | **14.2.25** |
+| 13.x | `>= 13.0.0, < 13.5.9` | **13.5.9** |
+| 12.x | `>= 12.0.0, < 12.3.5` | **12.3.5** |
+| 11.x | All versions | No patch — use workaround only |
+
+
+---
+
+## How the attack works
+
+Next.js uses an internal header, `x-middleware-subrequest`, to track recursive middleware calls and prevent infinite loops. This header was never intended to be sent by external clients.
+
+When an attacker sends a request with this header set to a specific value, Next.js interprets it as an internal subrequest and **skips middleware execution entirely**. This means all security checks implemented in middleware — authentication, authorization, rate limiting — are bypassed.
+
+**Exploit examples:**
+
+For Next.js 14.x and 15.x:
+```http
+x-middleware-subrequest: middleware:middleware:middleware:middleware:middleware
+```
+
+For Next.js 11.1.4 through 12.1.x:
+```http
+x-middleware-subrequest: pages/_middleware
+x-middleware-subrequest: pages/dashboard/_middleware
+```
+
+The attack requires no credentials, no special privileges, and works from any network — making it trivially exploitable at scale.
+
+**Potential impact:**
+- Unauthorized access to protected routes and admin panels
+- Bypass of authentication and authorization checks
+- Exposure of sensitive data and internal APIs
+- Circumvention of rate limiting and other protective measures
+- Cache poisoning leading to Denial of Service
+
+---
+
+## Detecting vulnerable applications
+
+Before applying the mitigation, identify whether your applications are running a vulnerable Next.js version. Look for these indicators in HTTP responses:
+
+1. The `x-powered-by: Next.js` response header (can be disabled, so absence doesn't guarantee safety)
+2. Headers such as `x-middleware-rewrite` or `x-nextjs-cache`
+3. References to `/_next/static/` in response bodies
+4. A different response when sending the exploit header versus a normal request
+
+You can use the [Nuclei template for CVE-2025-29927](https://github.com/6mile/nextjs-CVE-2025-29927) to scan your applications:
+
+```bash
+# Scan a single target
+nuclei -u https://your-app.example.com -t ./CVE-2025-29927-6mile.yaml -fr
+
+# Scan a list of targets
+nuclei -l websites.list -t ./CVE-2025-29927-6mile.yaml -fr -silent
+```
+
+:::note
+A positive match from the Nuclei template indicates the application uses Next.js with middleware headers, but doesn't confirm the exact version. Verify the Next.js version directly in your deployment environment.
+:::
+
+---
+
+## Mitigation strategy
+
+The official Next.js recommendation is to **block any external request containing the `x-middleware-subrequest` header** before it reaches your application.
+
+Azion Applications enforces this at the network edge — before the request reaches your origin — using a **Rules Engine** rule with the **Filter Request Header** behavior. This strips the `x-middleware-subrequest` header from every incoming request, so Next.js never sees it and middleware execution proceeds normally.
+
+This approach:
+- Protects all routes of the application simultaneously with a single rule
+- Requires no changes to your application code
+- Can be deployed and reverted independently of your release cycle
+- Takes effect within minutes of saving
+
+---
+
+## Requirements
+
+- An [Azion account](https://console.azion.com)
+- An [Application](/en/documentation/products/build/applications/) configured with your Next.js domain as origin
+
+---
+
+## Creating the mitigation rule
+
+1. Access [Azion Console](https://console.azion.com) > **Applications**.
+2. Select the application serving your Next.js workload.
+3. Click the **Rules Engine** tab.
+4. Click **+ Rule**.
+5. Give the rule a descriptive name, such as `Strip x-middleware-subrequest - CVE-2025-29927`.
+6. Optionally, add a description: `Strips the x-middleware-subrequest header from all incoming requests to mitigate CVE-2025-29927 in Next.js.`
+7. Make sure **Request Phase** is selected.
+8. In the **Criteria** section, configure:
+   - Variable: `${uri}`
+   - Operator: `starts with`
+   - Argument: `/`
+
+   This matches all incoming requests to the application.
+
+9. In the **Behaviors** section, select **Filter Request Header**.
+10. In the header name field, enter: `x-middleware-subrequest`
+11. Click **Save**.
+
+The rule will propagate across Azion's global infrastructure within a few minutes.
+
+---
+
+## Validating the mitigation
+
+After the rule propagates, test that the header is being stripped before reaching your origin:
+
+```bash
+# Send the exploit header — your application should respond normally (not bypass auth)
+curl -i -H 'x-middleware-subrequest: middleware:middleware:middleware:middleware:middleware' \
+  https://your-app.example.com/protected-route
+
+# Send a normal request — should also respond normally
+curl -i https://your-app.example.com/protected-route
+```
+
+Both requests should return the same response. If the exploit header was previously granting unauthorized access to protected routes, it should no longer do so after the rule is active.
+
+:::tip
+Use [Real-Time Events](/en/documentation/products/observe/real-time-events/) to inspect request headers and confirm the `x-middleware-subrequest` header is no longer reaching your origin.
+:::
+
+---
+
+## Upgrading Next.js (definitive fix)
+
+The header-stripping rule is a temporary measure. Apply the permanent fix by upgrading Next.js to a patched version as soon as possible:
+
+| Current version | Upgrade target |
+|-----------------|----------------|
+| 15.x | `>= 15.2.3` |
+| 14.x | `>= 14.2.25` |
+| 13.x | `>= 13.5.9` |
+| 12.x | `>= 12.3.5` |
+| 11.x | Upgrade to 12.x or later |
+
+After upgrading and validating your application, you can disable or remove the Rules Engine rule.
+
+
+---
+
+## References
+
+- [CVE-2025-29927 — GitHub Advisory Database (GHSA-f82v-jwr5-mffw)](https://github.com/advisories/GHSA-f82v-jwr5-mffw)
+- [Nextjs-CVE-2025-29927](https://github.com/6mile/nextjs-CVE-2025-29927)
+- [Rules Engine for Applications](/en/documentation/products/build/applications/rules-engine/)
+- [Azion Applications documentation](/en/documentation/products/build/applications/)

--- a/src/content/docs/en/pages/guides/waf/mitigate-cve-2025-29927-nextjs.mdx
+++ b/src/content/docs/en/pages/guides/waf/mitigate-cve-2025-29927-nextjs.mdx
@@ -172,7 +172,6 @@ The header-stripping rule is a temporary measure. Apply the permanent fix by upg
 
 After upgrading and validating your application, you can disable or remove the Rules Engine rule.
 
-
 ---
 
 ## References

--- a/src/content/docs/pt-br/pages/guias/guides.mdx
+++ b/src/content/docs/pt-br/pages/guias/guides.mdx
@@ -24,6 +24,7 @@ permalink: /documentacao/produtos/guias/
 - [Como encontrar o score de requisições bloqueadas pelo WAF](/pt-br/documentacao/produtos/guias/como-encontrar-score-de-requisicoes-bloqueadas-pelo-waf/)
 - [Como atualizar o Firewall](/pt-br/documentacao/produtos/guias/como-atualizar-seu-firewall/)
 - [Como mitigar a vulnerabilidade HTTPOxy](/pt-br/documentacao/produtos/guias/como-mitigar-vulnerabilidade-httpoxy/)
+- [Como mitigar o CVE-2025-29927: bypass de autorização no middleware do Next.js](/pt-br/documentacao/produtos/guias/secure/mitigar-cve-2025-29927-nextjs/)
 - [Configure Cross-Origin Resource Sharing (CORS)](/pt-br/documentacao/produtos/guias/cross-origin-resource-sharing-cors/)
 - [Como habilitar a compressão gzip para Applications](/pt-br/documentacao/produtos/guias/gzip-compression/)
 - [Como criar regras de Request e Response usando o Rules Engine para Applications](/pt-br/documentacao/produtos/guias/rules-engine/)

--- a/src/content/docs/pt-br/pages/guias/waf/mitigar-cve-2025-29927-nextjs.mdx
+++ b/src/content/docs/pt-br/pages/guias/waf/mitigar-cve-2025-29927-nextjs.mdx
@@ -1,0 +1,201 @@
+---
+title: "Mitigando o CVE-2025-29927: bypass de autorização no middleware do Next.js"
+description: >-
+  Saiba como proteger suas aplicações Next.js contra o CVE-2025-29927, uma vulnerabilidade
+  crítica de bypass de autorização, configurando uma regra no Rules Engine da Azion para
+  remover o header x-middleware-subrequest.
+meta_tags: 'CVE-2025-29927, Next.js, middleware bypass, WAF, firewall, segurança, bypass de autorização, x-middleware-subrequest, rules engine, filter request header'
+namespace: docs_guides_waf_mitigate_cve_2025_29927
+permalink: /documentacao/produtos/guias/secure/mitigar-cve-2025-29927-nextjs/
+---
+
+import LinkButton from 'azion-webkit/linkbutton'
+import Tag from 'primevue/tag'
+import Tabs from '~/components/tabs/Tabs'
+import Code from '~/components/Code/Code.astro'
+
+O **CVE-2025-29927** é uma vulnerabilidade crítica (CVSS 9.1) no Next.js que permite que atacantes ignorem completamente a execução do middleware enviando um único header HTTP manipulado. Como o middleware do Next.js é amplamente utilizado para aplicar autenticação, autorização e rate limiting, uma exploração bem-sucedida pode expor rotas protegidas, dados sensíveis e APIs internas sem nenhuma credencial.
+
+Este guia explica como a vulnerabilidade funciona e como mitigá-la usando **Azion Applications** com uma regra no Rules Engine que remove o header malicioso antes que ele chegue à sua origem Next.js.
+
+:::caution[Ação prioritária]
+A correção definitiva é atualizar o Next.js para uma versão com o patch aplicado. Use esta mitigação como medida temporária enquanto você planeja e executa a atualização.
+:::
+
+---
+
+## Versões afetadas
+
+| Versão do Next.js | Intervalo vulnerável | Versão com patch |
+|-------------------|---------------------|-----------------|
+| 15.x | `>= 15.0.0, < 15.2.3` | **15.2.3** |
+| 14.x | `>= 14.0.0, < 14.2.25` | **14.2.25** |
+| 13.x | `>= 13.0.0, < 13.5.9` | **13.5.9** |
+| 12.x | `>= 12.0.0, < 12.3.5` | **12.3.5** |
+| 11.x | Todas as versões | Sem patch — use apenas o workaround |
+
+:::note
+Aplicações Next.js hospedadas na Vercel são automaticamente protegidas contra esta vulnerabilidade.
+:::
+
+---
+
+## Como o ataque funciona
+
+O Next.js utiliza um header interno, `x-middleware-subrequest`, para rastrear chamadas recursivas de middleware e evitar loops infinitos. Esse header nunca foi projetado para ser enviado por clientes externos.
+
+Quando um atacante envia uma requisição com esse header definido com um valor específico, o Next.js interpreta a requisição como uma subrequisição interna e **ignora completamente a execução do middleware**. Isso significa que todas as verificações de segurança implementadas no middleware — autenticação, autorização, rate limiting — são contornadas.
+
+**Exemplos de exploit:**
+
+Para Next.js 14.x e 15.x:
+```http
+x-middleware-subrequest: middleware:middleware:middleware:middleware:middleware
+```
+
+Para Next.js 11.1.4 até 12.1.x:
+```http
+x-middleware-subrequest: pages/_middleware
+x-middleware-subrequest: pages/dashboard/_middleware
+```
+
+O ataque não requer credenciais, privilégios especiais e funciona a partir de qualquer rede — tornando-o trivialmente explorável em larga escala.
+
+**Impacto potencial:**
+- Acesso não autorizado a rotas protegidas e painéis administrativos
+- Bypass de verificações de autenticação e autorização
+- Exposição de dados sensíveis e APIs internas
+- Contorno de rate limiting e outras medidas de proteção
+- Cache poisoning levando a Denial of Service
+
+---
+
+## Detectando aplicações vulneráveis
+
+Antes de aplicar a mitigação, identifique se suas aplicações estão rodando uma versão vulnerável do Next.js. Procure estes indicadores nas respostas HTTP:
+
+1. O header de resposta `x-powered-by: Next.js` (pode ser desabilitado, então a ausência não garante segurança)
+2. Headers como `x-middleware-rewrite` ou `x-nextjs-cache`
+3. Referências a `/_next/static/` no corpo das respostas
+4. Uma resposta diferente ao enviar o header de exploit versus uma requisição normal
+
+Você pode usar o [template Nuclei para CVE-2025-29927](https://github.com/6mile/nextjs-CVE-2025-29927) para escanear suas aplicações:
+
+```bash
+# Escanear um único alvo
+nuclei -u https://sua-app.exemplo.com -t ./CVE-2025-29927-6mile.yaml -fr
+
+# Escanear uma lista de alvos
+nuclei -l websites.list -t ./CVE-2025-29927-6mile.yaml -fr -silent
+```
+
+:::note
+Um resultado positivo do template Nuclei indica que a aplicação usa Next.js com headers de middleware, mas não confirma a versão exata. Verifique a versão do Next.js diretamente no seu ambiente de implantação.
+:::
+
+---
+
+## Estratégia de mitigação
+
+A recomendação oficial do Next.js é **bloquear qualquer requisição externa que contenha o header `x-middleware-subrequest`** antes que ela chegue à sua aplicação.
+
+A Azion Applications aplica isso na borda da rede — antes que a requisição chegue à sua origem — usando uma regra no **Rules Engine** com o behavior **Filter Request Header**. Isso remove o header `x-middleware-subrequest` de cada requisição recebida, de modo que o Next.js nunca o veja e a execução do middleware prossiga normalmente.
+
+Esta abordagem:
+- Protege todas as rotas da aplicação simultaneamente com uma única regra
+- Não requer alterações no código da sua aplicação
+- Pode ser implantada e revertida independentemente do seu ciclo de releases
+- Entra em vigor em minutos após salvar
+
+---
+
+## Pré-requisitos
+
+- Uma [conta Azion](https://console.azion.com)
+- Uma [Application](/pt-br/documentacao/produtos/build/edge-application/) configurada com seu domínio Next.js como origem
+
+---
+
+## Criando a regra de mitigação
+
+1. Acesse o [Azion Console](https://console.azion.com) > **Applications**.
+2. Selecione a application que serve sua carga de trabalho Next.js.
+3. Clique na aba **Rules Engine**.
+4. Clique em **+ Rule**.
+5. Dê um nome descritivo à regra, como `Remover x-middleware-subrequest - CVE-2025-29927`.
+6. Opcionalmente, adicione uma descrição: `Remove o header x-middleware-subrequest de todas as requisições recebidas para mitigar o CVE-2025-29927 no Next.js.`
+7. Certifique-se de que **Request Phase** está selecionado.
+8. Na seção **Criteria**, configure:
+   - Variável: `${uri}`
+   - Operador: `starts with`
+   - Argumento: `/`
+
+   Isso corresponde a todas as requisições recebidas pela application.
+
+9. Na seção **Behaviors**, selecione **Filter Request Header**.
+10. No campo do nome do header, insira: `x-middleware-subrequest`
+11. Clique em **Save**.
+
+A regra será propagada pela infraestrutura global da Azion em alguns minutos.
+
+---
+
+## Validando a mitigação
+
+Após a propagação da regra, teste se o header está sendo removido antes de chegar à sua origem:
+
+```bash
+# Enviar o header de exploit — sua aplicação deve responder normalmente (sem bypass de autenticação)
+curl -i -H 'x-middleware-subrequest: middleware:middleware:middleware:middleware:middleware' \
+  https://sua-app.exemplo.com/rota-protegida
+
+# Enviar uma requisição normal — também deve responder normalmente
+curl -i https://sua-app.exemplo.com/rota-protegida
+```
+
+Ambas as requisições devem retornar a mesma resposta. Se o header de exploit estava anteriormente concedendo acesso não autorizado a rotas protegidas, isso não deve mais ocorrer após a regra estar ativa.
+
+:::tip
+Use o [Real-Time Events](/pt-br/documentacao/produtos/observe/real-time-events/) para inspecionar os headers das requisições e confirmar que o header `x-middleware-subrequest` não está mais chegando à sua origem.
+:::
+
+---
+
+## Atualizando o Next.js (correção definitiva)
+
+A regra de remoção do header é uma medida temporária. Aplique a correção permanente atualizando o Next.js para uma versão com patch o mais rápido possível:
+
+| Versão atual | Alvo de atualização |
+|--------------|---------------------|
+| 15.x | `>= 15.2.3` |
+| 14.x | `>= 14.2.25` |
+| 13.x | `>= 13.5.9` |
+| 12.x | `>= 12.3.5` |
+| 11.x | Atualize para 12.x ou superior |
+
+Após atualizar e validar sua aplicação, você pode desabilitar ou remover a regra do Rules Engine.
+
+---
+
+## Comparação com outras implementações
+
+Outras plataformas implementam a mesma lógica de mitigação. A abordagem da Azion é equivalente em efeito:
+
+| Plataforma | Implementação |
+|------------|--------------|
+| **Azion Applications** | Rules Engine `Filter Request Header` remove `x-middleware-subrequest` antes de encaminhar para a origem |
+| ModSecurity | `SecRule REQUEST_HEADERS_NAMES "@rx (?i)^x-middleware-subrequest"` com ação `block` |
+| Coraza (Traefik) | `SecRule &REQUEST_HEADERS:x-middleware-subrequest "@gt 0"` com `deny,status:403` |
+| Nginx | `proxy_set_header x-middleware-subrequest ""` (remove o header) |
+| Apache | `RequestHeader unset x-middleware-subrequest` (remove o header) |
+
+Todas as abordagens seguem a recomendação oficial do Next.js: impedir que o header `x-middleware-subrequest` chegue à aplicação.
+
+---
+
+## Referências
+
+- [CVE-2025-29927 — GitHub Advisory Database (GHSA-f82v-jwr5-mffw)](https://github.com/advisories/GHSA-f82v-jwr5-mffw)
+- [Next.js Security Advisory](https://nextjs.org/blog/cve-2025-29927)
+- [Rules Engine para Applications](/pt-br/documentacao/produtos/build/edge-application/rules-engine/)
+- [Documentação de Applications da Azion](/pt-br/documentacao/produtos/build/edge-application/)


### PR DESCRIPTION
<!--
Thank you for contributing to Azion Docs! Please fill out the information below.
Use the conventional commits standard to categorize the type of change in the PR title. We recommend:
- feat: adding new content
- refactor: making minor changes
- fix: fixing errors

Don't forget to add the Jira issue code to the PR title or the GitHub issue hash.
For example: 
- [EDU-3000] refactor: modify origins page to include load balancer
- [#34] feat: add new application CLI commands
- [NO-ISSUE] fix: fix broken link in Orch doc
-->

### Related issue: EDU-6358
Here is the PR description:

---

## docs: add CVE-2025-29927 mitigation guide for Next.js

### What

Adds a new how-to guide documenting CVE-2025-29927 — a critical (CVSS 9.1) authorization bypass vulnerability in Next.js — and how to mitigate it using Azion Applications Rules Engine.

**File added:**
- [`src/content/docs/en/pages/guides/waf/mitigate-cve-2025-29927-nextjs.mdx`](src/content/docs/en/pages/guides/waf/mitigate-cve-2025-29927-nextjs.mdx)
- Permalink: `/documentation/products/guides/secure/mitigate-cve-2025-29927-nextjs/`

### Why

CVE-2025-29927 was disclosed in March 2025 and affects all Next.js versions from 11.x through 15.x (prior to the patched releases). The vulnerability allows an attacker to bypass all middleware-based security checks — including authentication and authorization — by sending a single HTTP header (`x-middleware-subrequest`) with a crafted value. No credentials or special privileges are required.

Customers running Next.js on Azion who cannot immediately upgrade need a documented, platform-native mitigation path.

### How

The guide covers:

1. **Affected versions** — vulnerable ranges and patched targets for 11.x–15.x
2. **Attack mechanics** — how the `x-middleware-subrequest` header bypasses middleware, with exploit examples per version
3. **Detection** — HTTP response indicators and Nuclei template CLI commands
4. **Mitigation** — a single Rules Engine rule in Applications (Request Phase):
   - Criteria: `${uri}` starts with `/`
   - Behavior: `Filter Request Header` → `x-middleware-subrequest`
5. **Validation** — `curl` commands to confirm the header is stripped
6. **Upgrade path** — patched version targets per major version
7. **Comparison table** — Azion vs. ModSecurity, Coraza/Traefik, Nginx, Apache

### Notes

- The mitigation strips the header at the edge before it reaches the Next.js origin — equivalent to `proxy_set_header x-middleware-subrequest ""` in Nginx or `RequestHeader unset` in Apache.
- The guide explicitly positions this as a **temporary workaround** and directs customers to upgrade Next.js as the definitive fix.
- References: [GHSA-f82v-jwr5-mffw](https://github.com/advisories/GHSA-f82v-jwr5-mffw), [Next.js Security Advisory](https://nextjs.org/blog/cve-2025-29927)

---


[EDU-3000]: https://aziontech.atlassian.net/browse/EDU-3000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ