### PR TITLE
Remove redundant H1 from Akamai to Azion guide

### DIFF
--- a/src/content/docs/en/pages/guides/akamai-to-azion/akamai-to-azion-comprehensive-guide.mdx
+++ b/src/content/docs/en/pages/guides/akamai-to-azion/akamai-to-azion-comprehensive-guide.mdx
@@ -10,8 +10,6 @@ permalink: /documentation/products/guides/akamai-migration-guide/
 import Tabs from '~/components/tabs/Tabs'
 import Code from '~/components/Code/Code.astro'
 
-# Migrate from Akamai to Azion
-
 A platform migration from Akamai usually starts with an inventory problem. Delivery properties, behaviors, hostnames, Cloudlets, EdgeWorkers, EdgeKV data, security policies, DNS zones, traffic steering rules, storage, and observability streams may be managed across multiple products and operational processes.
 
 For teams using Akamai Ion, App & API Protector, EdgeWorkers, EdgeKV, Cloudlets, Edge DNS, Global Traffic Management, NetStorage, DataStream, mPulse, Prolexic, Image & Video Manager, or related delivery products, Azion provides equivalent capabilities through Applications, Rules Engine, Functions, KV Store, Object Storage, Firewall, Web Application Firewall, DDoS Protection, Bot Manager, Edge DNS, Load Balancer, Data Stream, Edge Pulse, Real-Time Events, and Real-Time Metrics.


### PR DESCRIPTION
Essa página está sendo acusada no Semrush por ter mais de um H1, retirei o que estava redundante/repetido.