### PR TITLE
Remove redundant H1 header from comprehensive guide

### DIFF
--- a/src/content/docs/en/pages/guides/cloudflare-to-azion/cf-to-azion-comprehensive-guide.mdx
+++ b/src/content/docs/en/pages/guides/cloudflare-to-azion/cf-to-azion-comprehensive-guide.mdx
@@ -10,7 +10,6 @@ permalink: /documentation/products/guides/cloudflare-migration-guide/
 import Tabs from '~/components/tabs/Tabs'
 import Code from '~/components/Code/Code.astro'
 
-# Migrate from Cloudflare to Azion
 
 A platform migration usually begins long before the first configuration file is changed. It starts when a team notices that its current environment no longer gives the same level of clarity, speed, or control it once did.
 


### PR DESCRIPTION
Essa página está sendo acusada no Semrush por ter mais de um H1, retirei o que estava redundante/repetido.

