### PR TITLE
Remove repetitive H1 from Fastly to Azion guide

### DIFF
--- a/src/content/docs/en/pages/guides/fastly-to-azion/fastly-to-azion-comprehensive-guide.mdx
+++ b/src/content/docs/en/pages/guides/fastly-to-azion/fastly-to-azion-comprehensive-guide.mdx
@@ -10,7 +10,6 @@ permalink: /documentation/products/guides/fastly-migration-guide/
 import Tabs from '~/components/tabs/Tabs'
 import Code from '~/components/Code/Code.astro'
 
-# Migrate from Fastly to Azion
 
 A platform migration usually begins long before the first service is cloned or the first domain is cut over. It starts when a team notices that delivery, compute, cache, security, and observability workflows are spread across too many configuration surfaces.
 


### PR DESCRIPTION
Essa página está sendo acusada no Semrush por ter mais de um H1, retirei o que estava redundante/repetido.

