### PR TITLE
Update header level for On-Demand Pricing

### DIFF
--- a/src/content/docs/en/pages/main-menu/pricing/pricing.mdx
+++ b/src/content/docs/en/pages/main-menu/pricing/pricing.mdx
@@ -9,7 +9,7 @@ import LinkButton from 'azion-webkit/linkbutton'
 import Tag from 'primevue/tag';
 import TablePricing from '~/components/Table/TablePricing.astro';
 
-# On-Demand Pricing
+## On-Demand Pricing
 
 Our On-Demand billing model utilizes monthly tiered pricing. You only pay for what you use during the month, and your unit cost automatically decreases as your operation grows.
 


### PR DESCRIPTION
Changed header from H1 to H2 for On-Demand Pricing section.

