### PR TITLE
Change header from H1 to H2 for project linking

### DIFF
--- a/src/content/docs/en/pages/devtools/mcp/mcp-local-development.mdx
+++ b/src/content/docs/en/pages/devtools/mcp/mcp-local-development.mdx
@@ -83,7 +83,7 @@ Deploy your own instance of the MCP server to Azion Platform.
 ### 1. Link your project to your Azion account
 
 
-# Link your project
+## Link your project
 azion link
 
 


### PR DESCRIPTION
Essa página está sendo acusada no Semrush por ter mais de um H1, retirei o que estava redundante/repetido.