### PR TITLE
Enhance Object Storage API documentation with interactive exploration…

### DIFF
--- a/src/content/docs/en/pages/main-menu/reference/store/object-storage/index.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/store/object-storage/index.mdx
@@ -144,8 +144,10 @@ Our billing model is transparent and focused on actual usage, without penalizing
 ### Azion API operations
 
 :::tip
-All the API operations are available in the [Azion API](https://api.azion.com/v4#/operations/GetEdgeStorageBuckets) documentation.
+All the API operations are available in the [Azion API](https://api.azion.com/v4#/operations/GetEdgeStorageBuckets) documentation. You can also explore and test them interactively in the API reference.
 :::
+
+<LinkButton link="https://api.azion.com/v4#/operations/GetEdgeStorageBuckets" label="Explore the Object Storage API reference" severity="secondary" target="_blank" />
 
 | Class | Operation name | HTTP method |
 |-------|-----------------------|-------------|
@@ -169,12 +171,38 @@ Retrieves a list of objects loaded into a bucket.
 
 This operation returns details of all objects in the bucket, including the size in bytes and the timestamp of the last modification.
 
+```bash
+curl --request GET \
+  --url 'https://api.azion.com/v4/workspace/storage/buckets/{bucket_name}/objects' \
+  --header 'Authorization: Token {your-personal-token}'
+```
+
 #### CreateBucket
+
 Creates a new bucket for an account.
+
+```bash
+curl --request POST \
+  --url https://api.azion.com/v4/workspace/storage/buckets \
+  --header 'Accept: application/json' \
+  --header 'Authorization: Bearer [token]' \
+  --header 'Content-Type: application/json' \
+  --data '{
+  "name": "string",
+  "workloads_access": "read_only"
+}'
+```
 
 #### ListBuckets
 
 Retrieves a list of buckets associated with an account.
+
+```bash
+curl --request GET \
+  --url https://api.azion.com/v4/workspace/storage/buckets \
+  --header 'Accept: application/json' \
+  --header 'Authorization: Bearer [token]'
+```
 
 #### UpdateBucket
 
@@ -182,25 +210,55 @@ Modifies bucket information.
 
 Use this operation to change the access permissions to the objects in the bucket. Buckets cannot be renamed with this operation.
 
+```bash
+curl --request PATCH \
+  --url https://api.azion.com/v4/workspace/storage/buckets/{bucket_name} \
+  --header 'Accept: application/json' \
+  --header 'Authorization: Bearer [token]' \
+  --header 'Content-Type: application/json' \
+  --data '{
+  "workloads_access": "read_only"
+}'
+```
+
 #### GetObject
 
 Retrieves an object from a bucket.
 
-:::tip
-For API cURL requests, add the `-O -J` options to the command to download the object to your device using this operation.
-:::
+
+```bash
+curl --request GET \
+  --url https://api.azion.com/v4/workspace/storage/buckets/{bucket_name}/objects/{object_key} \
+  --header 'Accept: application/octet-stream, application/json' \
+  --header 'Authorization: Bearer [token]'
+```
 
 #### PostObject
 
 Uploads an object to a bucket. Objects are limited to a maximum size of 20 MB.
 
-:::tip
-For API cURL requests, use the `--data-binary` option in the command to send raw binary data, such as images or complex files without undergoing URL encoding.
-:::
 
 For the **Azion API**, you can specify the MIME type of the object being sent in the body using the `Content-Type` header. For example, objects with the `.txt` extension should contain the `Content-Type: text/plain` header. If the MIME type isn't specified, **Object Storage** will attempt to interpret the file type based on the file extension. Alternatively, use the `application/octet-stream` MIME type to indicate that the data is a binary stream and the server should handle it as raw binary data.
 
 Sending a new object with an object key already in the bucket will replace the previous object.
+
+```bash
+curl --request POST \
+  --url https://api.azion.com/v4/workspace/storage/buckets/{bucket_name}/objects/{object_key} \
+  --header 'Accept: application/json' \
+  --header 'Authorization: Bearer [token]' \
+  --header 'Storage-Content-Type: '
+```
+
+To upload a binary file such as an image:
+
+```bash
+curl --request POST \
+  --url 'https://api.azion.com/v4/workspace/storage/buckets/{bucket_name}/objects/images/photo.jpg' \
+  --header 'Authorization: Token {your-personal-token}' \
+  --header 'Content-Type: image/jpeg' \
+  --data-binary '@/path/to/photo.jpg'
+```
 
 #### PutObject
 
@@ -208,21 +266,40 @@ Uploads an object to a bucket.
 
 Sending a new object with an object key that already existed in the bucket will replace the previous object.
 
+```bash
+curl --request PUT \
+  --url 'https://api.azion.com/v4/workspace/storage/buckets/{bucket_name}/objects/{object_key}' \
+  --header 'Authorization: Token {your-personal-token}' \
+  --header 'Content-Type: application/octet-stream' \
+  --data-binary '@/path/to/local/file'
+```
+
 #### DeleteObject
 
 Removes an object from a bucket.
 
 When you delete an object being served on the edge, it'll immediately stop being served and will no longer be listed in the bucket.
 
-:::caution[warning]
-For S3 credential access, this operation is allowed through the capability `deleteFiles`, which requires the `writeFiles` capability to be enabled.
-:::
+
+```bash
+curl --request DELETE \
+  --url https://api.azion.com/v4/workspace/storage/buckets/{bucket_name}/objects/{object_key} \
+  --header 'Accept: application/json' \
+  --header 'Authorization: Bearer [token]'
+```
 
 #### DeleteBucket
 
 Removes a bucket from an account.
 
 Buckets that contain objects cannot be deleted. After removing the final object from a bucket, there is a 24-hour period before the bucket can be deleted.
+
+```bash
+curl --request DELETE \
+  --url https://api.azion.com/v4/workspace/storage/buckets/{bucket_name} \
+  --header 'Accept: application/json' \
+  --header 'Authorization: Bearer [token]'
+```
 
 ### S3 operations
 

--- a/src/content/docs/pt-br/pages/menu-principal/referencia/store/edge-storage/index.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/referencia/store/edge-storage/index.mdx
@@ -149,17 +149,19 @@ Nosso modelo de faturamento é transparente e focado no uso efetivo, sem penaliz
 ### Operações da API da Azion
 
 :::tip
-Todas as operações da API estão disponíveis na documentação da [API da Azion](https://api.azion.com/#565230b1-5f75-49e5-b025-0dc9e271883d).
+Todas as operações da API estão disponíveis na documentação da [API da Azion](https://api.azion.com/v4#/operations/GetEdgeStorageBuckets). Você também pode explorá-las e testá-las interativamente na referência da API.
 :::
+
+<LinkButton link="https://api.azion.com/v4#/operations/GetEdgeStorageBuckets" label="Explorar a referência da API do Object Storage" severity="secondary" target="_blank" />
 
 | Classe | Nome da operação | Método HTTP |
 | --- | --- | --- |
 | A | [ListObjects](#listobjects) | `GET` |
 | A | [CreateBucket](#createbucket) | `POST` |
-| A | [ListBuckets](#listbuckets) | `GET` | 
+| A | [ListBuckets](#listbuckets) | `GET` |
 | A | [UpdateBucket](#updatebucket) | `PATCH` |
 | B | [GetObject](#getobject) | `GET` |
-| C | [PostObject](#postobject) | `POST` | 
+| C | [PostObject](#postobject) | `POST` |
 | C | [PutObject](#putobject) | `PUT` |
 | C | [DeleteObject](#deleteobject) | `DELETE` |
 | C | [DeleteBucket](#deletebucket) | `DELETE` |
@@ -174,13 +176,39 @@ Recupera uma lista de objetos carregados em um bucket.
 
 Esta operação retorna detalhes de todos os objetos no bucket, incluindo o tamanho em bytes e o timestamp da última modificação.
 
+```bash
+curl --request GET \
+  --url 'https://api.azion.com/v4/workspace/storage/buckets/{bucket_name}/objects' \
+  --header 'Accept: application/json' \
+  --header 'Authorization: Bearer [token]'
+```
+
 #### CreateBucket
 
 Cria um novo bucket para uma conta.
 
+```bash
+curl --request POST \
+  --url https://api.azion.com/v4/workspace/storage/buckets \
+  --header 'Accept: application/json' \
+  --header 'Authorization: Bearer [token]' \
+  --header 'Content-Type: application/json' \
+  --data '{
+  "name": "string",
+  "workloads_access": "read_only"
+}'
+```
+
 #### ListBuckets
 
 Recupera uma lista de buckets associados a uma conta.
+
+```bash
+curl --request GET \
+  --url https://api.azion.com/v4/workspace/storage/buckets \
+  --header 'Accept: application/json' \
+  --header 'Authorization: Bearer [token]'
+```
 
 #### UpdateBucket
 
@@ -188,31 +216,67 @@ Modifica as informações do bucket.
 
 Use esta operação para alterar as permissões de acesso aos objetos no bucket. Buckets não podem ser renomeados com esta operação.
 
+```bash
+curl --request PATCH \
+  --url https://api.azion.com/v4/workspace/storage/buckets/{bucket_name} \
+  --header 'Accept: application/json' \
+  --header 'Authorization: Bearer [token]' \
+  --header 'Content-Type: application/json' \
+  --data '{
+  "workloads_access": "read_only"
+}'
+```
+
 #### GetObject
 
 Recupera um objeto de um bucket.
 
-:::tip
-Para requisições cURL da API, adicione as opções `-O -J` ao comando para baixar o objeto para o seu dispositivo usando esta operação.
-:::
+```bash
+curl --request GET \
+  --url https://api.azion.com/v4/workspace/storage/buckets/{bucket_name}/objects/{object_key} \
+  --header 'Accept: application/octet-stream, application/json' \
+  --header 'Authorization: Bearer [token]'
+```
 
 #### PostObject
 
 Faz o upload de um objeto para um bucket. Os objetos são limitados a um tamanho máximo de 20 MB.
 
-:::tip
-Para requisições cURL da API, use a opção `--data-binary` no comando para enviar dados binários brutos, como imagens ou arquivos complexos, sem passar pela codificação de URL.
-:::
-
 Para a **API da Azion**, você pode especificar o tipo MIME do objeto sendo enviado no corpo usando o cabeçalho `Content-Type`. Por exemplo, objetos com a extensão `.txt` devem conter o cabeçalho `Content-Type: text/plain`. Se o tipo MIME não for especificado, **Object Storage** tentará interpretar o tipo de arquivo com base na extensão do arquivo. Alternativamente, use o tipo MIME `application/octet-stream` para indicar que os dados são um fluxo binário e o servidor deve tratá-los como dados binários brutos.
 
 Enviar um novo objeto com uma chave de objeto já existente no bucket substituirá o objeto anterior.
+
+```bash
+curl --request POST \
+  --url https://api.azion.com/v4/workspace/storage/buckets/{bucket_name}/objects/{object_key} \
+  --header 'Accept: application/json' \
+  --header 'Authorization: Bearer [token]' \
+  --header 'Storage-Content-Type: '
+```
+
+Para fazer upload de um arquivo binário, como uma imagem:
+
+```bash
+curl --request POST \
+  --url 'https://api.azion.com/v4/workspace/storage/buckets/{bucket_name}/objects/images/photo.jpg' \
+  --header 'Authorization: Bearer [token]' \
+  --header 'Content-Type: image/jpeg' \
+  --data-binary '@/caminho/para/photo.jpg'
+```
 
 #### PutObject
 
 Faz o upload de um objeto para um bucket.
 
 Enviar um novo objeto com uma chave de objeto que já existia no bucket substituirá o objeto anterior.
+
+```bash
+curl --request PUT \
+  --url 'https://api.azion.com/v4/workspace/storage/buckets/{bucket_name}/objects/{object_key}' \
+  --header 'Authorization: Bearer [token]' \
+  --header 'Content-Type: application/octet-stream' \
+  --data-binary '@/caminho/para/arquivo'
+```
 
 #### DeleteObject
 
@@ -224,11 +288,25 @@ Quando você exclui um objeto que está sendo servido no edge, ele deixará de s
 Para acesso com credenciais S3, esta operação é permitida através da capacidade `deleteFiles`, que requer que a capacidade `writeFiles` esteja habilitada.
 :::
 
+```bash
+curl --request DELETE \
+  --url https://api.azion.com/v4/workspace/storage/buckets/{bucket_name}/objects/{object_key} \
+  --header 'Accept: application/json' \
+  --header 'Authorization: Bearer [token]'
+```
+
 #### DeleteBucket
 
 Remove um bucket de uma conta.
 
 Buckets que contêm objetos não podem ser excluídos. Após remover o último objeto de um bucket, há um período de 24 horas antes que o bucket possa ser excluído.
+
+```bash
+curl --request DELETE \
+  --url https://api.azion.com/v4/workspace/storage/buckets/{bucket_name} \
+  --header 'Accept: application/json' \
+  --header 'Authorization: Bearer [token]'
+```
 
 ### Operações do protocolo S3
 


### PR DESCRIPTION
… links and additional cURL examples

<!--
Thank you for contributing to Azion Docs! Please fill out the information below.
Use the conventional commits standard to categorize the type of change in the PR title. We recommend:
- feat: adding new content
- refactor: making minor changes
- fix: fixing errors

Don't forget to add the Jira issue code to the PR title or the GitHub issue hash.
For example: 
- [EDU-3000] refactor: modify origins page to include load balancer
- [#34] feat: add new application CLI commands
- [NO-ISSUE] fix: fix broken link in Orch doc
-->

### Related issue: EDU-6820


## docs: improve Object Storage reference with cURL examples (EN + PT-BR)

### Problem

Users trying to use the Object Storage API — especially for operations like `PostObject` that have no Console UI — had to leave the docs and navigate to `api.azion.com` to figure out the actual request structure. The reference page described each operation in prose but provided no executable code, creating an unnecessary friction point.

### What changed

**`src/content/docs/en/pages/main-menu/reference/store/object-storage/index.mdx`**
**`src/content/docs/pt-br/pages/menu-principal/referencia/store/edge-storage/index.mdx`**

- Updated the `:::tip` in the **Azion API operations** section to point to the correct API v4 reference URL (`api.azion.com/v4#/operations/GetEdgeStorageBuckets`)
- Added a `LinkButton` to the interactive API reference for quick access
- Added `curl` examples to all 9 Azion API operations:
  - `ListObjects` — `GET /buckets/{bucket_name}/objects`
  - `CreateBucket` — `POST /buckets` with `workloads_access` field
  - `ListBuckets` — `GET /buckets`
  - `UpdateBucket` — `PATCH /buckets/{bucket_name}` with `workloads_access`
  - `GetObject` — `GET` with `Accept: application/octet-stream`
  - `PostObject` — `POST` with `Storage-Content-Type` header + binary file example
  - `PutObject` — `PUT` with `--data-binary`
  - `DeleteObject` — `DELETE /objects/{object_key}`
  - `DeleteBucket` — `DELETE /buckets/{bucket_name}`

### Why

Object Storage has no Console UI for object-level operations. `curl` examples are the minimum viable path for developers to get unblocked without leaving the docs page. The S3 operations section already had `s3cmd` commands — this change brings the same level of actionability to the Azion API section.

[EDU-3000]: https://aziontech.atlassian.net/browse/EDU-3000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ