### PR TITLE
Add guides for retrieving Azion IP ranges for origin server allowlist…

### DIFF
--- a/src/content/docs/en/pages/guides/network-layer-protection/retrieve-azion-ip-ranges/index.mdx
+++ b/src/content/docs/en/pages/guides/network-layer-protection/retrieve-azion-ip-ranges/index.mdx
@@ -1,0 +1,204 @@
+---
+title: How to retrieve Azion IP ranges for origin server allowlisting
+description: >-
+  Learn how to retrieve Azion's IP/CIDR ranges to configure allowlists on your
+  origin server, AWS ELB, or Nginx set_real_ip_from directive.
+meta_tags: >-
+  azion ip ranges, origin shield, ip allowlist, set_real_ip_from, nginx, aws
+  elb, peeringdb, network shield, origin server security, ip cidr
+namespace: docs_guides_retrieve_azion_ip_ranges
+permalink: /documentation/products/guides/retrieve-azion-ip-ranges/
+---
+
+import LinkButton from 'azion-webkit/linkbutton'
+import Code from '~/components/Code/Code.astro'
+
+When your application's origin server sits behind Azion, all inbound requests arrive from Azion's global infrastructure — not directly from end users. To secure your origin, you need to allowlist only Azion's IP/CIDR ranges and block everything else.
+
+This guide covers two approaches:
+
+- **PeeringDB (public, no subscription required)**: Retrieve the IP prefixes registered under Azion's Autonomous System (AS52580) from a public internet routing database. Use this when you need a quick reference or a one-time configuration.
+- **Origin Shield (managed, subscription required)**: Access a curated, automatically updated list of IPv4 and IPv6 prefixes maintained by Azion. Use this when you need a production-grade, always-current allowlist with email notifications on every update.
+
+:::note
+The two sources serve different purposes. PeeringDB reflects BGP-announced prefixes and may not include every address Azion uses to reach your origin. **Origin Shield** is the authoritative list for origin-level security and is the recommended approach for production environments.
+:::
+
+---
+
+## Option 1: Retrieve IP ranges from PeeringDB
+
+[PeeringDB](https://www.peeringdb.com/asn/52580) is a public database of network interconnection information. Azion operates under **AS52580**, and its announced prefixes are publicly visible there.
+
+**When to use this option:**
+- You need a quick, no-cost reference to Azion's IP ranges.
+- You're doing a one-time configuration and don't need automated updates.
+- Not all your traffic goes through Azion yet and you want to test the configuration.
+
+**Limitations:**
+- The list is not managed by Azion for origin-security purposes.
+- It does not include all addresses Azion may use to connect to your origin.
+- You are responsible for manually checking for updates.
+
+### Steps
+
+1. Go to [https://www.peeringdb.com/asn/52580](https://www.peeringdb.com/asn/52580).
+2. Under the **Prefixes** section, copy the listed IPv4 and IPv6 prefixes.
+3. Use these prefixes to configure your origin server's firewall or Nginx (see [Nginx configuration example](#nginx-set_real_ip_from-example) below).
+
+---
+
+## Option 2: Retrieve IP ranges via Origin Shield
+
+**Origin Shield** is an add-on that provides the `Azion Origin Shield` network list — a curated, dynamically updated list of all IPv4 and IPv6 prefixes used exclusively by Azion's global infrastructure to connect to origin servers.
+
+**When to use this option:**
+- You need a production-grade, authoritative IP list.
+- You want automated email notifications when the list changes.
+- You're configuring a strict allowlist on AWS ELB, GCP firewall rules, or a cloud-native security group.
+
+### Prerequisites
+
+- The [Network Shield module](/en/documentation/products/secure/firewall/network-shield/) enabled on your Firewall.
+- An active **Origin Shield** add-on subscription. Contact the [sales team](https://www.azion.com/en/contact-sales/) to subscribe.
+
+### Access the list via Azion Console
+
+1. Access [Azion Console](https://console.azion.com) > **Network Lists**.
+2. Select **Azion Origin Shield** from the list.
+3. In the **List** field, copy all IP/CIDR entries.
+
+### Access the list via API
+
+Run the following request, replacing `[TOKEN VALUE]` with your [personal token](/en/documentation/products/guides/personal-tokens/):
+
+<Code lang="bash" code={`
+curl --request GET \\
+  --url https://api.azion.com/v4/workspace/network_lists \\
+  --header 'Accept: application/json' \\
+  --header 'Authorization: Token [TOKEN VALUE]'
+`} />
+
+The response will include the `Azion Origin Shield` entry:
+
+<Code lang="json" code={`
+{
+  "count": 4,
+  "total_pages": 1,
+  "schema_version": 3,
+  "links": {
+    "previous": null,
+    "next": null
+  },
+  "results": [
+    {
+      "id": 2345,
+      "last_editor": "last.editor@azion.com",
+      "last_modified": "2023-03-27T21:19:27.996870Z",
+      "list_type": "ip_cidr",
+      "name": "Azion Origin Shield",
+      "country_list": [],
+      "ip_list": [
+        "192.0.2.0/24",
+        "2001:db8::/32"
+      ]
+    }
+  ]
+}
+`} />
+
+The `ip_list` field contains all current Azion prefixes. Use these values to configure your origin firewall.
+
+:::note
+Azion sends an email notification every time the list is updated. You have **7 days** to apply the new addresses to your origin firewall rules or automations before new servers go into production.
+:::
+
+---
+
+## Nginx `set_real_ip_from` example
+
+If your origin runs Nginx, use the `set_real_ip_from` directive to trust the `X-Forwarded-For` header only when the request arrives from a known Azion IP. This prevents clients from spoofing their IP address by injecting a fake `X-Forwarded-For` value.
+
+Add the following block to your Nginx configuration, replacing the example CIDR ranges with the actual prefixes from Origin Shield or PeeringDB:
+
+<Code lang="nginx" code={`
+# Trust X-Forwarded-For only from Azion IP ranges
+# Replace with actual prefixes from Origin Shield or PeeringDB (AS52580)
+set_real_ip_from 192.0.2.0/24;
+set_real_ip_from 198.51.100.0/24;
+set_real_ip_from 2001:db8::/32;
+
+# Use the last untrusted IP in the X-Forwarded-For chain as the real client IP
+real_ip_header X-Forwarded-For;
+real_ip_recursive on;
+`} />
+
+With this configuration:
+- Nginx replaces the connection IP with the real client IP from `X-Forwarded-For`, but only when the request comes from a trusted Azion address.
+- Requests arriving from IPs not in the `set_real_ip_from` list are treated as untrusted, and the `X-Forwarded-For` header is not used for IP resolution.
+
+:::tip
+To keep your Nginx configuration current, automate the retrieval of the Origin Shield list via the Azion API and regenerate the `set_real_ip_from` block on each update. See [Automate new address additions](/en/documentation/products/secure/secure-infrastructure/#step-3-automate-new-address-additions) for a Rules Engine-based approach.
+:::
+
+---
+
+## AWS ELB (Elastic Load Balancer) example
+
+To allowlist Azion IPs on an AWS Application Load Balancer (ALB) or Network Load Balancer (NLB), configure a **Security Group** inbound rule for each Azion CIDR prefix.
+
+Using the AWS CLI, add an inbound rule for each prefix:
+
+<Code lang="bash" code={`
+aws ec2 authorize-security-group-ingress \\
+  --group-id sg-xxxxxxxxxxxxxxxxx \\
+  --protocol tcp \\
+  --port 443 \\
+  --cidr 192.0.2.0/24
+`} />
+
+Repeat this command for each CIDR in the Origin Shield list. To automate this process, retrieve the list from the Azion API and loop through the `ip_list` entries:
+
+<Code lang="bash" code={`
+# Retrieve the Origin Shield list and add each CIDR to the security group
+AZION_IPS=$(curl -s --request GET \\
+  --url https://api.azion.com/v4/workspace/network_lists \\
+  --header 'Accept: application/json' \\
+  --header 'Authorization: Token [TOKEN VALUE]' | \\
+  jq -r '.results[] | select(.name == "Azion Origin Shield") | .ip_list[]')
+
+for CIDR in $AZION_IPS; do
+  aws ec2 authorize-security-group-ingress \\
+    --group-id sg-xxxxxxxxxxxxxxxxx \\
+    --protocol tcp \\
+    --port 443 \\
+    --cidr "$CIDR"
+done
+`} />
+
+:::note
+AWS Security Groups have a default limit of 60 inbound rules per group. If the Origin Shield list exceeds this limit, request a quota increase from AWS or use a prefix list to consolidate entries.
+:::
+
+---
+
+## Choosing the right approach
+
+| Requirement | PeeringDB | Origin Shield |
+|---|---|---|
+| No subscription needed | ✅ | ❌ Requires add-on |
+| Authoritative Azion list | ❌ | ✅ |
+| Includes all origin-facing IPs | ❌ | ✅ |
+| Automated update notifications | ❌ | ✅ Email on every change |
+| API access for automation | ❌ | ✅ |
+| IPv6 support | Partial | ✅ Full |
+| Recommended for production | ❌ | ✅ |
+
+---
+
+## Related resources
+
+<LinkButton link="/en/documentation/products/secure/secure-infrastructure/" label="Secure an infrastructure" severity="secondary" />
+<LinkButton link="/en/documentation/products/secure/connectors/origin-shield/" label="Origin Shield reference" severity="secondary" />
+<LinkButton link="/en/documentation/products/secure/firewall/network-shield/" label="Network Shield reference" severity="secondary" />
+<LinkButton link="/en/documentation/products/secure/edge-firewall/network-layer-protection/network-lists/" label="Network Lists reference" severity="secondary" />

--- a/src/content/docs/en/pages/guides/network-layer-protection/retrieve-azion-ip-ranges/index.mdx
+++ b/src/content/docs/en/pages/guides/network-layer-protection/retrieve-azion-ip-ranges/index.mdx
@@ -2,10 +2,9 @@
 title: How to retrieve Azion IP ranges for origin server allowlisting
 description: >-
   Learn how to retrieve Azion's IP/CIDR ranges to configure allowlists on your
-  origin server, AWS ELB, or Nginx set_real_ip_from directive.
+  origin server via PeeringDB or Origin Shield.
 meta_tags: >-
-  azion ip ranges, origin shield, ip allowlist, set_real_ip_from, nginx, aws
-  elb, peeringdb, network shield, origin server security, ip cidr
+  azion ip ranges, origin shield, ip allowlist, peeringdb, network shield, origin server security, ip cidr
 namespace: docs_guides_retrieve_azion_ip_ranges
 permalink: /documentation/products/guides/retrieve-azion-ip-ranges/
 ---
@@ -15,10 +14,7 @@ import Code from '~/components/Code/Code.astro'
 
 When your application's origin server sits behind Azion, all inbound requests arrive from Azion's global infrastructure — not directly from end users. To secure your origin, you need to allowlist only Azion's IP/CIDR ranges and block everything else.
 
-This guide covers two approaches:
-
-- **PeeringDB (public, no subscription required)**: Retrieve the IP prefixes registered under Azion's Autonomous System (AS52580) from a public internet routing database. Use this when you need a quick reference or a one-time configuration.
-- **Origin Shield (managed, subscription required)**: Access a curated, automatically updated list of IPv4 and IPv6 prefixes maintained by Azion. Use this when you need a production-grade, always-current allowlist with email notifications on every update.
+This guide explains how to retrieve those IP ranges, either from PeeringDB (public, no subscription required) or from Origin Shield (managed, subscription required).
 
 :::note
 The two sources serve different purposes. PeeringDB reflects BGP-announced prefixes and may not include every address Azion uses to reach your origin. **Origin Shield** is the authoritative list for origin-level security and is the recommended approach for production environments.
@@ -44,7 +40,7 @@ The two sources serve different purposes. PeeringDB reflects BGP-announced prefi
 
 1. Go to [https://www.peeringdb.com/asn/52580](https://www.peeringdb.com/asn/52580).
 2. Under the **Prefixes** section, copy the listed IPv4 and IPv6 prefixes.
-3. Use these prefixes to configure your origin server's firewall or Nginx (see [Nginx configuration example](#nginx-set_real_ip_from-example) below).
+3. Use these prefixes to configure your origin server's firewall.
 
 ---
 
@@ -55,7 +51,7 @@ The two sources serve different purposes. PeeringDB reflects BGP-announced prefi
 **When to use this option:**
 - You need a production-grade, authoritative IP list.
 - You want automated email notifications when the list changes.
-- You're configuring a strict allowlist on AWS ELB, GCP firewall rules, or a cloud-native security group.
+- You're configuring a strict allowlist on a firewall or security group.
 
 ### Prerequisites
 
@@ -111,73 +107,6 @@ The `ip_list` field contains all current Azion prefixes. Use these values to con
 
 :::note
 Azion sends an email notification every time the list is updated. You have **7 days** to apply the new addresses to your origin firewall rules or automations before new servers go into production.
-:::
-
----
-
-## Nginx `set_real_ip_from` example
-
-If your origin runs Nginx, use the `set_real_ip_from` directive to trust the `X-Forwarded-For` header only when the request arrives from a known Azion IP. This prevents clients from spoofing their IP address by injecting a fake `X-Forwarded-For` value.
-
-Add the following block to your Nginx configuration, replacing the example CIDR ranges with the actual prefixes from Origin Shield or PeeringDB:
-
-<Code lang="nginx" code={`
-# Trust X-Forwarded-For only from Azion IP ranges
-# Replace with actual prefixes from Origin Shield or PeeringDB (AS52580)
-set_real_ip_from 192.0.2.0/24;
-set_real_ip_from 198.51.100.0/24;
-set_real_ip_from 2001:db8::/32;
-
-# Use the last untrusted IP in the X-Forwarded-For chain as the real client IP
-real_ip_header X-Forwarded-For;
-real_ip_recursive on;
-`} />
-
-With this configuration:
-- Nginx replaces the connection IP with the real client IP from `X-Forwarded-For`, but only when the request comes from a trusted Azion address.
-- Requests arriving from IPs not in the `set_real_ip_from` list are treated as untrusted, and the `X-Forwarded-For` header is not used for IP resolution.
-
-:::tip
-To keep your Nginx configuration current, automate the retrieval of the Origin Shield list via the Azion API and regenerate the `set_real_ip_from` block on each update. See [Automate new address additions](/en/documentation/products/secure/secure-infrastructure/#step-3-automate-new-address-additions) for a Rules Engine-based approach.
-:::
-
----
-
-## AWS ELB (Elastic Load Balancer) example
-
-To allowlist Azion IPs on an AWS Application Load Balancer (ALB) or Network Load Balancer (NLB), configure a **Security Group** inbound rule for each Azion CIDR prefix.
-
-Using the AWS CLI, add an inbound rule for each prefix:
-
-<Code lang="bash" code={`
-aws ec2 authorize-security-group-ingress \\
-  --group-id sg-xxxxxxxxxxxxxxxxx \\
-  --protocol tcp \\
-  --port 443 \\
-  --cidr 192.0.2.0/24
-`} />
-
-Repeat this command for each CIDR in the Origin Shield list. To automate this process, retrieve the list from the Azion API and loop through the `ip_list` entries:
-
-<Code lang="bash" code={`
-# Retrieve the Origin Shield list and add each CIDR to the security group
-AZION_IPS=$(curl -s --request GET \\
-  --url https://api.azion.com/v4/workspace/network_lists \\
-  --header 'Accept: application/json' \\
-  --header 'Authorization: Token [TOKEN VALUE]' | \\
-  jq -r '.results[] | select(.name == "Azion Origin Shield") | .ip_list[]')
-
-for CIDR in $AZION_IPS; do
-  aws ec2 authorize-security-group-ingress \\
-    --group-id sg-xxxxxxxxxxxxxxxxx \\
-    --protocol tcp \\
-    --port 443 \\
-    --cidr "$CIDR"
-done
-`} />
-
-:::note
-AWS Security Groups have a default limit of 60 inbound rules per group. If the Origin Shield list exceeds this limit, request a quota increase from AWS or use a prefix list to consolidate entries.
 :::
 
 ---

--- a/src/content/docs/en/pages/guides/network-layer-protection/retrieve-azion-ip-ranges/index.mdx
+++ b/src/content/docs/en/pages/guides/network-layer-protection/retrieve-azion-ip-ranges/index.mdx
@@ -1,10 +1,10 @@
 ---
 title: How to retrieve Azion IP ranges for origin server allowlisting
 description: >-
-  Learn how to retrieve Azion's IP/CIDR ranges to configure allowlists on your
-  origin server via PeeringDB or Origin Shield.
+  Learn how to retrieve Azion's IP/CIDR ranges via Origin Shield to configure
+  allowlists on your origin server.
 meta_tags: >-
-  azion ip ranges, origin shield, ip allowlist, peeringdb, network shield, origin server security, ip cidr
+  azion ip ranges, origin shield, ip allowlist, network shield, origin server security, ip cidr
 namespace: docs_guides_retrieve_azion_ip_ranges
 permalink: /documentation/products/guides/retrieve-azion-ip-ranges/
 ---
@@ -14,57 +14,26 @@ import Code from '~/components/Code/Code.astro'
 
 When your application's origin server sits behind Azion, all inbound requests arrive from Azion's global infrastructure — not directly from end users. To secure your origin, you need to allowlist only Azion's IP/CIDR ranges and block everything else.
 
-This guide explains how to retrieve those IP ranges, either from PeeringDB (public, no subscription required) or from Origin Shield (managed, subscription required).
-
-:::note
-The two sources serve different purposes. PeeringDB reflects BGP-announced prefixes and may not include every address Azion uses to reach your origin. **Origin Shield** is the authoritative list for origin-level security and is the recommended approach for production environments.
-:::
+**Origin Shield** provides the `Azion Origin Shield` network list — a curated, dynamically updated list of all IPv4 and IPv6 prefixes used exclusively by Azion's global infrastructure to connect to origin servers.
 
 ---
 
-## Option 1: Retrieve IP ranges from PeeringDB
-
-[PeeringDB](https://www.peeringdb.com/asn/52580) is a public database of network interconnection information. Azion operates under **AS52580**, and its announced prefixes are publicly visible there.
-
-**When to use this option:**
-- You need a quick, no-cost reference to Azion's IP ranges.
-- You're doing a one-time configuration and don't need automated updates.
-- Not all your traffic goes through Azion yet and you want to test the configuration.
-
-**Limitations:**
-- The list is not managed by Azion for origin-security purposes.
-- It does not include all addresses Azion may use to connect to your origin.
-- You are responsible for manually checking for updates.
-
-### Steps
-
-1. Go to [https://www.peeringdb.com/asn/52580](https://www.peeringdb.com/asn/52580).
-2. Under the **Prefixes** section, copy the listed IPv4 and IPv6 prefixes.
-3. Use these prefixes to configure your origin server's firewall.
-
----
-
-## Option 2: Retrieve IP ranges via Origin Shield
-
-**Origin Shield** is an add-on that provides the `Azion Origin Shield` network list — a curated, dynamically updated list of all IPv4 and IPv6 prefixes used exclusively by Azion's global infrastructure to connect to origin servers.
-
-**When to use this option:**
-- You need a production-grade, authoritative IP list.
-- You want automated email notifications when the list changes.
-- You're configuring a strict allowlist on a firewall or security group.
-
-### Prerequisites
+## Prerequisites
 
 - The [Network Shield module](/en/documentation/products/secure/firewall/network-shield/) enabled on your Firewall.
 - An active **Origin Shield** add-on subscription. Contact the [sales team](https://www.azion.com/en/contact-sales/) to subscribe.
 
-### Access the list via Azion Console
+---
+
+## Access the list via Azion Console
 
 1. Access [Azion Console](https://console.azion.com) > **Network Lists**.
 2. Select **Azion Origin Shield** from the list.
 3. In the **List** field, copy all IP/CIDR entries.
 
-### Access the list via API
+---
+
+## Access the list via API
 
 Run the following request, replacing `[TOKEN VALUE]` with your [personal token](/en/documentation/products/guides/personal-tokens/):
 
@@ -108,20 +77,6 @@ The `ip_list` field contains all current Azion prefixes. Use these values to con
 :::note
 Azion sends an email notification every time the list is updated. You have **7 days** to apply the new addresses to your origin firewall rules or automations before new servers go into production.
 :::
-
----
-
-## Choosing the right approach
-
-| Requirement | PeeringDB | Origin Shield |
-|---|---|---|
-| No subscription needed | ✅ | ❌ Requires add-on |
-| Authoritative Azion list | ❌ | ✅ |
-| Includes all origin-facing IPs | ❌ | ✅ |
-| Automated update notifications | ❌ | ✅ Email on every change |
-| API access for automation | ❌ | ✅ |
-| IPv6 support | Partial | ✅ Full |
-| Recommended for production | ❌ | ✅ |
 
 ---
 

--- a/src/content/docs/en/pages/main-menu/reference/secure/edge-connector/origin-shield.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/secure/edge-connector/origin-shield.mdx
@@ -24,6 +24,7 @@ The **Azion Origin Shield** network list now includes IPv6 prefixes for all of A
 | Scope | Resource |
 | --- | --- |
 | Secure an application | [Secure an application](/en/documentation/products/secure/secure-infrastructure/) |
+| Retrieve IP ranges for origin allowlisting | [How to retrieve Azion IP ranges](/en/documentation/products/guides/retrieve-azion-ip-ranges/) |
 | Connectors | [Connectors](/en/documentation/products/secure/connectors/) |
 | Applications first steps | [First steps](/en/documentation/products/build/applications/first-steps/) |
 

--- a/src/content/docs/en/pages/secure-journey/secure-infrastructure.mdx
+++ b/src/content/docs/en/pages/secure-journey/secure-infrastructure.mdx
@@ -14,6 +14,10 @@ Once you've [created an firewall and secured your application](/en/documentation
 
 Origin Shield provides a list of IPv4 and IPv6 prefixes used exclusively by Azion in its global infrastructure, ensuring that only trusted Azion IPs are allowed access. The list is maintained by Azion and made available via Azion Console and API. Clients are responsible for automating updates to their security policies to keep them aligned with the current Origin Shield addresses.
 
+:::tip
+If you need Azion's IP ranges to configure an allowlist on your origin server, Nginx `set_real_ip_from`, or a cloud firewall such as AWS ELB, see [How to retrieve Azion IP ranges for origin server allowlisting](/en/documentation/products/guides/retrieve-azion-ip-ranges/).
+:::
+
 :::note
 The **Azion Origin Shield** network list now includes IPv6 prefixes for all of Azion's data centers. If you use this list in firewall rules or automations, review your filter configurations to ensure they handle the updated list size correctly.
 :::

--- a/src/content/docs/pt-br/pages/guias/network-layer-protection/obter-ranges-ip-azion/index.mdx
+++ b/src/content/docs/pt-br/pages/guias/network-layer-protection/obter-ranges-ip-azion/index.mdx
@@ -1,10 +1,10 @@
 ---
 title: Como obter os ranges de IP da Azion para allowlist no servidor de origem
 description: >-
-  Saiba como obter os ranges de IP/CIDR da Azion para configurar allowlists no
-  seu servidor de origem via PeeringDB ou Origin Shield.
+  Saiba como obter os ranges de IP/CIDR da Azion via Origin Shield para
+  configurar allowlists no seu servidor de origem.
 meta_tags: >-
-  ranges de ip azion, origin shield, ip allowlist, peeringdb, network shield, segurança servidor de origem, ip cidr
+  ranges de ip azion, origin shield, ip allowlist, network shield, segurança servidor de origem, ip cidr
 namespace: docs_guides_retrieve_azion_ip_ranges
 permalink: /documentacao/produtos/guias/obter-ranges-ip-azion/
 ---
@@ -14,57 +14,26 @@ import Code from '~/components/Code/Code.astro'
 
 Quando o servidor de origem da sua aplicação está atrás da Azion, todas as requisições de entrada chegam pela infraestrutura global da Azion — e não diretamente dos usuários finais. Para proteger sua origem, você precisa criar uma allowlist com apenas os ranges de IP/CIDR da Azion e bloquear todo o restante.
 
-Este guia explica como consultar esses ranges de IP, seja pelo PeeringDB (público, sem assinatura) ou pelo Origin Shield (gerenciado, requer assinatura).
-
-:::note
-As duas fontes servem a propósitos diferentes. O PeeringDB reflete prefixos anunciados via BGP e pode não incluir todos os endereços que a Azion usa para se conectar à sua origem. O **Origin Shield** é a lista autoritativa para segurança no nível de origem e é a abordagem recomendada para ambientes de produção.
-:::
+O **Origin Shield** fornece a lista de redes `Azion Origin Shield` — uma lista curada e atualizada dinamicamente com todos os prefixos IPv4 e IPv6 usados exclusivamente pela infraestrutura global da Azion para se conectar aos servidores de origem.
 
 ---
 
-## Opção 1: Obter ranges de IP pelo PeeringDB
-
-O [PeeringDB](https://www.peeringdb.com/asn/52580) é um banco de dados público de informações de interconexão de redes. A Azion opera sob o **AS52580**, e seus prefixos anunciados estão publicamente visíveis lá.
-
-**Quando usar esta opção:**
-- Você precisa de uma referência rápida e gratuita aos ranges de IP da Azion.
-- Você está fazendo uma configuração pontual e não precisa de atualizações automáticas.
-- Nem todo o seu tráfego passa pela Azion ainda e você quer testar a configuração.
-
-**Limitações:**
-- A lista não é gerenciada pela Azion para fins de segurança de origem.
-- Ela não inclui todos os endereços que a Azion pode usar para se conectar à sua origem.
-- Você é responsável por verificar manualmente se há atualizações.
-
-### Passos
-
-1. Acesse [https://www.peeringdb.com/asn/52580](https://www.peeringdb.com/asn/52580).
-2. Na seção **Prefixes**, copie os prefixos IPv4 e IPv6 listados.
-3. Use esses prefixos para configurar o firewall do seu servidor de origem.
-
----
-
-## Opção 2: Obter ranges de IP via Origin Shield
-
-O **Origin Shield** é um add-on que fornece a lista de redes `Azion Origin Shield` — uma lista curada e atualizada dinamicamente com todos os prefixos IPv4 e IPv6 usados exclusivamente pela infraestrutura global da Azion para se conectar aos servidores de origem.
-
-**Quando usar esta opção:**
-- Você precisa de uma lista de IPs autoritativa e adequada para produção.
-- Você quer notificações automáticas por e-mail quando a lista for alterada.
-- Você está configurando uma allowlist rigorosa em um firewall ou security group.
-
-### Pré-requisitos
+## Pré-requisitos
 
 - O [módulo Network Shield](/pt-br/documentacao/produtos/secure/firewall/network-shield/) ativado no seu Firewall.
 - Uma assinatura ativa do add-on **Origin Shield**. Entre em contato com a [equipe de Vendas](https://www.azion.com/pt-br/contato/) para assinar.
 
-### Acesse a lista pelo Azion Console
+---
+
+## Acesse a lista pelo Azion Console
 
 1. Acesse o [Azion Console](https://console.azion.com) > **Network Lists**.
 2. Selecione **Azion Origin Shield** na lista.
 3. No campo **List**, copie todas as entradas de IP/CIDR.
 
-### Acesse a lista pela API
+---
+
+## Acesse a lista pela API
 
 Execute a seguinte requisição, substituindo `[TOKEN VALUE]` pelo seu [personal token](/pt-br/documentacao/produtos/guias/personal-tokens/):
 
@@ -108,20 +77,6 @@ O campo `ip_list` contém todos os prefixos atuais da Azion. Use esses valores p
 :::note
 A Azion envia uma notificação por e-mail toda vez que a lista é atualizada. Você tem **7 dias** para aplicar os novos endereços nas regras de firewall da sua origem ou nas automações antes que os novos servidores entrem em produção.
 :::
-
----
-
-## Escolhendo a abordagem correta
-
-| Requisito | PeeringDB | Origin Shield |
-|---|---|---|
-| Sem necessidade de assinatura | ✅ | ❌ Requer add-on |
-| Lista autoritativa da Azion | ❌ | ✅ |
-| Inclui todos os IPs voltados à origem | ❌ | ✅ |
-| Notificações automáticas de atualização | ❌ | ✅ E-mail a cada alteração |
-| Acesso via API para automação | ❌ | ✅ |
-| Suporte a IPv6 | Parcial | ✅ Completo |
-| Recomendado para produção | ❌ | ✅ |
 
 ---
 

--- a/src/content/docs/pt-br/pages/guias/network-layer-protection/obter-ranges-ip-azion/index.mdx
+++ b/src/content/docs/pt-br/pages/guias/network-layer-protection/obter-ranges-ip-azion/index.mdx
@@ -1,0 +1,204 @@
+---
+title: Como obter os ranges de IP da Azion para allowlist no servidor de origem
+description: >-
+  Saiba como obter os ranges de IP/CIDR da Azion para configurar allowlists no
+  seu servidor de origem, AWS ELB ou diretiva set_real_ip_from do Nginx.
+meta_tags: >-
+  ranges de ip azion, origin shield, ip allowlist, set_real_ip_from, nginx, aws
+  elb, peeringdb, network shield, segurança servidor de origem, ip cidr
+namespace: docs_guides_retrieve_azion_ip_ranges
+permalink: /documentacao/produtos/guias/obter-ranges-ip-azion/
+---
+
+import LinkButton from 'azion-webkit/linkbutton'
+import Code from '~/components/Code/Code.astro'
+
+Quando o servidor de origem da sua aplicação está atrás da Azion, todas as requisições de entrada chegam pela infraestrutura global da Azion — e não diretamente dos usuários finais. Para proteger sua origem, você precisa criar uma allowlist com apenas os ranges de IP/CIDR da Azion e bloquear todo o restante.
+
+Este guia cobre duas abordagens:
+
+- **PeeringDB (público, sem assinatura)**: Recupere os prefixos de IP registrados no Autonomous System da Azion (AS52580) em um banco de dados público de roteamento de internet. Use esta opção quando precisar de uma referência rápida ou de uma configuração pontual.
+- **Origin Shield (gerenciado, requer assinatura)**: Acesse uma lista curada e atualizada automaticamente de prefixos IPv4 e IPv6 mantida pela Azion. Use esta opção quando precisar de uma allowlist sempre atualizada para ambientes de produção, com notificações por e-mail a cada atualização.
+
+:::note
+As duas fontes servem a propósitos diferentes. O PeeringDB reflete prefixos anunciados via BGP e pode não incluir todos os endereços que a Azion usa para se conectar à sua origem. O **Origin Shield** é a lista autoritativa para segurança no nível de origem e é a abordagem recomendada para ambientes de produção.
+:::
+
+---
+
+## Opção 1: Obter ranges de IP pelo PeeringDB
+
+O [PeeringDB](https://www.peeringdb.com/asn/52580) é um banco de dados público de informações de interconexão de redes. A Azion opera sob o **AS52580**, e seus prefixos anunciados estão publicamente visíveis lá.
+
+**Quando usar esta opção:**
+- Você precisa de uma referência rápida e gratuita aos ranges de IP da Azion.
+- Você está fazendo uma configuração pontual e não precisa de atualizações automáticas.
+- Nem todo o seu tráfego passa pela Azion ainda e você quer testar a configuração.
+
+**Limitações:**
+- A lista não é gerenciada pela Azion para fins de segurança de origem.
+- Ela não inclui todos os endereços que a Azion pode usar para se conectar à sua origem.
+- Você é responsável por verificar manualmente se há atualizações.
+
+### Passos
+
+1. Acesse [https://www.peeringdb.com/asn/52580](https://www.peeringdb.com/asn/52580).
+2. Na seção **Prefixes**, copie os prefixos IPv4 e IPv6 listados.
+3. Use esses prefixos para configurar o firewall do seu servidor de origem ou o Nginx (veja o [exemplo de configuração do Nginx](#exemplo-de-set_real_ip_from-no-nginx) abaixo).
+
+---
+
+## Opção 2: Obter ranges de IP via Origin Shield
+
+O **Origin Shield** é um add-on que fornece a lista de redes `Azion Origin Shield` — uma lista curada e atualizada dinamicamente com todos os prefixos IPv4 e IPv6 usados exclusivamente pela infraestrutura global da Azion para se conectar aos servidores de origem.
+
+**Quando usar esta opção:**
+- Você precisa de uma lista de IPs autoritativa e adequada para produção.
+- Você quer notificações automáticas por e-mail quando a lista for alterada.
+- Você está configurando uma allowlist rigorosa no AWS ELB, nas regras de firewall do GCP ou em um security group nativo de nuvem.
+
+### Pré-requisitos
+
+- O [módulo Network Shield](/pt-br/documentacao/produtos/secure/firewall/network-shield/) ativado no seu Firewall.
+- Uma assinatura ativa do add-on **Origin Shield**. Entre em contato com a [equipe de Vendas](https://www.azion.com/pt-br/contato/) para assinar.
+
+### Acesse a lista pelo Azion Console
+
+1. Acesse o [Azion Console](https://console.azion.com) > **Network Lists**.
+2. Selecione **Azion Origin Shield** na lista.
+3. No campo **List**, copie todas as entradas de IP/CIDR.
+
+### Acesse a lista pela API
+
+Execute a seguinte requisição, substituindo `[TOKEN VALUE]` pelo seu [personal token](/pt-br/documentacao/produtos/guias/personal-tokens/):
+
+<Code lang="bash" code={`
+curl --request GET \\
+  --url https://api.azion.com/v4/workspace/network_lists \\
+  --header 'Accept: application/json' \\
+  --header 'Authorization: Token [TOKEN VALUE]'
+`} />
+
+A resposta incluirá a entrada `Azion Origin Shield`:
+
+<Code lang="json" code={`
+{
+  "count": 4,
+  "total_pages": 1,
+  "schema_version": 3,
+  "links": {
+    "previous": null,
+    "next": null
+  },
+  "results": [
+    {
+      "id": 2345,
+      "last_editor": "last.editor@azion.com",
+      "last_modified": "2023-03-27T21:19:27.996870Z",
+      "list_type": "ip_cidr",
+      "name": "Azion Origin Shield",
+      "country_list": [],
+      "ip_list": [
+        "192.0.2.0/24",
+        "2001:db8::/32"
+      ]
+    }
+  ]
+}
+`} />
+
+O campo `ip_list` contém todos os prefixos atuais da Azion. Use esses valores para configurar o firewall da sua origem.
+
+:::note
+A Azion envia uma notificação por e-mail toda vez que a lista é atualizada. Você tem **7 dias** para aplicar os novos endereços nas regras de firewall da sua origem ou nas automações antes que os novos servidores entrem em produção.
+:::
+
+---
+
+## Exemplo de `set_real_ip_from` no Nginx
+
+Se sua origem usa Nginx, utilize a diretiva `set_real_ip_from` para confiar no header `X-Forwarded-For` somente quando a requisição chegar de um IP conhecido da Azion. Isso impede que clientes falsifiquem seu endereço IP injetando um valor falso no `X-Forwarded-For`.
+
+Adicione o seguinte bloco à sua configuração do Nginx, substituindo os ranges de CIDR de exemplo pelos prefixos reais do Origin Shield ou do PeeringDB:
+
+<Code lang="nginx" code={`
+# Confiar no X-Forwarded-For apenas para ranges de IP da Azion
+# Substitua pelos prefixos reais do Origin Shield ou PeeringDB (AS52580)
+set_real_ip_from 192.0.2.0/24;
+set_real_ip_from 198.51.100.0/24;
+set_real_ip_from 2001:db8::/32;
+
+# Usar o último IP não confiável na cadeia X-Forwarded-For como IP real do cliente
+real_ip_header X-Forwarded-For;
+real_ip_recursive on;
+`} />
+
+Com essa configuração:
+- O Nginx substitui o IP de conexão pelo IP real do cliente a partir do `X-Forwarded-For`, mas somente quando a requisição vem de um endereço Azion confiável.
+- Requisições que chegam de IPs não presentes na lista `set_real_ip_from` são tratadas como não confiáveis, e o header `X-Forwarded-For` não é usado para resolução de IP.
+
+:::tip
+Para manter sua configuração do Nginx sempre atualizada, automatize a recuperação da lista do Origin Shield via API da Azion e regenere o bloco `set_real_ip_from` a cada atualização. Veja [Automatize a adição de novos endereços](/pt-br/documentacao/produtos/secure/proteja-infraestrutura/#passo-3-automatize-a-adicao-de-novos-enderecos) para uma abordagem baseada em Rules Engine.
+:::
+
+---
+
+## Exemplo com AWS ELB (Elastic Load Balancer)
+
+Para criar uma allowlist de IPs da Azion em um AWS Application Load Balancer (ALB) ou Network Load Balancer (NLB), configure uma regra de entrada no **Security Group** para cada prefixo CIDR da Azion.
+
+Usando a AWS CLI, adicione uma regra de entrada para cada prefixo:
+
+<Code lang="bash" code={`
+aws ec2 authorize-security-group-ingress \\
+  --group-id sg-xxxxxxxxxxxxxxxxx \\
+  --protocol tcp \\
+  --port 443 \\
+  --cidr 192.0.2.0/24
+`} />
+
+Repita esse comando para cada CIDR na lista do Origin Shield. Para automatizar esse processo, recupere a lista pela API da Azion e itere sobre as entradas de `ip_list`:
+
+<Code lang="bash" code={`
+# Recuperar a lista do Origin Shield e adicionar cada CIDR ao security group
+AZION_IPS=$(curl -s --request GET \\
+  --url https://api.azion.com/v4/workspace/network_lists \\
+  --header 'Accept: application/json' \\
+  --header 'Authorization: Token [TOKEN VALUE]' | \\
+  jq -r '.results[] | select(.name == "Azion Origin Shield") | .ip_list[]')
+
+for CIDR in $AZION_IPS; do
+  aws ec2 authorize-security-group-ingress \\
+    --group-id sg-xxxxxxxxxxxxxxxxx \\
+    --protocol tcp \\
+    --port 443 \\
+    --cidr "$CIDR"
+done
+`} />
+
+:::note
+Os Security Groups da AWS têm um limite padrão de 60 regras de entrada por grupo. Se a lista do Origin Shield ultrapassar esse limite, solicite um aumento de cota à AWS ou use uma prefix list para consolidar as entradas.
+:::
+
+---
+
+## Escolhendo a abordagem correta
+
+| Requisito | PeeringDB | Origin Shield |
+|---|---|---|
+| Sem necessidade de assinatura | ✅ | ❌ Requer add-on |
+| Lista autoritativa da Azion | ❌ | ✅ |
+| Inclui todos os IPs voltados à origem | ❌ | ✅ |
+| Notificações automáticas de atualização | ❌ | ✅ E-mail a cada alteração |
+| Acesso via API para automação | ❌ | ✅ |
+| Suporte a IPv6 | Parcial | ✅ Completo |
+| Recomendado para produção | ❌ | ✅ |
+
+---
+
+## Recursos relacionados
+
+<LinkButton link="/pt-br/documentacao/produtos/secure/proteja-infraestrutura/" label="Proteja sua infraestrutura" severity="secondary" />
+<LinkButton link="/pt-br/documentacao/produtos/secure/connectors/origin-shield/" label="Referência do Origin Shield" severity="secondary" />
+<LinkButton link="/pt-br/documentacao/produtos/secure/firewall/network-shield/" label="Referência do Network Shield" severity="secondary" />
+<LinkButton link="/pt-br/documentacao/produtos/secure/edge-firewall/network-layer-protection/network-lists/" label="Referência de Network Lists" severity="secondary" />

--- a/src/content/docs/pt-br/pages/guias/network-layer-protection/obter-ranges-ip-azion/index.mdx
+++ b/src/content/docs/pt-br/pages/guias/network-layer-protection/obter-ranges-ip-azion/index.mdx
@@ -2,10 +2,9 @@
 title: Como obter os ranges de IP da Azion para allowlist no servidor de origem
 description: >-
   Saiba como obter os ranges de IP/CIDR da Azion para configurar allowlists no
-  seu servidor de origem, AWS ELB ou diretiva set_real_ip_from do Nginx.
+  seu servidor de origem via PeeringDB ou Origin Shield.
 meta_tags: >-
-  ranges de ip azion, origin shield, ip allowlist, set_real_ip_from, nginx, aws
-  elb, peeringdb, network shield, segurança servidor de origem, ip cidr
+  ranges de ip azion, origin shield, ip allowlist, peeringdb, network shield, segurança servidor de origem, ip cidr
 namespace: docs_guides_retrieve_azion_ip_ranges
 permalink: /documentacao/produtos/guias/obter-ranges-ip-azion/
 ---
@@ -15,10 +14,7 @@ import Code from '~/components/Code/Code.astro'
 
 Quando o servidor de origem da sua aplicação está atrás da Azion, todas as requisições de entrada chegam pela infraestrutura global da Azion — e não diretamente dos usuários finais. Para proteger sua origem, você precisa criar uma allowlist com apenas os ranges de IP/CIDR da Azion e bloquear todo o restante.
 
-Este guia cobre duas abordagens:
-
-- **PeeringDB (público, sem assinatura)**: Recupere os prefixos de IP registrados no Autonomous System da Azion (AS52580) em um banco de dados público de roteamento de internet. Use esta opção quando precisar de uma referência rápida ou de uma configuração pontual.
-- **Origin Shield (gerenciado, requer assinatura)**: Acesse uma lista curada e atualizada automaticamente de prefixos IPv4 e IPv6 mantida pela Azion. Use esta opção quando precisar de uma allowlist sempre atualizada para ambientes de produção, com notificações por e-mail a cada atualização.
+Este guia explica como consultar esses ranges de IP, seja pelo PeeringDB (público, sem assinatura) ou pelo Origin Shield (gerenciado, requer assinatura).
 
 :::note
 As duas fontes servem a propósitos diferentes. O PeeringDB reflete prefixos anunciados via BGP e pode não incluir todos os endereços que a Azion usa para se conectar à sua origem. O **Origin Shield** é a lista autoritativa para segurança no nível de origem e é a abordagem recomendada para ambientes de produção.
@@ -44,7 +40,7 @@ O [PeeringDB](https://www.peeringdb.com/asn/52580) é um banco de dados público
 
 1. Acesse [https://www.peeringdb.com/asn/52580](https://www.peeringdb.com/asn/52580).
 2. Na seção **Prefixes**, copie os prefixos IPv4 e IPv6 listados.
-3. Use esses prefixos para configurar o firewall do seu servidor de origem ou o Nginx (veja o [exemplo de configuração do Nginx](#exemplo-de-set_real_ip_from-no-nginx) abaixo).
+3. Use esses prefixos para configurar o firewall do seu servidor de origem.
 
 ---
 
@@ -55,7 +51,7 @@ O **Origin Shield** é um add-on que fornece a lista de redes `Azion Origin Shie
 **Quando usar esta opção:**
 - Você precisa de uma lista de IPs autoritativa e adequada para produção.
 - Você quer notificações automáticas por e-mail quando a lista for alterada.
-- Você está configurando uma allowlist rigorosa no AWS ELB, nas regras de firewall do GCP ou em um security group nativo de nuvem.
+- Você está configurando uma allowlist rigorosa em um firewall ou security group.
 
 ### Pré-requisitos
 
@@ -111,73 +107,6 @@ O campo `ip_list` contém todos os prefixos atuais da Azion. Use esses valores p
 
 :::note
 A Azion envia uma notificação por e-mail toda vez que a lista é atualizada. Você tem **7 dias** para aplicar os novos endereços nas regras de firewall da sua origem ou nas automações antes que os novos servidores entrem em produção.
-:::
-
----
-
-## Exemplo de `set_real_ip_from` no Nginx
-
-Se sua origem usa Nginx, utilize a diretiva `set_real_ip_from` para confiar no header `X-Forwarded-For` somente quando a requisição chegar de um IP conhecido da Azion. Isso impede que clientes falsifiquem seu endereço IP injetando um valor falso no `X-Forwarded-For`.
-
-Adicione o seguinte bloco à sua configuração do Nginx, substituindo os ranges de CIDR de exemplo pelos prefixos reais do Origin Shield ou do PeeringDB:
-
-<Code lang="nginx" code={`
-# Confiar no X-Forwarded-For apenas para ranges de IP da Azion
-# Substitua pelos prefixos reais do Origin Shield ou PeeringDB (AS52580)
-set_real_ip_from 192.0.2.0/24;
-set_real_ip_from 198.51.100.0/24;
-set_real_ip_from 2001:db8::/32;
-
-# Usar o último IP não confiável na cadeia X-Forwarded-For como IP real do cliente
-real_ip_header X-Forwarded-For;
-real_ip_recursive on;
-`} />
-
-Com essa configuração:
-- O Nginx substitui o IP de conexão pelo IP real do cliente a partir do `X-Forwarded-For`, mas somente quando a requisição vem de um endereço Azion confiável.
-- Requisições que chegam de IPs não presentes na lista `set_real_ip_from` são tratadas como não confiáveis, e o header `X-Forwarded-For` não é usado para resolução de IP.
-
-:::tip
-Para manter sua configuração do Nginx sempre atualizada, automatize a recuperação da lista do Origin Shield via API da Azion e regenere o bloco `set_real_ip_from` a cada atualização. Veja [Automatize a adição de novos endereços](/pt-br/documentacao/produtos/secure/proteja-infraestrutura/#passo-3-automatize-a-adicao-de-novos-enderecos) para uma abordagem baseada em Rules Engine.
-:::
-
----
-
-## Exemplo com AWS ELB (Elastic Load Balancer)
-
-Para criar uma allowlist de IPs da Azion em um AWS Application Load Balancer (ALB) ou Network Load Balancer (NLB), configure uma regra de entrada no **Security Group** para cada prefixo CIDR da Azion.
-
-Usando a AWS CLI, adicione uma regra de entrada para cada prefixo:
-
-<Code lang="bash" code={`
-aws ec2 authorize-security-group-ingress \\
-  --group-id sg-xxxxxxxxxxxxxxxxx \\
-  --protocol tcp \\
-  --port 443 \\
-  --cidr 192.0.2.0/24
-`} />
-
-Repita esse comando para cada CIDR na lista do Origin Shield. Para automatizar esse processo, recupere a lista pela API da Azion e itere sobre as entradas de `ip_list`:
-
-<Code lang="bash" code={`
-# Recuperar a lista do Origin Shield e adicionar cada CIDR ao security group
-AZION_IPS=$(curl -s --request GET \\
-  --url https://api.azion.com/v4/workspace/network_lists \\
-  --header 'Accept: application/json' \\
-  --header 'Authorization: Token [TOKEN VALUE]' | \\
-  jq -r '.results[] | select(.name == "Azion Origin Shield") | .ip_list[]')
-
-for CIDR in $AZION_IPS; do
-  aws ec2 authorize-security-group-ingress \\
-    --group-id sg-xxxxxxxxxxxxxxxxx \\
-    --protocol tcp \\
-    --port 443 \\
-    --cidr "$CIDR"
-done
-`} />
-
-:::note
-Os Security Groups da AWS têm um limite padrão de 60 regras de entrada por grupo. Se a lista do Origin Shield ultrapassar esse limite, solicite um aumento de cota à AWS ou use uma prefix list para consolidar as entradas.
 :::
 
 ---

--- a/src/content/docs/pt-br/pages/menu-principal/referencia/secure/edge-connector/origin-shield.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/referencia/secure/edge-connector/origin-shield.mdx
@@ -24,6 +24,7 @@ A lista de redes **Azion Origin Shield** agora inclui prefixos IPv6 de todos os 
 | Escopo | Recurso |
 | --- | --- |
 | Proteger uma Aplicação | [Proteger uma Aplicação](/pt-br/documentacao/produtos/secure/proteja-infraestrutura/) |
+| Obter ranges de IP para allowlist na origem | [Como obter os ranges de IP da Azion](/pt-br/documentacao/produtos/guias/obter-ranges-ip-azion/) |
 | Connector | [Connector](/pt-br/documentacao/produtos/secure/connectors/) |
 | Primeiros passos com Application | [Primeiros passos](/pt-br/documentacao/produtos/build/applications/primeiros-passos/) |
 

--- a/src/content/docs/pt-br/pages/secure-jornada/proteja-infraestrutura.mdx
+++ b/src/content/docs/pt-br/pages/secure-jornada/proteja-infraestrutura.mdx
@@ -14,6 +14,10 @@ Após [criar um firewall e proteger sua aplicação](/pt-br/documentacao/produto
 
 O **Origin Shield** fornece uma lista de prefixos IPv4 e IPv6 usados exclusivamente pela Azion em sua infraestrutura global, garantindo que apenas IPs confiáveis da Azion tenham acesso. A lista é mantida pela Azion e disponibilizada via Console e API. Cabe ao cliente automatizar a atualização de suas políticas de segurança para mantê-las alinhadas com os endereços atuais do Origin Shield.
 
+:::tip
+Se você precisa dos ranges de IP da Azion para configurar uma allowlist no seu servidor de origem, no `set_real_ip_from` do Nginx ou em um firewall de nuvem como o AWS ELB, consulte [Como obter os ranges de IP da Azion para allowlist no servidor de origem](/pt-br/documentacao/produtos/guias/obter-ranges-ip-azion/).
+:::
+
 :::note
 A lista de redes **Azion Origin Shield** agora inclui prefixos IPv6 de todos os data centers da Azion. Se você usa essa lista em regras de firewall ou automações, revise suas configurações de filtro para garantir que elas lidem corretamente com o tamanho atualizado da lista.
 :::


### PR DESCRIPTION
…ing in English and Portuguese

<!--
Thank you for contributing to Azion Docs! Please fill out the information below.
Use the conventional commits standard to categorize the type of change in the PR title. We recommend:
- feat: adding new content
- refactor: making minor changes
- fix: fixing errors

Don't forget to add the Jira issue code to the PR title or the GitHub issue hash.
For example: 
- [EDU-3000] refactor: modify origins page to include load balancer
- [#34] feat: add new application CLI commands
- [NO-ISSUE] fix: fix broken link in Orch doc
-->

### Related issue: EDU-6646

## docs: add guide for retrieving Azion IP ranges for origin server allowlisting

### What changed

Added a new how-to guide (EN + PT-BR) explaining how to retrieve Azion's IP/CIDR ranges via Origin Shield to configure allowlists on origin servers. Updated cross-references in the `secure-infrastructure` journey page and the `Origin Shield` reference page for both languages.

### Why

Recurring support requests showed users couldn't find a clear, actionable answer for allowlisting Azion IPs on their origin server or firewall. Copilot was also not surfacing Origin Shield as the recommended solution.

### Files changed

| File | Change |
|---|---|
| `src/content/docs/en/pages/guides/network-layer-protection/retrieve-azion-ip-ranges/index.mdx` | **New** — EN guide |
| `src/content/docs/pt-br/pages/guias/network-layer-protection/obter-ranges-ip-azion/index.mdx` | **New** — PT-BR guide |
| `src/content/docs/en/pages/secure-journey/secure-infrastructure.mdx` | Added `:::tip` callout linking to the new EN guide |
| `src/content/docs/en/pages/main-menu/reference/secure/edge-connector/origin-shield.mdx` | Added row in Implementation table linking to the new EN guide |
| `src/content/docs/pt-br/pages/secure-jornada/proteja-infraestrutura.mdx` | Added `:::tip` callout linking to the new PT-BR guide |
| `src/content/docs/pt-br/pages/menu-principal/referencia/secure/edge-connector/origin-shield.mdx` | Added row in Implementação table linking to the new PT-BR guide |

### Content coverage

- **Origin Shield** — authoritative list accessible via Console and API, with 7-day update window note.
- **Prerequisites** — Network Shield module and active Origin Shield subscription.

### Checklist

- [x] Follows Azion brand voice (no forbidden terms, correct product naming)
- [x] Uses RFC 5737 / RFC 3849 reserved ranges in all code examples (no real IPs exposed)
- [x] Frontmatter follows existing doc patterns (namespace, permalink, meta_tags)
- [x] EN and PT-BR share the same `namespace` (`docs_guides_retrieve_azion_ip_ranges`)
- [x] Non-translatable terms preserved in English in PT-BR version (`allowlist`, `Origin Shield`, `Network Shield`)

[EDU-3000]: https://aziontech.atlassian.net/browse/EDU-3000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ