### PR TITLE
Enhance documentation on Node.js API compatibility and polyfills, add…

### DIFF
--- a/src/content/docs/en/pages/devtools/azion-edge-runtime/compatibility/node-polyfills/cells-node.mdx
+++ b/src/content/docs/en/pages/devtools/azion-edge-runtime/compatibility/node-polyfills/cells-node.mdx
@@ -60,7 +60,25 @@ The Azion Runtime provides native support for the File System (FS) module, allow
 
 A polyfill is a code snippet, often used in JavaScript, that brings new features to environments lacking these capabilities. Polyfills are used during build time at Azion and can be configured through the [azion.config.js](/en/documentation/devtools/cli/configs/azion-config-js/) file.
 
-The following Node APIs are supported through polyfills, along with their respective supported methods. 
+The following Node APIs are supported through polyfills, along with their respective supported methods.
+
+**Status legend:**
+
+- 🟢 **Supported**: the API works normally at runtime.
+- 🟡 **Partially supported**: only some methods or features are available.
+- 🔴 **Build-only**: the module is included so the build process completes without errors, but API calls do not work at runtime.
+
+:::note[About the Azion Cells runtime environment]
+Functions on Azion run inside **Cells**, an isolation environment based on **V8 Isolates**. Each Cell is a lightweight, secure execution context with no direct access to the underlying operating system.
+
+For multi-tenant security and infrastructure integrity reasons, Cells do not allow:
+
+- Access to operating system properties (such as hostname, platform, or CPU/memory information via `node:os`).
+- DNS resolution via native system calls (`node:dns`, `node:dns/promises`).
+- Creation of low-level TCP/UDP sockets that require direct syscalls.
+
+Modules marked as 🔴 **Build-only** are included as stubs to ensure that NPM packages with static dependencies on these modules can be compiled. Calls to these modules at runtime produce no results and may return default values or throw silent errors.
+:::
 
 | Module                | Status |
 |-----------------------|--------|
@@ -89,8 +107,8 @@ The following Node APIs are supported through polyfills, along with their respec
 | [crypto](/en/documentation/products/azion-edge-runtime/compatibility/node/crypto/)          | 🟡 Partially supported     |
 | dgram           | 🟢 Supported     |
 | diagnostics_channel | 🟢 Supported     |
-| dns             | 🟢 Supported     |
-| dns/promises    | 🟢 Supported     |
+| dns             | 🔴 Build-only     |
+| dns/promises    | 🔴 Build-only     |
 | domain          | 🟢 Supported     |
 | [events](/en/documentation/products/azion-edge-runtime/compatibility/node/events/)          | 🟢 Supported     |
 | [fs](/en/documentation/products/azion-edge-runtime/compatibility/node/fs/)              | 🟡 Partially supported     |
@@ -102,7 +120,7 @@ The following Node APIs are supported through polyfills, along with their respec
 | inspector/promises    | 🟡 Partially supported     |
 | [module](/en/documentation/products/azion-edge-runtime/compatibility/node/module/)          | 🟡 Partially supported     |
 | net             | 🟡 Partially supported     |
-| [os](/en/documentation/products/azion-edge-runtime/compatibility/node/os/)              | 🟢 Supported     |
+| [os](/en/documentation/products/azion-edge-runtime/compatibility/node/os/)              | 🔴 Build-only     |
 | [path](/en/documentation/products/azion-edge-runtime/compatibility/node/path/)            | 🟢 Supported     |
 | path/posix            | 🟡 Partially supported     |
 | path/win32           | 🟡 Partially supported     |

--- a/src/content/docs/en/pages/devtools/azion-edge-runtime/compatibility/use-polyfills.mdx
+++ b/src/content/docs/en/pages/devtools/azion-edge-runtime/compatibility/use-polyfills.mdx
@@ -185,6 +185,34 @@ Now you can check the logs in the terminal and see the Buffer API working throug
 You can access a list of APIs resolved through polyfills by Azion Bundler build on [its repository](https://github.com/aziontech/bundler) and on [Azion's compatibility documentation](/en/documentation/products/azion-edge-runtime/compatibility/node/). Azion Bundler's an **open-source** project and you can propose new presets and implementations.
 :::
 
-
-
 ---
+
+## Deploy the function to Azion
+
+After testing locally with `azion dev`, deploy your function to the Azion Platform:
+
+13. Run the deploy command:
+
+```bash
+azion deploy
+```
+
+The CLI builds the project, applies the configured polyfills, and publishes the function to the platform. At the end of the process, you'll receive the URL to access your application.
+
+### Useful deploy flags
+
+| Flag | Description |
+|------|-------------|
+| `--auto` | Runs the complete build, provisioning, and distribution flow without interruptions or interactive prompts. |
+| `--workers <number>` | Sets the number of parallel workers for uploading static files to Object Storage. By default, it's automatically calculated based on available CPU cores (maximum: 20). |
+| `--dry-run` | Simulates the deploy process locally, validating the generated routing rules without affecting production resources. |
+
+**Example with flags:**
+
+```bash
+azion deploy --auto --workers 10
+```
+
+:::note
+The build process applies polyfills automatically based on the `azion.config.js` file configuration. Make sure the required modules are listed in the `polyfills` property before deploying.
+:::

--- a/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/compatibilidade/node-polyfills/node.mdx
+++ b/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/compatibilidade/node-polyfills/node.mdx
@@ -63,6 +63,24 @@ Um polyfill é um trecho de código, frequentemente usado em JavaScript, que tra
 
 A tabela abaixo contém a compatibilidade dos módulos Node.Js resolvidos com polyfills.
 
+**Legenda de status:**
+
+- 🟢 **Suportada**: a API funciona normalmente em tempo de execução.
+- 🟡 **Parcialmente suportada**: apenas alguns métodos ou funcionalidades estão disponíveis.
+- 🔴 **Somente para build**: o módulo é incluído para que o processo de build seja concluído sem erros, mas as chamadas à API não funcionam em tempo de execução.
+
+:::note[Sobre o ambiente de execução Azion Cells]
+As functions na Azion são executadas dentro de **Cells**, um ambiente de isolamento baseado em **V8 Isolates**. Cada Cell é um contexto de execução leve e seguro, sem acesso direto ao sistema operacional subjacente.
+
+Por razões de segurança multilocatário e integridade da infraestrutura, as Cells não permitem:
+
+- Acesso a propriedades do sistema operacional (como hostname, plataforma ou informações de CPU/memória via `node:os`).
+- Resolução de DNS via chamadas de sistema nativas (`node:dns`, `node:dns/promises`).
+- Criação de sockets TCP/UDP de baixo nível que exijam syscalls diretas.
+
+Módulos marcados como 🔴 **Somente para build** são incluídos como stubs para garantir que pacotes NPM com dependências estáticas nesses módulos possam ser compilados. As chamadas a esses módulos em runtime não produzem resultados e podem retornar valores padrão ou lançar erros silenciosos.
+:::
+
 | Module                | Status |
 |-----------------------|--------|
 | _http_agent           | 🟡  Parcialmente suportada     |
@@ -90,8 +108,8 @@ A tabela abaixo contém a compatibilidade dos módulos Node.Js resolvidos com po
 | [crypto](/pt-br/documentacao/produtos/devtools/azion-edge-runtime/compatibilidade/node/crypto/)          | 🟡  Parcialmente suportada    |
 | dgram           | 🟢 Suportada     |
 | diagnostics_channel | 🟢 Suportada     |
-| dns             | 🟢 Suportada     |
-| dns/promises    | 🟢 Suportada     |
+| dns             | 🔴  Somente para build     |
+| dns/promises    | 🔴  Somente para build     |
 | domain          | 🟢 Suportada     |
 | [events](/pt-br/documentacao/produtos/devtools/azion-edge-runtime/compatibilidade/node/events/)          | 🟢 Suportada     |
 | [fs](/pt-br/documentacao/produtos/devtools/azion-edge-runtime/compatibilidade/node/fs/)              | 🟡  Parcialmente suportada    |
@@ -103,7 +121,7 @@ A tabela abaixo contém a compatibilidade dos módulos Node.Js resolvidos com po
 | inspector/promises    | 🟡  Parcialmente suportada     |
 | [module](/pt-br/documentacao/produtos/devtools/azion-edge-runtime/compatibilidade/node/module/)          | 🟡  Parcialmente suportada    |
 | net             | 🟡  Parcialmente suportada    |
-| [os](/pt-br/documentacao/produtos/devtools/azion-edge-runtime/compatibilidade/node/os/)              | 🟢 Suportada     |
+| [os](/pt-br/documentacao/produtos/devtools/azion-edge-runtime/compatibilidade/node/os/)              | 🔴  Somente para build     |
 | [path](/pt-br/documentacao/produtos/devtools/azion-edge-runtime/compatibilidade/node/path/)            | 🟢 Suportada     |
 | path/posix            | 🟡  Parcialmente suportada     |
 | path/win32           | 🟡  Parcialmente suportada     |

--- a/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/compatibilidade/use-polyfills.mdx
+++ b/src/content/docs/pt-br/pages/devtools/azion-edge-runtime/compatibilidade/use-polyfills.mdx
@@ -184,3 +184,35 @@ Agora você pode verificar os logs no terminal e ver a API Buffer funcionando at
 :::tip
 Você pode acessar uma lista de APIs que são resolvidas através de polyfills no [repósitório do Azion Bundler](https://github.com/aziontech/bundler) e na [documentacão de compatibilidade da Azion](/pt-br/documentacao/produtos/devtools/azion-edge-runtime/compatibilidade/node/). Azion Bundler é um projeto **open-source** e você pode propor novos presets e implementações.
 :::
+
+---
+
+## Fazer o deploy da function na Azion
+
+Após testar localmente com `azion dev`, faça o deploy da sua function para a Azion Platform:
+
+13. Execute o comando de deploy:
+
+```bash
+azion deploy
+```
+
+O CLI realiza o build do projeto, aplica os polyfills configurados e publica a function na plataforma. Ao final do processo, você receberá a URL de acesso à sua aplicação.
+
+### Opções úteis do comando deploy
+
+| Flag | Descrição |
+|------|-----------|
+| `--auto` | Executa o fluxo completo de build, provisionamento e distribuição sem interrupções ou prompts interativos. |
+| `--workers <número>` | Define o número de workers paralelos para upload de arquivos estáticos para o Object Storage. Por padrão, é calculado automaticamente com base nos núcleos de CPU disponíveis (máximo: 20). |
+| `--dry-run` | Simula o processo de deploy localmente, validando as regras de roteamento geradas sem afetar recursos em produção. |
+
+**Exemplo com flags:**
+
+```bash
+azion deploy --auto --workers 10
+```
+
+:::note
+O processo de build aplica os polyfills automaticamente com base na configuração do arquivo `azion.config.js`. Certifique-se de que os módulos necessários estão listados na propriedade `polyfills` antes de fazer o deploy.
+:::


### PR DESCRIPTION
…ing status legends and deployment instructions for Azion functions.

<!--
Thank you for contributing to Azion Docs! Please fill out the information below.
Use the conventional commits standard to categorize the type of change in the PR title. We recommend:
- feat: adding new content
- refactor: making minor changes
- fix: fixing errors

Don't forget to add the Jira issue code to the PR title or the GitHub issue hash.
For example: 
- [EDU-3000] refactor: modify origins page to include load balancer
- [#34] feat: add new application CLI commands
- [NO-ISSUE] fix: fix broken link in Orch doc
-->

### Related issue: EDU-6567


## docs: fix polyfill compatibility and add deploy section

### Summary

This PR addresses two documentation accuracy issues and adds missing deployment guidance for the polyfills guide.

### Changes

#### `use-polyfills.mdx` (PT-BR + EN)

- **Added deploy section** after the local testing step (`azion dev`). The guide previously ended without explaining how to publish the function to the Azion Platform.
- Added step 13 with the `azion deploy` command.
- Added a table documenting useful deploy flags (`--auto`, `--workers`, `--dry-run`) with descriptions sourced directly from the CLI source code.
- Added a usage example combining `--auto` and `--workers`.
- Added a `:::note` callout reminding users to configure the `polyfills` property in `azion.config.js` before deploying.

#### `node.mdx` / `cells-node.mdx` (PT-BR + EN)

- **Corrected compatibility status** for `dns`, `dns/promises`, and `os` modules:
  - **Before:** `🟢 Supported` (EN) / `🟢 Suportada` (PT-BR)
  - **After:** `🔴 Build-only` (EN) / `🔴 Somente para build` (PT-BR)
  - These modules are included as stubs to allow NPM packages with static dependencies to compile, but their API calls do not function at runtime due to Azion Cells environment restrictions.
- **Added status legend** before the polyfills table, explaining the three support levels (🟢 / 🟡 / 🔴).
- **Added architectural callout** (`:::note[About the Azion Cells runtime environment]`) explaining that functions run inside V8 Isolate-based Cells, which block OS property access, native DNS resolution, and low-level socket syscalls for multi-tenant security reasons.

### Motivation

- The `dns`, `dns/promises`, and `os` modules were incorrectly documented as fully supported, which could lead developers to ship broken code expecting runtime DNS resolution or OS information.
- The `os` module does not work at runtime due to Cells' isolation model (no access to underlying OS properties).
- The polyfills guide lacked a deploy step, leaving developers without a complete end-to-end workflow.

### Files changed

- `src/content/docs/pt-br/pages/devtools/azion-edge-runtime/compatibilidade/use-polyfills.mdx`
- `src/content/docs/pt-br/pages/devtools/azion-edge-runtime/compatibilidade/node-polyfills/node.mdx`
- `src/content/docs/en/pages/devtools/azion-edge-runtime/compatibility/use-polyfills.mdx`
- `src/content/docs/en/pages/devtools/azion-edge-runtime/compatibility/node-polyfills/cells-node.mdx`


[EDU-3000]: https://aziontech.atlassian.net/browse/EDU-3000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ