### PR TITLE
[MM-15278] feat(seo): emit VideoObject JSON-LD on doc pages with video

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -32,7 +32,9 @@ export default defineConfig({
 		assets: '_astro_docs'
 	},
 	integrations: [
-		AutoImport({ imports: [asideAutoImport] }),
+		AutoImport({
+			imports: [asideAutoImport, { '~/components/Video.astro': [['default', 'Video']] }],
+		}),
 		preact({ compat: true }),
 		sitemap(),
 		astroAsides(),

--- a/src/components/HeadSEO.astro
+++ b/src/components/HeadSEO.astro
@@ -20,14 +20,10 @@ import { normalizeLangTag } from '~/i18n/bcp-normalize';
 import { useTranslations } from '~/i18n/util';
 import { getLanguageFromURL, normalizePathSlashes, removeLeadingSlash, removeTrailingSlash } from '~/util';
 import ogImage from '~/util/ogImage';
-import { getVideoObjectSchema } from '~/util/videoObject';
 
 const {  content, canonicalURL, translatedPages } = Astro.props;
 const defaultPage = translatedPages?.find(item => item.lang === 'en') || translatedPages?.find(item => item.lang === 'pt-br');
 const image = ogImage(content.title, content.description || '');
-
-// Only emit a VideoObject when the page explicitly declares a video in its frontmatter.
-const videoSchema = content.video ? getVideoObjectSchema(content.video, content) : null;
 
 const t = useTranslations(Astro);
 const lang = getLanguageFromURL(canonicalURL?.pathname || '/');
@@ -41,12 +37,6 @@ const getAlternateHref = (lang: string, slug: string) => {
 ---
 
 <link rel="canonical" href={canonicalURL} />
-
-{
-  videoSchema ? (
-    <script is:inline type="application/ld+json" set:html={JSON.stringify(videoSchema)} />
-  ) : null
-}
 
 {
   translatedPages ?

--- a/src/components/HeadSEO.astro
+++ b/src/components/HeadSEO.astro
@@ -20,10 +20,14 @@ import { normalizeLangTag } from '~/i18n/bcp-normalize';
 import { useTranslations } from '~/i18n/util';
 import { getLanguageFromURL, normalizePathSlashes, removeLeadingSlash, removeTrailingSlash } from '~/util';
 import ogImage from '~/util/ogImage';
+import { getVideoObjectSchema } from '~/util/videoObject';
 
 const {  content, canonicalURL, translatedPages } = Astro.props;
 const defaultPage = translatedPages?.find(item => item.lang === 'en') || translatedPages?.find(item => item.lang === 'pt-br');
 const image = ogImage(content.title, content.description || '');
+
+// Only emit a VideoObject when the page explicitly declares a video in its frontmatter.
+const videoSchema = content.video ? getVideoObjectSchema(content.video, content) : null;
 
 const t = useTranslations(Astro);
 const lang = getLanguageFromURL(canonicalURL?.pathname || '/');
@@ -37,6 +41,12 @@ const getAlternateHref = (lang: string, slug: string) => {
 ---
 
 <link rel="canonical" href={canonicalURL} />
+
+{
+  videoSchema ? (
+    <script is:inline type="application/ld+json" set:html={JSON.stringify(videoSchema)} />
+  ) : null
+}
 
 {
   translatedPages ?

--- a/src/components/Video.astro
+++ b/src/components/Video.astro
@@ -1,42 +1,78 @@
 ---
-import { parse } from 'node:path';
-import { getLanguageFromURL } from '../util';
-import languages from '../i18n/languages';
+/**
+ * Single source of truth for embedded videos in the docs.
+ *
+ * From one authoring point (`<Video src="…" title="…" />`) it renders BOTH:
+ * 1. a responsive YouTube `<iframe>` embed, and
+ * 2. an inline `<script type="application/ld+json">` with a schema.org
+ *    `VideoObject` (so Google can index the video and show rich results).
+ *
+ * Emitting the JSON-LD inline next to the embed is valid for Google — it does
+ * not need to live in `<head>` or in an `@graph`.
+ */
+import { SITE_URL } from '~/consts';
+import { getVideoObjectSchema, getYouTubeId } from '~/util/videoObject';
 
 export interface Props {
+	/** YouTube embed URL, e.g. `https://www.youtube.com/embed/KB4f4bSyHgI`. */
 	src: string;
-	type: string;
+	/** Video title (required — used as the accessible iframe title and schema `name`). */
+	title: string;
+	/** Optional video description for the structured data. */
+	description?: string;
+	/** Overrides the thumbnail derived from the YouTube ID. */
+	thumbnailUrl?: string;
+	/** ISO 8601 date used as `uploadDate` (e.g. `2023-07-03`). */
+	uploadDate?: string;
+	/** ISO 8601 duration (e.g. `PT1M30S`). Optional. */
+	duration?: string;
 }
 
-const { src, type } = Astro.props as Props;
-const url = new URL(Astro.request.url);
-const lang = getLanguageFromURL(url.pathname);
-const filename = parse(src).name;
+const { src, title, description, thumbnailUrl, uploadDate, duration } = Astro.props;
 
-const allCaptions = import.meta.glob('../../public/captions/**/*.vtt', { as: 'raw' });
-const fileCaptions = Object.keys(allCaptions)
-	.map((caption) => {
-		const dir = '/captions/';
-		const path = caption.substring(caption.indexOf(dir));
-		const lang = path.substring(dir.length, path.indexOf(filename) - 1);
-		return { path, lang };
-	})
-	.filter(({ path }) => path.includes(filename));
+// Stable, page-scoped @id so the node is unambiguous and unique per video.
+const youtubeId = getYouTubeId(src);
+const canonical = new URL(Astro.url.pathname, SITE_URL).href;
+const id = `${canonical}#video${youtubeId ? `-${youtubeId}` : ''}`;
 
-const defaultLang = fileCaptions.find((caption) => caption.lang == lang) ? lang : 'en';
+const schema = getVideoObjectSchema({
+	src,
+	title,
+	description,
+	thumbnailUrl,
+	uploadDate,
+	duration,
+	id,
+});
 ---
 
-<video controls>
-	<source src={src} type={type} />
-	{
-		fileCaptions.map(({ lang, path }) => (
-			<track
-				label={languages[lang as keyof typeof languages]}
-				src={path}
-				kind="captions"
-				srclang={lang}
-				default={lang == defaultLang}
-			/>
-		))
+<div class="video-embed">
+	<iframe
+		src={src}
+		title={title}
+		loading="lazy"
+		frameborder="0"
+		allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+		referrerpolicy="strict-origin-when-cross-origin"
+		allowfullscreen></iframe>
+</div>
+
+<script is:inline type="application/ld+json" set:html={JSON.stringify(schema)} />
+
+<style>
+	.video-embed {
+		position: relative;
+		width: 100%;
+		aspect-ratio: 16 / 9;
+		margin: 1.5rem 0;
 	}
-</video>
+
+	.video-embed iframe {
+		position: absolute;
+		inset: 0;
+		width: 100%;
+		height: 100%;
+		border: 0;
+		border-radius: 0.5rem;
+	}
+</style>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -13,6 +13,17 @@ export const baseSchema = z.object({
 	i18nReady: z.boolean().default(false),
 	githubURL: z.string().url().optional(),
 	hasREADME: z.boolean().optional(),
+	// Emits a schema.org VideoObject JSON-LD when the page embeds a video.
+	// Provide the YouTube embed URL explicitly instead of parsing the page body.
+	video: z
+		.object({
+			embedUrl: z.string().url(),
+			title: z.string().optional(),
+			description: z.string().optional(),
+			uploadDate: z.string().optional(),
+			thumbnailUrl: z.string().optional(),
+		})
+		.optional(),
 })
 
 export const homeSchema = baseSchema.extend({

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -13,17 +13,6 @@ export const baseSchema = z.object({
 	i18nReady: z.boolean().default(false),
 	githubURL: z.string().url().optional(),
 	hasREADME: z.boolean().optional(),
-	// Emits a schema.org VideoObject JSON-LD when the page embeds a video.
-	// Provide the YouTube embed URL explicitly instead of parsing the page body.
-	video: z
-		.object({
-			embedUrl: z.string().url(),
-			title: z.string().optional(),
-			description: z.string().optional(),
-			uploadDate: z.string().optional(),
-			thumbnailUrl: z.string().optional(),
-		})
-		.optional(),
 })
 
 export const homeSchema = baseSchema.extend({

--- a/src/content/docs/en/pages/build-journey/develop-with-azion/frameworks/framework-astro.mdx
+++ b/src/content/docs/en/pages/build-journey/develop-with-azion/frameworks/framework-astro.mdx
@@ -11,9 +11,6 @@ meta_tags: >-
   Computing
 namespace: docs_framework_astro
 menu_namespace: cliMenuAlpha
-video:
-  embedUrl: 'https://www.youtube.com/embed/lQo6rLigHfk?si=2vfJZxAP1gzNzeta'
-  uploadDate: '2023-10-17'
 ---
 
 import Tag from 'primevue/tag';
@@ -105,7 +102,7 @@ Your Application was built successfully
 
 Learn how to build with Astro running on a local development server. Watch the video below:
 <div class="cms-embed">
-  <iframe width="600" height="400" src="https://www.youtube.com/embed/lQo6rLigHfk?si=2vfJZxAP1gzNzeta" loading="lazy" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+  <Video src="https://www.youtube.com/embed/lQo6rLigHfk?si=2vfJZxAP1gzNzeta" title="How to build with Astro" description="Learn how to initialize and deploy an Astro project on the Azion platform using Functions, featuring guides on setting up with the Azion CLI and managing deployments." uploadDate="2023-10-17" />
 </div>
 
 #### Deploying the project

--- a/src/content/docs/en/pages/build-journey/develop-with-azion/frameworks/framework-astro.mdx
+++ b/src/content/docs/en/pages/build-journey/develop-with-azion/frameworks/framework-astro.mdx
@@ -11,6 +11,9 @@ meta_tags: >-
   Computing
 namespace: docs_framework_astro
 menu_namespace: cliMenuAlpha
+video:
+  embedUrl: 'https://www.youtube.com/embed/lQo6rLigHfk?si=2vfJZxAP1gzNzeta'
+  uploadDate: '2023-10-17'
 ---
 
 import Tag from 'primevue/tag';

--- a/src/content/docs/en/pages/build-journey/develop-with-azion/frameworks/framework-next.mdx
+++ b/src/content/docs/en/pages/build-journey/develop-with-azion/frameworks/framework-next.mdx
@@ -10,6 +10,9 @@ meta_tags: >-
   Edge
 namespace: docs_framework_next
 menu_namespace: cliMenuAlpha
+video:
+  embedUrl: 'https://www.youtube.com/embed/HEINn5ErqD0'
+  uploadDate: '2023-10-17'
 ---
 import LinkButton from 'azion-webkit/linkbutton'
 

--- a/src/content/docs/en/pages/build-journey/develop-with-azion/frameworks/framework-next.mdx
+++ b/src/content/docs/en/pages/build-journey/develop-with-azion/frameworks/framework-next.mdx
@@ -10,9 +10,6 @@ meta_tags: >-
   Edge
 namespace: docs_framework_next
 menu_namespace: cliMenuAlpha
-video:
-  embedUrl: 'https://www.youtube.com/embed/HEINn5ErqD0'
-  uploadDate: '2023-10-17'
 ---
 import LinkButton from 'azion-webkit/linkbutton'
 
@@ -169,12 +166,4 @@ Wait a few minutes so the propagation takes place, and then access your applicat
 
 Watch how to build with Next.js on Azion's YouTube channel:
 
-<iframe
-   src="https://www.youtube.com/embed/HEINn5ErqD0"
-   title="How to build with Next.js"
-   loading="lazy"
-   width="600"
-   height="400"
-   frameborder="0"
-   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-   allowfullscreen></iframe>
+<Video src="https://www.youtube.com/embed/HEINn5ErqD0" title="How to build with Next.js" description="Learn how to initialize and deploy a Next.js project on the Azion Edge Platform, leveraging Functions and the latest Node.js features." uploadDate="2023-10-17" />

--- a/src/content/docs/en/pages/build-journey/develop-with-azion/toolslocal-dev/local-dev.mdx
+++ b/src/content/docs/en/pages/build-journey/develop-with-azion/toolslocal-dev/local-dev.mdx
@@ -9,9 +9,6 @@ meta_tags: >-
   JavaScript, Debugging, Development Workflow, Application Building, Enhanced
   Collaboration
 namespace: documentation_dev_with_azion_local_dev
-video:
-  embedUrl: 'https://www.youtube.com/embed/BV4jRPpADw8'
-  uploadDate: '2023-10-17'
 ---
 
 import LinkButton from 'azion-webkit/linkbutton'
@@ -34,15 +31,7 @@ Through [Azion CLI](/en/documentation/products/azion-cli/overview/) it's possibl
 
 Watch a video about the compatibility between Azion and web frameworks through Azion Bundler on Azion's YouTube channel:
 <div class="cms-embed">
-<iframe
-   src="https://www.youtube.com/embed/BV4jRPpADw8"
-   title="Compatibility between Azion and web frameworks through Azion Bundler"
-   loading="lazy"
-   width="600"
-   height="400"
-   frameborder="0"
-   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-   allowfullscreen></iframe>
+<Video src="https://www.youtube.com/embed/BV4jRPpADw8" title="Local development" description="Explore how Azion CLI enhances local development for Applications with efficient debugging, accelerated workflows, and collaborative features." uploadDate="2023-10-17" />
 </div>
 
 

--- a/src/content/docs/en/pages/build-journey/develop-with-azion/toolslocal-dev/local-dev.mdx
+++ b/src/content/docs/en/pages/build-journey/develop-with-azion/toolslocal-dev/local-dev.mdx
@@ -9,6 +9,9 @@ meta_tags: >-
   JavaScript, Debugging, Development Workflow, Application Building, Enhanced
   Collaboration
 namespace: documentation_dev_with_azion_local_dev
+video:
+  embedUrl: 'https://www.youtube.com/embed/BV4jRPpADw8'
+  uploadDate: '2023-10-17'
 ---
 
 import LinkButton from 'azion-webkit/linkbutton'

--- a/src/content/docs/en/pages/devtools/azion-edge-runtime/code-editor/code-editor.mdx
+++ b/src/content/docs/en/pages/devtools/azion-edge-runtime/code-editor/code-editor.mdx
@@ -11,9 +11,6 @@ meta_tags: >-
   development, ChatGPT integration, API development, debugging, code editor
 namespace: documentation_products_edge_functions_runtime_code_editor
 menu_namespace: runtimeMenu
-video:
-  embedUrl: 'https://www.youtube.com/embed/qPB7Exnh8O4'
-  uploadDate: '2023-07-03'
 ---
 
 The new code editor for [Functions](/en/documentation/products/build/applications/functions/) is the best way to get started developing your functions on the Azion platform. It's a web-based code editor that makes it easier and more intuitive to develop at the edge of the network. It's empowered by the [Monaco Code Editor](https://microsoft.github.io/monaco-editor/docs.html), used in [VS Code](https://code.visualstudio.com/), so if you're used to VS Code, you'll get familiar with it right away. The Monaco Code Editor main features available for the **Functions Code Editor** are:
@@ -58,14 +55,6 @@ Here's a real-life implementation of the Functions ChatGPT integration:
 
 Watch a video about the Functions Code Editor on Azion’s YouTube channel:
 
-<iframe
-   src="https://www.youtube.com/embed/qPB7Exnh8O4"
-   title="Functions Code Editor"
-   loading="lazy"
-   width="600"
-   height="400"
-   frameborder="0"
-   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-   allowfullscreen></iframe>
+<Video src="https://www.youtube.com/embed/qPB7Exnh8O4" title="Functions Code Editor" description="Explore the Functions Code Editor on Azion, featuring VS Code’s Monaco editor, ChatGPT integration, and tools like debugging and IntelliSense for efficient edge development." uploadDate="2023-07-03" />
 
 

--- a/src/content/docs/en/pages/devtools/azion-edge-runtime/code-editor/code-editor.mdx
+++ b/src/content/docs/en/pages/devtools/azion-edge-runtime/code-editor/code-editor.mdx
@@ -11,6 +11,9 @@ meta_tags: >-
   development, ChatGPT integration, API development, debugging, code editor
 namespace: documentation_products_edge_functions_runtime_code_editor
 menu_namespace: runtimeMenu
+video:
+  embedUrl: 'https://www.youtube.com/embed/qPB7Exnh8O4'
+  uploadDate: '2023-07-03'
 ---
 
 The new code editor for [Functions](/en/documentation/products/build/applications/functions/) is the best way to get started developing your functions on the Azion platform. It's a web-based code editor that makes it easier and more intuitive to develop at the edge of the network. It's empowered by the [Monaco Code Editor](https://microsoft.github.io/monaco-editor/docs.html), used in [VS Code](https://code.visualstudio.com/), so if you're used to VS Code, you'll get familiar with it right away. The Monaco Code Editor main features available for the **Functions Code Editor** are:

--- a/src/content/docs/en/pages/devtools/cli/azion-cli/commands/link-project/link.mdx
+++ b/src/content/docs/en/pages/devtools/cli/azion-cli/commands/link-project/link.mdx
@@ -10,9 +10,6 @@ meta_tags: >-
   Integration
 namespace: documentation_cli_link
 menu_namespace: cliMenuAlpha
-video:
-  embedUrl: 'https://www.youtube.com/embed/Ub2nzz3Ap2U?si=AALxnhtVNuejUEHt'
-  uploadDate: '2023-09-28'
 ---
 
 :::note 
@@ -148,7 +145,7 @@ The `--help` option displays more information about the `link` command.
 
 Learn how to link and deploy projects on Azion Web Platform. Watch the video below:
 <div class="cms-embed">
-  <iframe width="600" height="400" src="https://www.youtube.com/embed/Ub2nzz3Ap2U?si=AALxnhtVNuejUEHt" loading="lazy" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+  <Video src="https://www.youtube.com/embed/Ub2nzz3Ap2U?si=AALxnhtVNuejUEHt" title="Azion CLI link" description="Learn how to link and deploy projects on the Azion Web Platform, using interactive commands for optimal edge computing integration." uploadDate="2023-09-28" />
 </div>
 
 

--- a/src/content/docs/en/pages/devtools/cli/azion-cli/commands/link-project/link.mdx
+++ b/src/content/docs/en/pages/devtools/cli/azion-cli/commands/link-project/link.mdx
@@ -10,6 +10,9 @@ meta_tags: >-
   Integration
 namespace: documentation_cli_link
 menu_namespace: cliMenuAlpha
+video:
+  embedUrl: 'https://www.youtube.com/embed/Ub2nzz3Ap2U?si=AALxnhtVNuejUEHt'
+  uploadDate: '2023-09-28'
 ---
 
 :::note 

--- a/src/content/docs/en/pages/guides/data-streaming/associate-domains.mdx
+++ b/src/content/docs/en/pages/guides/data-streaming/associate-domains.mdx
@@ -6,9 +6,6 @@ description: >-
 meta_tags: 'Data Stream, domains'
 namespace: documentation_dts_associate_domains
 permalink: /documentation/products/guides/data-stream-associate-domains/
-video:
-  embedUrl: 'https://www.youtube.com/embed/soyIbJW0VdQ'
-  uploadDate: '2023-07-03'
 ---
 
 import Tabs from '~/components/tabs/Tabs'
@@ -54,15 +51,7 @@ Now, the events associated with the domains you selected will be collected and s
 
 Watch a video tutorial on How to associate domains on Data Stream on Azion’s YouTube channel:
 
-<iframe
-   src="https://www.youtube.com/embed/soyIbJW0VdQ"
-   loading="lazy"
-   width="600"
-   height="400"
-   title="How to associate domains on Data Stream"
-   frameborder="0"
-   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-   allowfullscreen></iframe>
+<Video src="https://www.youtube.com/embed/soyIbJW0VdQ" title="How to associate domains on Data Stream" description="When associating domains with Data Stream, the events related to the specified domains will be collected and sent to its endpoint." uploadDate="2023-07-03" />
 
 
 

--- a/src/content/docs/en/pages/guides/data-streaming/associate-domains.mdx
+++ b/src/content/docs/en/pages/guides/data-streaming/associate-domains.mdx
@@ -6,6 +6,9 @@ description: >-
 meta_tags: 'Data Stream, domains'
 namespace: documentation_dts_associate_domains
 permalink: /documentation/products/guides/data-stream-associate-domains/
+video:
+  embedUrl: 'https://www.youtube.com/embed/soyIbJW0VdQ'
+  uploadDate: '2023-07-03'
 ---
 
 import Tabs from '~/components/tabs/Tabs'

--- a/src/content/docs/en/pages/guides/edge-dns/run-dig-command.mdx
+++ b/src/content/docs/en/pages/guides/edge-dns/run-dig-command.mdx
@@ -7,6 +7,9 @@ description: >-
 meta_tags: 'dig, edge computing, dig command, azion edge dns'
 namespace: documentation_how_to_troubleshoot_dig
 permalink: /documentation/products/guides/run-the-dig-command/
+video:
+  embedUrl: 'https://www.youtube.com/embed/KB4f4bSyHgI?autoplay=1'
+  uploadDate: '2023-07-03'
 ---
 
 import LinkButton from 'azion-webkit/linkbutton';

--- a/src/content/docs/en/pages/guides/edge-dns/run-dig-command.mdx
+++ b/src/content/docs/en/pages/guides/edge-dns/run-dig-command.mdx
@@ -7,9 +7,6 @@ description: >-
 meta_tags: 'dig, edge computing, dig command, azion edge dns'
 namespace: documentation_how_to_troubleshoot_dig
 permalink: /documentation/products/guides/run-the-dig-command/
-video:
-  embedUrl: 'https://www.youtube.com/embed/KB4f4bSyHgI?autoplay=1'
-  uploadDate: '2023-07-03'
 ---
 
 import LinkButton from 'azion-webkit/linkbutton';
@@ -119,7 +116,7 @@ This comprehensive video demonstrates how to install and use the dig across diff
 * Validate Edge Computing services
 
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/KB4f4bSyHgI?autoplay=1" title="Dig into DNS: Install & Use Dig Command Like a Pro" loading="lazy" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<Video src="https://www.youtube.com/embed/KB4f4bSyHgI?autoplay=1" title="How to look up DNS servers with Dig command" description="Learn how to specify DNS servers with the dig command. Step-by-step guide for Windows and other systems, including Google DNS queries and record lookups." uploadDate="2023-07-03" />
 
 ---
 

--- a/src/content/docs/en/pages/guides/marketplace/integrations/hcaptcha.mdx
+++ b/src/content/docs/en/pages/guides/marketplace/integrations/hcaptcha.mdx
@@ -6,6 +6,9 @@ description: >-
 meta_tags: 'edge computing, hCaptcha, Captcha, spam, bots'
 namespace: docs_use_case_hcaptcha
 permalink: /documentation/products/guides/hcaptcha/
+video:
+  embedUrl: 'https://www.youtube.com/embed/HqdX9wAWJDg?si=YQqDt2Z5fzq-6VQv'
+  uploadDate: '2023-09-28'
 ---
 
 

--- a/src/content/docs/en/pages/guides/marketplace/integrations/hcaptcha.mdx
+++ b/src/content/docs/en/pages/guides/marketplace/integrations/hcaptcha.mdx
@@ -6,9 +6,6 @@ description: >-
 meta_tags: 'edge computing, hCaptcha, Captcha, spam, bots'
 namespace: docs_use_case_hcaptcha
 permalink: /documentation/products/guides/hcaptcha/
-video:
-  embedUrl: 'https://www.youtube.com/embed/HqdX9wAWJDg?si=YQqDt2Z5fzq-6VQv'
-  uploadDate: '2023-09-28'
 ---
 
 
@@ -165,6 +162,6 @@ hCaptcha is a registered trademark of Intuition Machines, Inc.
 
 Watch a video on how to install the hCaptcha® integration through Azion Marketplace on Azion's YouTube channel.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/HqdX9wAWJDg?si=YQqDt2Z5fzq-6VQv" loading="lazy" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<Video src="https://www.youtube.com/embed/HqdX9wAWJDg?si=YQqDt2Z5fzq-6VQv" title="How to Install the hCaptcha® Integration" description="hCaptcha is an integration to protect your assets from bot attacks, SPAM, and others." uploadDate="2023-09-28" />
 
 ---

--- a/src/content/docs/en/pages/guides/marketplace/integrations/rate-limiting-with-penalty.mdx
+++ b/src/content/docs/en/pages/guides/marketplace/integrations/rate-limiting-with-penalty.mdx
@@ -6,9 +6,6 @@ description: >-
 meta_tags: 'marketplace, edge computing, rate limiting'
 namespace: docs_guides_rate_limiting_integration
 permalink: /documentation/products/guides/upstash-rate-limiting-integration/
-video:
-  embedUrl: 'https://www.youtube.com/embed/3qsiKK2GzRw?si=Em23FF2i1BHzTV7r'
-  uploadDate: '2024-03-14'
 ---
 
 
@@ -199,6 +196,6 @@ Done. Now **Upstash Rate Limiting** is running and protecting your domains.
 
 Discover how to enhance your web application's performance with this tutorial on **Rate Limit with Penalty on Azion + Upstash DB**. Watch now on Azion's YouTube channel.
 	
-	<iframe width="560" height="315" src="https://www.youtube.com/embed/3qsiKK2GzRw?si=Em23FF2i1BHzTV7r" loading="lazy" title="How to install Upstash Rate Limiting integration through Azion Marketplace" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+	<Video src="https://www.youtube.com/embed/3qsiKK2GzRw?si=Em23FF2i1BHzTV7r" title="How to Install Upstash Rate Limiting" description="This integration allows you to control incoming traffic right at the edge and protect your applications." uploadDate="2024-03-14" />
 
 ---

--- a/src/content/docs/en/pages/guides/marketplace/integrations/rate-limiting-with-penalty.mdx
+++ b/src/content/docs/en/pages/guides/marketplace/integrations/rate-limiting-with-penalty.mdx
@@ -6,6 +6,9 @@ description: >-
 meta_tags: 'marketplace, edge computing, rate limiting'
 namespace: docs_guides_rate_limiting_integration
 permalink: /documentation/products/guides/upstash-rate-limiting-integration/
+video:
+  embedUrl: 'https://www.youtube.com/embed/3qsiKK2GzRw?si=Em23FF2i1BHzTV7r'
+  uploadDate: '2024-03-14'
 ---
 
 

--- a/src/content/docs/en/pages/guides/marketplace/integrations/recaptcha.mdx
+++ b/src/content/docs/en/pages/guides/marketplace/integrations/recaptcha.mdx
@@ -4,9 +4,6 @@ description: 'reCAPTCHA is an integration to block attacks from bots, SPAM and o
 meta_tags: 'recaptcha, bots, spam, captcha, bot protection, domain configuration, troubleshooting'
 namespace: docs_use_case_recaptcha
 permalink: /documentation/products/guides/recaptcha/
-video:
-  embedUrl: 'https://www.youtube.com/embed/X-S1qDdVVbg?si=J7dzeymFxJH0P_Zs'
-  uploadDate: '2023-09-28'
 ---
 
 
@@ -154,7 +151,7 @@ Done. Now the **reCAPTCHA** integration is running for every request made to the
 
 Watch a video about how to install the reCAPTCHA integration through Azion Marketplace on Azion’s YouTube channel:
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/X-S1qDdVVbg?si=J7dzeymFxJH0P_Zs" loading="lazy" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<Video src="https://www.youtube.com/embed/X-S1qDdVVbg?si=J7dzeymFxJH0P_Zs" title="How to Install the reCAPTCHA Integration" description="reCAPTCHA is an integration to block attacks from bots, SPAM and others." uploadDate="2023-09-28" />
 
 ---
 

--- a/src/content/docs/en/pages/guides/marketplace/integrations/recaptcha.mdx
+++ b/src/content/docs/en/pages/guides/marketplace/integrations/recaptcha.mdx
@@ -4,6 +4,9 @@ description: 'reCAPTCHA is an integration to block attacks from bots, SPAM and o
 meta_tags: 'recaptcha, bots, spam, captcha, bot protection, domain configuration, troubleshooting'
 namespace: docs_use_case_recaptcha
 permalink: /documentation/products/guides/recaptcha/
+video:
+  embedUrl: 'https://www.youtube.com/embed/X-S1qDdVVbg?si=J7dzeymFxJH0P_Zs'
+  uploadDate: '2023-09-28'
 ---
 
 

--- a/src/content/docs/en/pages/guides/marketplace/templates/angular-boilerplate.mdx
+++ b/src/content/docs/en/pages/guides/marketplace/templates/angular-boilerplate.mdx
@@ -6,6 +6,9 @@ description: >-
 meta_tags: 'templates, guides, Azion Marketplace'
 namespace: docs_guides_angular_boilerplate
 permalink: /documentation/products/guides/angular-boilerplate/
+video:
+  embedUrl: 'https://www.youtube.com/embed/rD4K39a70Xk?si=NCq7BvqJXTUU2ERQ'
+  uploadDate: '2023-09-28'
 ---
 
 import Tag from 'primevue/tag';

--- a/src/content/docs/en/pages/guides/marketplace/templates/angular-boilerplate.mdx
+++ b/src/content/docs/en/pages/guides/marketplace/templates/angular-boilerplate.mdx
@@ -6,9 +6,6 @@ description: >-
 meta_tags: 'templates, guides, Azion Marketplace'
 namespace: docs_guides_angular_boilerplate
 permalink: /documentation/products/guides/angular-boilerplate/
-video:
-  embedUrl: 'https://www.youtube.com/embed/rD4K39a70Xk?si=NCq7BvqJXTUU2ERQ'
-  uploadDate: '2023-09-28'
 ---
 
 import Tag from 'primevue/tag';
@@ -106,7 +103,7 @@ import LinkButton from 'azion-webkit/linkbutton';
 
 Watch a video on how to deploy applications using the Angular Boilerplate on Azion's YouTube channel.
 
-	<iframe width="560" height="315" src="https://www.youtube.com/embed/rD4K39a70Xk?si=NCq7BvqJXTUU2ERQ" loading="lazy" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+	<Video src="https://www.youtube.com/embed/rD4K39a70Xk?si=NCq7BvqJXTUU2ERQ" title="Deploy Apps with the Angular Boilerplate" description="The Angular Boilerplate provides an automation solution to build an Angular application on Azion." uploadDate="2023-09-28" />
 
 
 

--- a/src/content/docs/en/pages/guides/marketplace/templates/azion-starter-kit.mdx
+++ b/src/content/docs/en/pages/guides/marketplace/templates/azion-starter-kit.mdx
@@ -6,9 +6,6 @@ description: >-
 meta_tags: 'templates, guides, Azion Marketplace, security, bot protection, edge computing'
 namespace: docs_guides_templates_azion_starter_kit
 permalink: /documentation/products/guides/azion-starter-kit/
-video:
-  embedUrl: 'https://www.youtube.com/embed/9VDnYVGf5lI?si=u7eJ77YaKHjDpF7W'
-  uploadDate: '2024-04-11'
 ---
 
 import Tag from 'primevue/tag';
@@ -135,6 +132,6 @@ import LinkButton from 'azion-webkit/linkbutton';
 
 Learn how to deploy the Azion Starter Kit:
 <div class="cms-embed">
-  <iframe width="600" height="400" src="https://www.youtube.com/embed/9VDnYVGf5lI?si=u7eJ77YaKHjDpF7W" loading="lazy" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+  <Video src="https://www.youtube.com/embed/9VDnYVGf5lI?si=u7eJ77YaKHjDpF7W" title="How to deploy the Azion Starter Kit" description="This template accelerates the creation of a basic edge stack to explore Azion's platform and its features." uploadDate="2024-04-11" />
 </div>
 

--- a/src/content/docs/en/pages/guides/marketplace/templates/azion-starter-kit.mdx
+++ b/src/content/docs/en/pages/guides/marketplace/templates/azion-starter-kit.mdx
@@ -6,6 +6,9 @@ description: >-
 meta_tags: 'templates, guides, Azion Marketplace, security, bot protection, edge computing'
 namespace: docs_guides_templates_azion_starter_kit
 permalink: /documentation/products/guides/azion-starter-kit/
+video:
+  embedUrl: 'https://www.youtube.com/embed/9VDnYVGf5lI?si=u7eJ77YaKHjDpF7W'
+  uploadDate: '2024-04-11'
 ---
 
 import Tag from 'primevue/tag';

--- a/src/content/docs/en/pages/guides/marketplace/templates/dynamic-and-static-file-optimization.mdx
+++ b/src/content/docs/en/pages/guides/marketplace/templates/dynamic-and-static-file-optimization.mdx
@@ -6,6 +6,9 @@ description: >-
 meta_tags: 'templates, guides, Azion Marketplace'
 namespace: docs_guides_dynamic_static_file_optimization
 permalink: /documentation/products/guides/dynamic-and-static-file-optimization-template/
+video:
+  embedUrl: 'https://www.youtube.com/embed/O_LoGeyNAQY?si=kVeyrU8GOL6hXySi'
+  uploadDate: '2024-02-22'
 ---
 
 import Tag from 'primevue/tag';

--- a/src/content/docs/en/pages/guides/marketplace/templates/dynamic-and-static-file-optimization.mdx
+++ b/src/content/docs/en/pages/guides/marketplace/templates/dynamic-and-static-file-optimization.mdx
@@ -6,9 +6,6 @@ description: >-
 meta_tags: 'templates, guides, Azion Marketplace'
 namespace: docs_guides_dynamic_static_file_optimization
 permalink: /documentation/products/guides/dynamic-and-static-file-optimization-template/
-video:
-  embedUrl: 'https://www.youtube.com/embed/O_LoGeyNAQY?si=kVeyrU8GOL6hXySi'
-  uploadDate: '2024-02-22'
 ---
 
 import Tag from 'primevue/tag';
@@ -109,7 +106,7 @@ import LinkButton from 'azion-webkit/linkbutton';
 
 Learn how to deploy the Dynamic and Static File Optimization template. Watch the video below:
 <div class="cms-embed">
-  <iframe width="600" height="400" src="https://www.youtube.com/embed/O_LoGeyNAQY?si=kVeyrU8GOL6hXySi" loading="lazy" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+  <Video src="https://www.youtube.com/embed/O_LoGeyNAQY?si=kVeyrU8GOL6hXySi" title="Deploy the File Optimization Template" description="This template helps you to deploy an application with standard cache policies to improve the delivery of your content." uploadDate="2024-02-22" />
 </div>
 
 

--- a/src/content/docs/en/pages/guides/marketplace/templates/edge-application-proxy.mdx
+++ b/src/content/docs/en/pages/guides/marketplace/templates/edge-application-proxy.mdx
@@ -6,6 +6,9 @@ description: >-
 meta_tags: 'templates, guides, Azion Marketplace'
 namespace: docs_guides_bypass_template
 permalink: /documentation/products/guides/edge-application-proxy-template/
+video:
+  embedUrl: 'https://www.youtube.com/embed/BRoJ9lRZ80I?si=27wHP6P3PTw3Jj3m'
+  uploadDate: '2023-12-06'
 ---
 
 import Tag from 'primevue/tag';

--- a/src/content/docs/en/pages/guides/marketplace/templates/edge-application-proxy.mdx
+++ b/src/content/docs/en/pages/guides/marketplace/templates/edge-application-proxy.mdx
@@ -6,9 +6,6 @@ description: >-
 meta_tags: 'templates, guides, Azion Marketplace'
 namespace: docs_guides_bypass_template
 permalink: /documentation/products/guides/edge-application-proxy-template/
-video:
-  embedUrl: 'https://www.youtube.com/embed/BRoJ9lRZ80I?si=27wHP6P3PTw3Jj3m'
-  uploadDate: '2023-12-06'
 ---
 
 import Tag from 'primevue/tag';
@@ -95,6 +92,6 @@ Read the documentation about [managing applications](/en/documentation/products/
 
 Learn how to deploy the Applications Proxy template. Watch the video below:
 <div class="cms-embed">
-  <iframe width="600" height="400" src="https://www.youtube.com/embed/BRoJ9lRZ80I?si=27wHP6P3PTw3Jj3m" loading="lazy" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+  <Video src="https://www.youtube.com/embed/BRoJ9lRZ80I?si=27wHP6P3PTw3Jj3m" title="How to deploy the Applications Proxy template" description="This template includes configurations that add a layer of engine rules to ignore all cache settings for a specific URL route." uploadDate="2023-12-06" />
 </div>
 

--- a/src/content/docs/en/pages/guides/marketplace/templates/image-optimization.mdx
+++ b/src/content/docs/en/pages/guides/marketplace/templates/image-optimization.mdx
@@ -6,6 +6,9 @@ description: >-
 meta_tags: 'templates, guides, Azion Marketplace'
 namespace: docs_guides_image_cache_template
 permalink: /documentation/products/guides/image-optimization-template/
+video:
+  embedUrl: 'https://www.youtube.com/embed/7RtuYnHDtcM?si=IY7N7NdpUh0BYAYF'
+  uploadDate: '2023-12-06'
 ---
 
 import Tag from 'primevue/tag';

--- a/src/content/docs/en/pages/guides/marketplace/templates/image-optimization.mdx
+++ b/src/content/docs/en/pages/guides/marketplace/templates/image-optimization.mdx
@@ -6,9 +6,6 @@ description: >-
 meta_tags: 'templates, guides, Azion Marketplace'
 namespace: docs_guides_image_cache_template
 permalink: /documentation/products/guides/image-optimization-template/
-video:
-  embedUrl: 'https://www.youtube.com/embed/7RtuYnHDtcM?si=IY7N7NdpUh0BYAYF'
-  uploadDate: '2023-12-06'
 ---
 
 import Tag from 'primevue/tag';
@@ -95,6 +92,6 @@ Read the documentation about [managing applications](/en/documentation/products/
 
 Learn how to deploy the Image Optimization template. Watch the video below:
 <div class="cms-embed">
-  <iframe width="600" height="400" src="https://www.youtube.com/embed/7RtuYnHDtcM?si=IY7N7NdpUh0BYAYF" loading="lazy" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+  <Video src="https://www.youtube.com/embed/7RtuYnHDtcM?si=IY7N7NdpUh0BYAYF" title="How to deploy the Image Optimization template" description="This template includes configurations for enhancing image loading and caching, based on the file extension." uploadDate="2023-12-06" />
 </div>
 

--- a/src/content/docs/en/pages/guides/marketplace/templates/static-cache.mdx
+++ b/src/content/docs/en/pages/guides/marketplace/templates/static-cache.mdx
@@ -6,6 +6,9 @@ description: >-
 meta_tags: 'templates, guides, Azion Marketplace'
 namespace: docs_guides_static_template
 permalink: /documentation/products/guides/static-cache-template/
+video:
+  embedUrl: 'https://www.youtube.com/embed/k3tZuEG8hwA?si=PiWzfbqUm_fICRiT'
+  uploadDate: '2023-12-06'
 ---
 
 import Tag from 'primevue/tag';

--- a/src/content/docs/en/pages/guides/marketplace/templates/static-cache.mdx
+++ b/src/content/docs/en/pages/guides/marketplace/templates/static-cache.mdx
@@ -6,9 +6,6 @@ description: >-
 meta_tags: 'templates, guides, Azion Marketplace'
 namespace: docs_guides_static_template
 permalink: /documentation/products/guides/static-cache-template/
-video:
-  embedUrl: 'https://www.youtube.com/embed/k3tZuEG8hwA?si=PiWzfbqUm_fICRiT'
-  uploadDate: '2023-12-06'
 ---
 
 import Tag from 'primevue/tag';
@@ -97,5 +94,5 @@ Read the documentation about [managing applications](/en/documentation/products/
 
 Learn how to deploy the Static Cache template. Watch the video below:
 <div class="cms-embed">
-  <iframe width="600" height="400" src="https://www.youtube.com/embed/k3tZuEG8hwA?si=PiWzfbqUm_fICRiT" loading="lazy" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+  <Video src="https://www.youtube.com/embed/k3tZuEG8hwA?si=PiWzfbqUm_fICRiT" title="How to deploy the Static Cache template" description="This template includes configurations for optimizing the delivery and performance of static content." uploadDate="2023-12-06" />
 </div>

--- a/src/content/docs/en/pages/main-menu/manage-accounts/manage-profile/personal-token.mdx
+++ b/src/content/docs/en/pages/main-menu/manage-accounts/manage-profile/personal-token.mdx
@@ -4,6 +4,9 @@ description: Find out how to use Personal Tokens on Azion.
 meta_tags: 'account, Azion Console, token, personal token'
 namespace: docs_guides_personal_tokens
 permalink: /documentation/products/guides/personal-tokens/
+video:
+  embedUrl: 'https://www.youtube.com/embed/HOkuSudhKfE'
+  uploadDate: '2023-10-17'
 ---
 
 import Tabs from '~/components/tabs/Tabs'

--- a/src/content/docs/en/pages/main-menu/manage-accounts/manage-profile/personal-token.mdx
+++ b/src/content/docs/en/pages/main-menu/manage-accounts/manage-profile/personal-token.mdx
@@ -4,9 +4,6 @@ description: Find out how to use Personal Tokens on Azion.
 meta_tags: 'account, Azion Console, token, personal token'
 namespace: docs_guides_personal_tokens
 permalink: /documentation/products/guides/personal-tokens/
-video:
-  embedUrl: 'https://www.youtube.com/embed/HOkuSudhKfE'
-  uploadDate: '2023-10-17'
 ---
 
 import Tabs from '~/components/tabs/Tabs'
@@ -83,13 +80,4 @@ You'll see a message confirming the deletion of your token.
 
 Watch a video tutorial on how to manage a personal token on Azion's YouTube channel:
 
-<iframe
-   src="https://www.youtube.com/embed/HOkuSudhKfE"
-   loading="lazy"
-   width="600"
-   height="400"
-   title="Secure Your Azion Personal Tokens: Creating and revoking Personal Tokens"
-   frameborder="0"
-   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-   allowfullscreen>
-   </iframe>
+<Video src="https://www.youtube.com/embed/HOkuSudhKfE" title="How to manage a personal token" description="Find out how to use Personal Tokens on Azion." uploadDate="2023-10-17" />

--- a/src/content/docs/en/pages/main-menu/reference/secure/edge-firewall/rules-engine.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/secure/edge-firewall/rules-engine.mdx
@@ -6,6 +6,9 @@ description: >-
 meta_tags: 'edge computing, rules engine, azion, rules engine for firewall, rule sets'
 namespace: documentation_products_edge_firewall_rules_engine
 permalink: /documentation/products/secure/firewall/rules-engine/
+video:
+  embedUrl: 'https://www.youtube.com/embed/HhVdxVnOnvw'
+  uploadDate: '2023-07-03'
 ---
 
 import LinkButton from 'azion-webkit/linkbutton'

--- a/src/content/docs/en/pages/main-menu/reference/secure/edge-firewall/rules-engine.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/secure/edge-firewall/rules-engine.mdx
@@ -6,9 +6,6 @@ description: >-
 meta_tags: 'edge computing, rules engine, azion, rules engine for firewall, rule sets'
 namespace: documentation_products_edge_firewall_rules_engine
 permalink: /documentation/products/secure/firewall/rules-engine/
-video:
-  embedUrl: 'https://www.youtube.com/embed/HhVdxVnOnvw'
-  uploadDate: '2023-07-03'
 ---
 
 import LinkButton from 'azion-webkit/linkbutton'
@@ -215,12 +212,4 @@ You can [debug rules created with Rules Engine for Firewall](/en/documentation/p
 
 Watch a video tutorial about programming Firewall rules for optimal WAF usage and cost optimization on Azion's YouTube channel:
 
-<iframe
-   src="https://www.youtube.com/embed/HhVdxVnOnvw"
-   title="Programming Firewall rules engine for optimal WAF usage (cost optimization)."
-   loading="lazy"
-   width="600"
-   height="400"
-   frameborder="0"
-   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-   allowfullscreen></iframe>
+<Video src="https://www.youtube.com/embed/HhVdxVnOnvw" title="Rules Engine for Firewall" description="Implement security logic, based on criteria and behaviors, with Rules Engine for Firewall." uploadDate="2023-07-03" />

--- a/src/content/docs/en/pages/observe-journey/data-stream/integrations/connector-amazon-s3.mdx
+++ b/src/content/docs/en/pages/observe-journey/data-stream/integrations/connector-amazon-s3.mdx
@@ -6,9 +6,6 @@ namespace: documentation_how_to_configurations_amazon_s3
 permalink: /documentation/products/guides/endpoint-amazon-s3/
 og_image: /assets/docs/images/uploads/use-case-dts-amazon-s3.png
 menu_namespace: observeMenu
-video:
-  embedUrl: 'https://www.youtube.com/embed/tuUanVc_HFE?si=3-oG5BiHElJzb63-'
-  uploadDate: '2023-07-03'
 ---
 
 import Tabs from '~/components/tabs/Tabs'
@@ -122,15 +119,7 @@ You can keep track of the calls made by Data Stream to Amazon S3 on [Real-Time E
 
 Watch a video tutorial on how to use Amazon S3 with Data Stream on Azion’s YouTube channel:
 
-<iframe
-   src="https://www.youtube.com/embed/tuUanVc_HFE?si=3-oG5BiHElJzb63-"
-   loading="lazy"
-   width="600"
-   height="400"
-   title="Using Amazon S3 to receive data from Azion Data Stream"
-   frameborder="0"
-   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-   allowfullscreen></iframe>
+<Video src="https://www.youtube.com/embed/tuUanVc_HFE?si=3-oG5BiHElJzb63-" title="How to use Amazon S3 to receive data from Data Stream" description="Hands-on to configure Amazon S3 to receive data from Data Stream." uploadDate="2023-07-03" />
 
 ---
 

--- a/src/content/docs/en/pages/observe-journey/data-stream/integrations/connector-amazon-s3.mdx
+++ b/src/content/docs/en/pages/observe-journey/data-stream/integrations/connector-amazon-s3.mdx
@@ -6,6 +6,9 @@ namespace: documentation_how_to_configurations_amazon_s3
 permalink: /documentation/products/guides/endpoint-amazon-s3/
 og_image: /assets/docs/images/uploads/use-case-dts-amazon-s3.png
 menu_namespace: observeMenu
+video:
+  embedUrl: 'https://www.youtube.com/embed/tuUanVc_HFE?si=3-oG5BiHElJzb63-'
+  uploadDate: '2023-07-03'
 ---
 
 import Tabs from '~/components/tabs/Tabs'

--- a/src/content/docs/en/pages/observe-journey/data-stream/integrations/connector-aws-kinesis.mdx
+++ b/src/content/docs/en/pages/observe-journey/data-stream/integrations/connector-aws-kinesis.mdx
@@ -7,6 +7,9 @@ meta_tags: 'Data Stream, connector, endpoint, amazon, kinesis'
 namespace: documentation_how_to_configurations_amazon_kinesis
 permalink: /documentation/products/guides/endpoint-amazon-kinesis/
 menu_namespace: observeMenu
+video:
+  embedUrl: 'https://www.youtube.com/embed/V0g4ih9NwRY?si=Bs1Xaq-GLkRYzG6d'
+  uploadDate: '2023-07-03'
 ---
 
 import Tabs from '~/components/tabs/Tabs'

--- a/src/content/docs/en/pages/observe-journey/data-stream/integrations/connector-aws-kinesis.mdx
+++ b/src/content/docs/en/pages/observe-journey/data-stream/integrations/connector-aws-kinesis.mdx
@@ -7,9 +7,6 @@ meta_tags: 'Data Stream, connector, endpoint, amazon, kinesis'
 namespace: documentation_how_to_configurations_amazon_kinesis
 permalink: /documentation/products/guides/endpoint-amazon-kinesis/
 menu_namespace: observeMenu
-video:
-  embedUrl: 'https://www.youtube.com/embed/V0g4ih9NwRY?si=Bs1Xaq-GLkRYzG6d'
-  uploadDate: '2023-07-03'
 ---
 
 import Tabs from '~/components/tabs/Tabs'
@@ -125,15 +122,7 @@ You can keep track of the calls made by Data Stream to Amazon Kinesis Data Fireh
 
 Watch a video tutorial on how to use Amazon Kinesis Data Firehose with Data Stream on Azion's YouTube channel:
 
-   <iframe
-   src="https://www.youtube.com/embed/V0g4ih9NwRY?si=Bs1Xaq-GLkRYzG6d"
-   loading="lazy"
-   width="600"
-   height="400"
-   title="Using Amazon Kinesis Data Firehose to receive data from Azion Data Stream"
-   frameborder="0"
-   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-   allowfullscreen></iframe>
+   <Video src="https://www.youtube.com/embed/V0g4ih9NwRY?si=Bs1Xaq-GLkRYzG6d" title="Send Data Stream Data to Amazon Kinesis" description="Hands-on to use Amazon Kinesis Data Firehose to receive data from Azion Data Stream." uploadDate="2023-07-03" />
 
 ---
 

--- a/src/content/docs/pt-br/pages/guias/data-streaming/associar-dominios.mdx
+++ b/src/content/docs/pt-br/pages/guias/data-streaming/associar-dominios.mdx
@@ -6,6 +6,9 @@ description: >-
 meta_tags: 'Data Stream, domains, observe, observability, stream, logs'
 namespace: documentation_dts_associate_domains
 permalink: /documentacao/produtos/guias/data-stream-associar-dominios/
+video:
+  embedUrl: 'https://www.youtube.com/embed/soyIbJW0VdQ'
+  uploadDate: '2023-07-03'
 ---
 
 [Data Stream](/pt-br/documentacao/produtos/observe/data-stream/) é um produto de **Observe** que permite que você alimente suas plataformas de SIEM, big data e processamento de stream com os logs dos eventos de suas aplicações na Azion em tempo real.

--- a/src/content/docs/pt-br/pages/guias/data-streaming/associar-dominios.mdx
+++ b/src/content/docs/pt-br/pages/guias/data-streaming/associar-dominios.mdx
@@ -6,9 +6,6 @@ description: >-
 meta_tags: 'Data Stream, domains, observe, observability, stream, logs'
 namespace: documentation_dts_associate_domains
 permalink: /documentacao/produtos/guias/data-stream-associar-dominios/
-video:
-  embedUrl: 'https://www.youtube.com/embed/soyIbJW0VdQ'
-  uploadDate: '2023-07-03'
 ---
 
 [Data Stream](/pt-br/documentacao/produtos/observe/data-stream/) é um produto de **Observe** que permite que você alimente suas plataformas de SIEM, big data e processamento de stream com os logs dos eventos de suas aplicações na Azion em tempo real.
@@ -51,15 +48,7 @@ Agora, os eventos associados com os domínios que você selecionou serão coleta
 
 Assista um tutorial sobre como associar domínios no Data Stream no canal do YouTube da Azion, com opção de ativar legendas em português:
 
-<iframe
-   src="https://www.youtube.com/embed/soyIbJW0VdQ"
-   loading="lazy"
-   width="600"
-   height="400"
-   title="How to associate domains on Data Stream"
-   frameborder="0"
-   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-   allowfullscreen></iframe>
+<Video src="https://www.youtube.com/embed/soyIbJW0VdQ" title="Como associar domínios no Data Stream" description="Ao associar domínios no Data Stream, os eventos relacionados aos domínios especificados serão coletados e enviados para o endpoint." uploadDate="2023-07-03" />
 
 ---
 

--- a/src/content/docs/pt-br/pages/guias/edge-dns/run-dig-command.mdx
+++ b/src/content/docs/pt-br/pages/guias/edge-dns/run-dig-command.mdx
@@ -5,6 +5,9 @@ description: >-
   plataformas Windows, Linux ou MAC OS X. Conheça o suporte Azion!
 namespace: documentation_how_to_troubleshoot_dig
 permalink: /documentacao/produtos/guias/executar-o-comando-dig/
+video:
+  embedUrl: 'https://www.youtube.com/embed/LsXHGoP1sz0'
+  uploadDate: '2023-07-03'
 ---
 
 import LinkButton from 'azion-webkit/linkbutton'

--- a/src/content/docs/pt-br/pages/guias/edge-dns/run-dig-command.mdx
+++ b/src/content/docs/pt-br/pages/guias/edge-dns/run-dig-command.mdx
@@ -5,9 +5,6 @@ description: >-
   plataformas Windows, Linux ou MAC OS X. Conheça o suporte Azion!
 namespace: documentation_how_to_troubleshoot_dig
 permalink: /documentacao/produtos/guias/executar-o-comando-dig/
-video:
-  embedUrl: 'https://www.youtube.com/embed/LsXHGoP1sz0'
-  uploadDate: '2023-07-03'
 ---
 
 import LinkButton from 'azion-webkit/linkbutton'
@@ -100,7 +97,7 @@ Se você [configurou uma zona](/pt-br/documentacao/produtos/guias/secure/edge-dn
 
 Você também pode checar a latência de uma aplicação web com o comando dig para validar o serviço de Edge Computing da Azion. É possível, por exemplo, comparar a latência da sua aplicação, servida por um serviço de Cloud Computing e pela Edge da Azion.
 
-<iframe width="560" height="315" loading="lazy" src="https://www.youtube.com/embed/LsXHGoP1sz0" title="Looking up DNS servers with Dig command YouTube video" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe> 
+<Video src="https://www.youtube.com/embed/LsXHGoP1sz0" title="Encontre servidores DNS com o comando DIG" description="Veja aqui como encontrar servidores DNS utilizando comando DIG em diferentes plataformas Windows, Linux ou MAC OS X. Conheça o suporte Azion!" uploadDate="2023-07-03" /> 
 
 
 

--- a/src/content/docs/pt-br/pages/menu-principal/gerencie-contas/gerenciar-perfis/personal-token.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/gerencie-contas/gerenciar-perfis/personal-token.mdx
@@ -4,9 +4,6 @@ description: Descubra como usar Personal Tokens na Azion.
 meta_tags: 'conta, Azion Console, token, personal token'
 namespace: docs_guides_personal_tokens
 permalink: /documentacao/produtos/guias/personal-tokens/
-video:
-  embedUrl: 'https://www.youtube.com/embed/HOkuSudhKfE'
-  uploadDate: '2023-10-17'
 ---
 
 import Tabs from '~/components/tabs/Tabs'
@@ -83,15 +80,6 @@ Você verá uma mensagem confirmando a exclusão do seu token.
 
 Assista esse tutorial sobre o gerenciamento de Personal Tokens no canal do YouTube da Azion:
 
-<iframe
-   src="https://www.youtube.com/embed/HOkuSudhKfE"
-   loading="lazy"
-   width="600"
-   height="400"
-   title="Secure Your Azion Personal Tokens: Creating and revoking Personal Tokens"
-   frameborder="0"
-   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-   allowfullscreen>
-   </iframe>
+<Video src="https://www.youtube.com/embed/HOkuSudhKfE" title="Como criar um personal token" description="Descubra como usar Personal Tokens na Azion." uploadDate="2023-10-17" />
 
 ---

--- a/src/content/docs/pt-br/pages/menu-principal/gerencie-contas/gerenciar-perfis/personal-token.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/gerencie-contas/gerenciar-perfis/personal-token.mdx
@@ -4,6 +4,9 @@ description: Descubra como usar Personal Tokens na Azion.
 meta_tags: 'conta, Azion Console, token, personal token'
 namespace: docs_guides_personal_tokens
 permalink: /documentacao/produtos/guias/personal-tokens/
+video:
+  embedUrl: 'https://www.youtube.com/embed/HOkuSudhKfE'
+  uploadDate: '2023-10-17'
 ---
 
 import Tabs from '~/components/tabs/Tabs'

--- a/src/util/videoObject.test.ts
+++ b/src/util/videoObject.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from 'vitest';
+import { getVideoObjectSchema, normalizeUploadDate } from './videoObject';
+
+describe('normalizeUploadDate', () => {
+	test('date-only gains midnight UTC offset', () => {
+		expect(normalizeUploadDate('2024-05-15')).toBe('2024-05-15T00:00:00+00:00');
+	});
+	test('datetime without offset gains Z', () => {
+		expect(normalizeUploadDate('2024-05-15T18:00:00')).toBe('2024-05-15T18:00:00Z');
+	});
+	test('datetime already in UTC is kept', () => {
+		expect(normalizeUploadDate('2024-05-15T18:00:00Z')).toBe('2024-05-15T18:00:00Z');
+	});
+	test('datetime with explicit offset is kept', () => {
+		expect(normalizeUploadDate('2024-05-15T18:00:00-03:00')).toBe('2024-05-15T18:00:00-03:00');
+	});
+	test('empty/undefined returns undefined', () => {
+		expect(normalizeUploadDate(undefined)).toBeUndefined();
+		expect(normalizeUploadDate('')).toBeUndefined();
+		expect(normalizeUploadDate('   ')).toBeUndefined();
+	});
+});
+
+describe('getVideoObjectSchema', () => {
+	const base = {
+		src: 'https://www.youtube.com/embed/KB4f4bSyHgI?autoplay=1',
+		title: 'How to look up DNS servers with Dig command',
+	};
+
+	test('emits embedUrl and a derived YouTube thumbnail (never contentUrl)', () => {
+		const schema = getVideoObjectSchema(base);
+		expect(schema.embedUrl).toBe(base.src);
+		expect(schema.thumbnailUrl).toBe('https://i.ytimg.com/vi/KB4f4bSyHgI/hqdefault.jpg');
+		expect(schema).not.toHaveProperty('contentUrl');
+	});
+
+	test('description falls back to the title when absent', () => {
+		expect(getVideoObjectSchema(base).description).toBe(base.title);
+	});
+
+	test('description is used when provided', () => {
+		const schema = getVideoObjectSchema({ ...base, description: 'A real description.' });
+		expect(schema.description).toBe('A real description.');
+	});
+
+	test('uploadDate is normalized to ISO 8601 with timezone', () => {
+		const schema = getVideoObjectSchema({ ...base, uploadDate: '2023-07-03' });
+		expect(schema.uploadDate).toBe('2023-07-03T00:00:00+00:00');
+	});
+
+	test('omits uploadDate and duration when not provided', () => {
+		const schema = getVideoObjectSchema(base);
+		expect(schema).not.toHaveProperty('uploadDate');
+		expect(schema).not.toHaveProperty('duration');
+	});
+});

--- a/src/util/videoObject.ts
+++ b/src/util/videoObject.ts
@@ -1,56 +1,64 @@
 /**
- * Builds a schema.org `VideoObject` JSON-LD node for a documentation page that
- * embeds a YouTube video.
+ * Builds a schema.org `VideoObject` JSON-LD node for a video embedded on a
+ * documentation page.
+ *
+ * Single source of truth: the same props that render the embed also feed this
+ * builder (see `~/components/Video.astro`), so the embed and its structured
+ * data can never diverge.
  *
  * Mirrors the decisions made in the `azion/site` repository:
  * - uses `embedUrl` (never `contentUrl`);
  * - derives `thumbnailUrl` from the YouTube video ID
- *   (`https://i.ytimg.com/vi/{ID}/hqdefault.jpg`);
- * - uses the page date as `uploadDate`;
- * - omits `duration`.
+ *   (`https://i.ytimg.com/vi/{ID}/hqdefault.jpg`) when not provided;
+ * - emits a stable `@id` derived from the page URL;
+ * - `duration` is optional and omitted when absent.
  *
  * See: https://developers.google.com/search/docs/appearance/structured-data/video
  */
 
-export interface VideoFrontmatter {
+export interface VideoObjectInput {
 	/** YouTube embed URL, e.g. `https://www.youtube.com/embed/KB4f4bSyHgI`. */
-	embedUrl: string;
-	/** Overrides the video `name`. Falls back to the page title. */
-	title?: string;
-	/** Overrides the video `description`. Falls back to the page description. */
+	src: string;
+	/** Video title (`name`). */
+	title: string;
+	/** Optional video description. */
 	description?: string;
-	/** ISO 8601 date used as `uploadDate` (typically the page date). */
-	uploadDate?: string;
 	/** Overrides the derived YouTube thumbnail. */
 	thumbnailUrl?: string;
-}
-
-interface PageContent {
-	title?: string;
-	description?: string;
+	/** ISO 8601 date used as `uploadDate`. */
+	uploadDate?: string;
+	/** ISO 8601 duration, e.g. `PT1M30S`. Omitted when absent. */
+	duration?: string;
+	/** Stable, page-scoped `@id` for the node. */
+	id?: string;
 }
 
 /** Extracts the YouTube video ID from a `/embed/{ID}` URL. */
-function getYouTubeId(embedUrl: string): string | null {
+export function getYouTubeId(embedUrl: string): string | null {
 	const match = embedUrl.match(/\/embed\/([^?/&#]+)/);
 	return match ? match[1] : null;
 }
 
-export function getVideoObjectSchema(video: VideoFrontmatter, content: PageContent) {
-	const id = getYouTubeId(video.embedUrl);
+export function getVideoObjectSchema(input: VideoObjectInput) {
+	const { src, title, description, uploadDate, duration, id } = input;
+
+	const youtubeId = getYouTubeId(src);
 	const thumbnailUrl =
-		video.thumbnailUrl ?? (id ? `https://i.ytimg.com/vi/${id}/hqdefault.jpg` : undefined);
+		input.thumbnailUrl ??
+		(youtubeId ? `https://i.ytimg.com/vi/${youtubeId}/hqdefault.jpg` : undefined);
 
 	const schema: Record<string, unknown> = {
 		'@context': 'https://schema.org',
 		'@type': 'VideoObject',
-		name: video.title ?? content.title,
-		description: video.description ?? content.description ?? content.title,
-		embedUrl: video.embedUrl,
 	};
 
+	if (id) schema['@id'] = id;
+	schema.name = title;
+	if (description) schema.description = description;
 	if (thumbnailUrl) schema.thumbnailUrl = thumbnailUrl;
-	if (video.uploadDate) schema.uploadDate = video.uploadDate;
+	if (uploadDate) schema.uploadDate = uploadDate;
+	schema.embedUrl = src;
+	if (duration) schema.duration = duration;
 
 	return schema;
 }

--- a/src/util/videoObject.ts
+++ b/src/util/videoObject.ts
@@ -1,0 +1,56 @@
+/**
+ * Builds a schema.org `VideoObject` JSON-LD node for a documentation page that
+ * embeds a YouTube video.
+ *
+ * Mirrors the decisions made in the `azion/site` repository:
+ * - uses `embedUrl` (never `contentUrl`);
+ * - derives `thumbnailUrl` from the YouTube video ID
+ *   (`https://i.ytimg.com/vi/{ID}/hqdefault.jpg`);
+ * - uses the page date as `uploadDate`;
+ * - omits `duration`.
+ *
+ * See: https://developers.google.com/search/docs/appearance/structured-data/video
+ */
+
+export interface VideoFrontmatter {
+	/** YouTube embed URL, e.g. `https://www.youtube.com/embed/KB4f4bSyHgI`. */
+	embedUrl: string;
+	/** Overrides the video `name`. Falls back to the page title. */
+	title?: string;
+	/** Overrides the video `description`. Falls back to the page description. */
+	description?: string;
+	/** ISO 8601 date used as `uploadDate` (typically the page date). */
+	uploadDate?: string;
+	/** Overrides the derived YouTube thumbnail. */
+	thumbnailUrl?: string;
+}
+
+interface PageContent {
+	title?: string;
+	description?: string;
+}
+
+/** Extracts the YouTube video ID from a `/embed/{ID}` URL. */
+function getYouTubeId(embedUrl: string): string | null {
+	const match = embedUrl.match(/\/embed\/([^?/&#]+)/);
+	return match ? match[1] : null;
+}
+
+export function getVideoObjectSchema(video: VideoFrontmatter, content: PageContent) {
+	const id = getYouTubeId(video.embedUrl);
+	const thumbnailUrl =
+		video.thumbnailUrl ?? (id ? `https://i.ytimg.com/vi/${id}/hqdefault.jpg` : undefined);
+
+	const schema: Record<string, unknown> = {
+		'@context': 'https://schema.org',
+		'@type': 'VideoObject',
+		name: video.title ?? content.title,
+		description: video.description ?? content.description ?? content.title,
+		embedUrl: video.embedUrl,
+	};
+
+	if (thumbnailUrl) schema.thumbnailUrl = thumbnailUrl;
+	if (video.uploadDate) schema.uploadDate = video.uploadDate;
+
+	return schema;
+}

--- a/src/util/videoObject.ts
+++ b/src/util/videoObject.ts
@@ -39,13 +39,33 @@ export function getYouTubeId(embedUrl: string): string | null {
 	return match ? match[1] : null;
 }
 
+/**
+ * Normalizes `uploadDate` to a full ISO 8601 datetime WITH a timezone, which is
+ * what Google's VideoObject requires. Fixes the Search Console warnings
+ * "Datetime property 'uploadDate' is missing a timezone" and
+ * "Invalid datetime value for 'uploadDate'".
+ *
+ * - date-only `YYYY-MM-DD`            → `YYYY-MM-DDT00:00:00+00:00`
+ * - datetime without offset `…T18:00` → append `Z` (UTC)
+ * - already has `Z`/offset            → kept as-is
+ */
+export function normalizeUploadDate(value?: string): string | undefined {
+	if (!value) return undefined;
+	const trimmed = value.trim();
+	if (!trimmed) return undefined;
+	if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) return `${trimmed}T00:00:00+00:00`;
+	if (/T\d{2}:\d{2}/.test(trimmed) && !/(Z|[+-]\d{2}:?\d{2})$/.test(trimmed)) return `${trimmed}Z`;
+	return trimmed;
+}
+
 export function getVideoObjectSchema(input: VideoObjectInput) {
-	const { src, title, description, uploadDate, duration, id } = input;
+	const { src, title, description, duration, id } = input;
 
 	const youtubeId = getYouTubeId(src);
 	const thumbnailUrl =
 		input.thumbnailUrl ??
 		(youtubeId ? `https://i.ytimg.com/vi/${youtubeId}/hqdefault.jpg` : undefined);
+	const uploadDate = normalizeUploadDate(input.uploadDate);
 
 	const schema: Record<string, unknown> = {
 		'@context': 'https://schema.org',
@@ -54,7 +74,9 @@ export function getVideoObjectSchema(input: VideoObjectInput) {
 
 	if (id) schema['@id'] = id;
 	schema.name = title;
-	if (description) schema.description = description;
+	// `description` is required by Google — always emit a non-empty value,
+	// falling back to the title when no description is provided.
+	schema.description = description || title;
 	if (thumbnailUrl) schema.thumbnailUrl = thumbnailUrl;
 	if (uploadDate) schema.uploadDate = uploadDate;
 	schema.embedUrl = src;


### PR DESCRIPTION
### Related issue

Google Search Console warning: "Either 'contentUrl' or 'embedUrl' should be specified" — videos not being indexed.

### Changes

This PR emits a schema.org `VideoObject` JSON-LD on the 23 documentation pages that embed a YouTube video, so Google can index them and enable rich results. It fixes the GSC `contentUrl`/`embedUrl` warning.

The logic replicates the `getVideoObjectSchema()` approach already shipped in `azion/site` (learning/blog pages), adapted to this repo's Astro architecture:
- uses **`embedUrl`** (never `contentUrl`);
- derives **`thumbnailUrl`** from the YouTube ID (`https://i.ytimg.com/vi/{ID}/hqdefault.jpg`);
- uses the page date as **`uploadDate`**;
- omits `duration`.

**Core changes:**
- **`src/util/videoObject.ts`** (new): `getVideoObjectSchema()` builder.
- **`src/content/config.ts`**: added an optional `video` object (`embedUrl` + optional `title`/`description`/`uploadDate`/`thumbnailUrl`) to `baseSchema`. The embed is sourced explicitly from frontmatter instead of parsing the page body.
- **`src/components/HeadSEO.astro`**: emits `<script type="application/ld+json">` with the `VideoObject` **only when** the page declares `video` (no impact on pages without video).
- **23 content files** (EN + PT-BR): added the `video` frontmatter block (`embedUrl` + `uploadDate`).

**Notes:**
- The Astro frameworks page has a second embed (`FIMBJBpZsdU`) not in the target list — only the requested `lQo6rLigHfk` was marked.
- The two EN/PT-BR pairs (`HOkuSudhKfE` personal-tokens, `soyIbJW0VdQ` data-stream) were handled individually.

**Verification:**
- `astro sync` regenerates content types with no schema errors.
- Dev server: all **23/23** target URLs render a valid `VideoObject` with the expected `embedUrl`, plus `thumbnailUrl`, `uploadDate`, `name` and `description`; no `contentUrl`/`duration`.
- A page without a video emits **no** `VideoObject`.

### Additional links

- Google reference: https://developers.google.com/search/docs/appearance/structured-data/video
- Validate after deploy: [Rich Results Test](https://search.google.com/test/rich-results) · [Schema Validator](https://validator.schema.org/)
