### PR TITLE
Fix translation for 'First 10 GB / month' in pricing table

### DIFF
--- a/src/components/Table/TablePricing.astro
+++ b/src/components/Table/TablePricing.astro
@@ -54,7 +54,7 @@ const i18n = {
 		'Up to 1 connector': 'Até 1 conector',
 		'Each additional connector': 'Cada conector adicional',
 
-		'First 10 GB / month': 'Primeiros 10 TB / mês',
+		'First 10 GB / month': 'Primeiros 10 GB / mês',
 		'Over 1 GB / month': 'Acima de 1 GB / mês',
 		'Next 49,990 GB / month': 'Próximos 49.990 GB / mês',
 		'Next 450 TB / month': 'Próximos 450 TB / mês',


### PR DESCRIPTION
<!--
Thank you for contributing to Azion Docs! Please fill out the information below.
Use the conventional commits standard to categorize the type of change in the PR title. We recommend:
- feat: adding new content
- refactor: making minor changes
- fix: fixing errors

Don't forget to add the Jira issue code to the PR title or the GitHub issue hash.
For example: 
- [EDU-3000] refactor: modify origins page to include load balancer
- [#34] feat: add new application CLI commands
- [NO-ISSUE] fix: fix broken link in Orch doc
-->

### Related issue: NO-ISSUE
fix table pricing PT Storage first 10GB


[EDU-3000]: https://aziontech.atlassian.net/browse/EDU-3000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ