### PR TITLE
chore: update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @isaquebock @egermano @madureira-gabriel
+* @isaquebock @egermano @souzavinny @pedroribeiroazion
 
 src/content/docs @aziontech/product-content
 src/i18n @aziontech/product-content


### PR DESCRIPTION
### Related issue: N/A

### Changes

- Update `.github/CODEOWNERS` to replace `@madureira-gabriel` with `@souzavinny` and `@pedroribeiroazion` as owners for the repository root.

### Additional links