### PR TITLE
fix(docs): correct broken internal links and add glossary redirects

### DIFF
--- a/cicd/massive-redirect/en.json
+++ b/cicd/massive-redirect/en.json
@@ -1894,5 +1894,9 @@
   {
     "from": "https://www.azion.com/en/documentation/products/store/storage/s3-protocol-for-edge-storage/",
     "moved": "https://www.azion.com/en/documentation/products/store/storage/s3-protocol-for-object-storage/"
+  },
+  {
+    "from": "https://www.azion.com/en/documentation/products/azion-glossary/",
+    "moved": "https://www.azion.com/en/documentation/products/azion-platform-overview/"
   }
 ]

--- a/cicd/massive-redirect/pt-br.json
+++ b/cicd/massive-redirect/pt-br.json
@@ -1887,5 +1887,9 @@
   {
     "from": "https://www.azion.com/pt-br/documentacao/produtos/edge-sql/",
     "moved": "https://www.azion.com/pt-br/documentacao/produtos/store/sql-database/"
+  },
+  {
+    "from": "https://www.azion.com/pt-br/documentacao/produtos/glossario-azion/",
+    "moved": "https://www.azion.com/pt-br/documentacao/produtos/visao-geral-da-plataforma-da-azion/"
   }
 ]

--- a/src/content/docs/en/pages/guides/vercel-to-azion/vercel-to-azion-comprehensive-guide.mdx
+++ b/src/content/docs/en/pages/guides/vercel-to-azion/vercel-to-azion-comprehensive-guide.mdx
@@ -895,7 +895,7 @@ Use the S3 endpoint for object management operations. For end-user delivery, ser
 #### Reference documentation
 
 * [Object Storage](https://www.azion.com/en/documentation/products/store/object-storage/)
-* [How to access Object Storage using the S3 protocol](https://www.azion.com/en/documentation/products/guides/s3-protocol-for-object-storage/)
+* [How to access Object Storage using the S3 protocol](https://www.azion.com/en/documentation/products/guides/use-s3-compatible-tools-with-object-storage/)
 * [Create and modify a bucket](https://www.azion.com/en/documentation/products/guides/create-and-modify-bucket/)
 * [Upload and download objects](https://www.azion.com/en/documentation/products/guides/upload-and-download-objects-from-bucket/)
 * [Use a bucket as origin](https://www.azion.com/en/documentation/products/store/storage/use-bucket-as-origin/)

--- a/src/content/docs/pt-br/pages/build-jornada/desenvolva-com-azion/guias-frameworks/framework-nextal.mdx
+++ b/src/content/docs/pt-br/pages/build-jornada/desenvolva-com-azion/guias-frameworks/framework-nextal.mdx
@@ -29,7 +29,7 @@ Antes de começar, você deve ter:
 
 - Uma conta na [plataforma da Azion](/pt-br/documentacao/produtos/contas/criar-uma-conta/) com o produto [Functions](/pt-br/documentacao/produtos/build/applications/functions/) habilitado.
 - [A versão mais recente da Azion CLI instalada](/pt-br/documentacao/produtos/azion-cli/visao-geral/).
-- Um [personal token da Azion](/pt-br/documentacao/produtos/contas/personal-tokens/) válido configurado no terminal.
+- Um [personal token da Azion](/pt-br/documentacao/produtos/gestao-de-contas/personal-tokens/) válido configurado no terminal.
 - Um editor de código.
 - Acesso ao terminal.
 - Node.js ≥ 18 instalado.

--- a/src/content/docs/pt-br/pages/guias/marketplace/integrations/bot-manager-lite.mdx
+++ b/src/content/docs/pt-br/pages/guias/marketplace/integrations/bot-manager-lite.mdx
@@ -300,7 +300,7 @@ Após habilitado, as regras executadas são registradas no campo `$traceback` (D
 Isso confirma que a `Bot Manager Lite Rule` foi executada antes do conjunto de regras WAF para aquela requisição. Se o nome da regra não aparecer no `stacktrace`, os critérios configurados no Rules Engine não corresponderam — revise a configuração de critérios na aba **Rules Engine**.
 
 :::tip
-Consulte o guia [Como fazer debug de regras criadas com o Rules Engine](/pt-br/documentacao/produtos/guias/debug-rules/) para instruções detalhadas sobre como consultar o `traceback` via Data Stream, Real-Time Events e GraphQL API.
+Consulte o guia [Como fazer debug de regras criadas com o Rules Engine](/pt-br/documentacao/produtos/guias/debug-regras/) para instruções detalhadas sobre como consultar o `traceback` via Data Stream, Real-Time Events e GraphQL API.
 :::
 
 import LinkButton from 'azion-webkit/linkbutton';

--- a/src/content/docs/pt-br/pages/secure-jornada/firewall-configuracoes-avancadas/monitorar-e-calibrar-bot-manager.mdx
+++ b/src/content/docs/pt-br/pages/secure-jornada/firewall-configuracoes-avancadas/monitorar-e-calibrar-bot-manager.mdx
@@ -209,7 +209,7 @@ Se o seu endpoint de login (`/api/auth/login`) ou caminho de checkout (`/checkou
 
 <LinkButton link="/pt-br/documentacao/produtos/guias/consultar-dados-bot-manager-com-graphql/" label="Consultar dados do Bot Manager com GraphQL" severity="secondary" />
 <br />
-<LinkButton link="/pt-br/documentacao/produtos/guias/consultar-top-urls-impactadas-por-bots-com-graphql/" label="Consultar top URLs impactadas com GraphQL" severity="secondary" />
+<LinkButton link="/pt-br/documentacao/produtos/guias/consultar-dados-bot-manager-breakdown-com-graphql/" label="Consultar top URLs impactadas com GraphQL" severity="secondary" />
 
 ---
 
@@ -444,6 +444,6 @@ Use este checklist após cada ciclo de calibração:
 <br />
 <LinkButton link="/pt-br/documentacao/produtos/guias/consultar-dados-bot-manager-com-graphql/" label="Consultar dados do Bot Manager com GraphQL" severity="secondary" />
 <br />
-<LinkButton link="/pt-br/documentacao/produtos/guias/consultar-top-urls-impactadas-por-bots-com-graphql/" label="Consultar top URLs impactadas com GraphQL" severity="secondary" />
+<LinkButton link="/pt-br/documentacao/produtos/guias/consultar-dados-bot-manager-breakdown-com-graphql/" label="Consultar top URLs impactadas com GraphQL" severity="secondary" />
 <br />
 <LinkButton link="/pt-br/documentacao/produtos/observe/data-stream/" label="Referência do Data Stream" severity="secondary" />


### PR DESCRIPTION


# Brief

Fixes 404s in the docs portal: five internal links pointing to permalinks that no longer exist, and two retired glossary pages with no redirect.

## Break down

- Cross-checked the reported 404 URLs against the `permalink` frontmatter of every page under `src/content/docs/` to find the current target for each dead link.
- Updated the five broken links in place (4 content files). Only the URLs changed — no copy or structure edits.
- Added redirect entries for the two retired glossary pages to `cicd/massive-redirect/{en,pt-br}.json`, pointing to the platform overview.
- Verified both directions by grepping `permalink:` across the content collection: every new target resolves to an existing page, and every old target is confirmed absent.

## Evidences

**Broken links fixed**

| File | Before | After |
| --- | --- | --- |
| `en/.../vercel-to-azion-comprehensive-guide.mdx` | `/en/documentation/products/guides/s3-protocol-for-object-storage/` | `/en/documentation/products/guides/use-s3-compatible-tools-with-object-storage/` |
| `pt-br/.../guias-frameworks/framework-nextal.mdx` | `/pt-br/documentacao/produtos/contas/personal-tokens/` | `/pt-br/documentacao/produtos/gestao-de-contas/personal-tokens/` |
| `pt-br/.../marketplace/integrations/bot-manager-lite.mdx` | `/pt-br/documentacao/produtos/guias/debug-rules/` | `/pt-br/documentacao/produtos/guias/debug-regras/` |
| `pt-br/.../monitorar-e-calibrar-bot-manager.mdx` (2x) | `/pt-br/documentacao/produtos/guias/consultar-top-urls-impactadas-por-bots-com-graphql/` | `/pt-br/documentacao/produtos/guias/consultar-dados-bot-manager-breakdown-com-graphql/` |

**Redirects added**

| Locale | From (404) | To |
| --- | --- | --- |
| en | `/en/documentation/products/azion-glossary/` | `/en/documentation/products/azion-platform-overview/` |
| pt-br | `/pt-br/documentacao/produtos/glossario-azion/` | `/pt-br/documentacao/produtos/visao-geral-da-plataforma-da-azion/` |

## Screens

"use-s3-compatible-tools-with-object-storage"

Before: 
<img width="1180" height="442" alt="image" src="https://github.com/user-attachments/assets/1cf8cc69-2424-4ece-9073-7e88a2bff6ff" />

After: 

<img width="1636" height="914" alt="image" src="https://github.com/user-attachments/assets/f29e50fa-b535-4f0b-948c-8f24222dce62" />

"personal-tokens""

Before (Wrong page being used in /frameworks/nextal):

<img width="1154" height="425" alt="image" src="https://github.com/user-attachments/assets/ec790abb-0c41-4d9d-8554-528c776d9eb1" />

After:

<img width="678" height="154" alt="image" src="https://github.com/user-attachments/assets/eb5e3cff-f1fc-44ae-bace-71638fbddf18" />

"Botmanager lite pointing to en page""

Before: 

<img width="988" height="712" alt="Screenshot 2026-07-22 at 13 01 12" src="https://github.com/user-attachments/assets/3c7f611b-e644-46c5-bd14-0b88670d8afe" />

After:

<img width="1013" height="686" alt="image" src="https://github.com/user-attachments/assets/f4c43e35-aa10-47a1-af66-4e01d52f68af" />

"Consultar"

Before:

<img width="1138" height="387" alt="image" src="https://github.com/user-attachments/assets/fe006945-55d5-4cce-99ff-c687ed339646" />

After:

<img width="1425" height="657" alt="image" src="https://github.com/user-attachments/assets/2df97b9b-9e1b-4b9b-ba26-8c595893ed9a" />
