### PR TITLE
fix(pricing): update pricing API endpoint and guard non-OK responses

### DIFF
--- a/src/components/Table/TablePricing.astro
+++ b/src/components/Table/TablePricing.astro
@@ -188,7 +188,10 @@ const i18n = {
 
 async function fetchPricingData() {
 	// product_slug come from Astro.props
-  const response = await fetch(`https://www.azion.com/api/pricing/get/product_slug/${product_slug}`);
+  const response = await fetch(`https://vef4esszhdq.map.azionedge.net/api/pricing/get/product_slug/${product_slug}`);
+  if (!response.ok) {
+    throw new Error(`Pricing API returned ${response.status} for product_slug "${product_slug}"`);
+  }
   const data = await response.json();
   // Return empty array if API returns error object instead of array
   return Array.isArray(data) ? data : [];


### PR DESCRIPTION
# Brief

Production builds were failing on the pricing pages: the API at `www.azion.com/api/pricing` now returns an HTML 404 page instead of JSON, crashing `TablePricing.astro` at build time. Fixed by reverting the component at the working endpoint from previous state and adding a `response.ok` guard so future API failures produce a clear build error.

## Activities

- Traced the build error to `fetchPricingData()` in `src/components/Table/TablePricing.astro` and confirmed the new endpoint returns HTML 404 for every product slug.
- Swapped the fetch URL to `https://vef4esszhdq.map.azionedge.net/api/pricing/get/product_slug/<slug>` (Verified on the commit history at https://github.com/aziontech/docs/pull/2060) and added a `response.ok` guard.

## Evidences

- Reverted endpoint returns HTTP 200 JSON for all 15 product slugs; all 28 `product_slug`/`metric_slug` pairs used in the EN/PT-BR pages have matching data. All prices there are the same as the one currently live. 
- Both pricing pages rendered successfully via dev server with populated tables and correct currency/i18n formatting.


Before:
<img width="926" height="250" alt="image" src="https://github.com/user-attachments/assets/b606cd4b-ef66-42f7-bc69-ebd56fe8fd19" />

After:
<img width="1126" height="938" alt="image" src="https://github.com/user-attachments/assets/f8aaeaf9-1cc4-4768-b91b-bebfb3999337" />
