### PR TITLE
[MM-15701] fix: update contact sales links

### DIFF
--- a/src/content/docs/en/pages/architectures/bot-management/bot-management-architecture.mdx
+++ b/src/content/docs/en/pages/architectures/bot-management/bot-management-architecture.mdx
@@ -86,7 +86,7 @@ You can test and implement Azion Bot Manager in two ways:
     1. [Create an application](/en/documentation/products/guides/build/build-an-application/).
     2. [Add a custom domain to it](/en/documentation/products/guides/configure-a-domain/).
     3. [Enable Bot Manager](/en/documentation/products/secure/firewall/bot-manager/).
-        - Contact the [Sales team](https://www.azion.com/en/contact-sales/) for more details on the Bot Manager subscription.
+        - Contact the [Sales team](https://www.azion.com/en/contact/) for more details on the Bot Manager subscription.
         - [Configure Bot Manager Lite](/en/documentation/products/guides/bot-manager-lite/) if you've decided to use this version.
     4. [Monitor bot activity](/en/documentation/products/observe/data-stream/first-steps/) and calibrate rules.
 

--- a/src/content/docs/en/pages/architectures/edge-firewall/online-fraud-prevention.mdx
+++ b/src/content/docs/en/pages/architectures/edge-firewall/online-fraud-prevention.mdx
@@ -103,7 +103,7 @@ This approach performs fraud detection directly at the edge before reaching your
   - Run functions with custom logic.
 - [Instantiate functions](/en/documentation/products/guides/secure/instantiate-functions/) and [integrations](/en/documentation/products/marketplace/integrations/#edge-firewall-functions).
 5. [Enable Bot Manager](/en/documentation/products/secure/firewall/bot-manager/).
-- Contact the [Sales team](https://www.azion.com/en/contact-sales/) for more details on the Bot Manager subscription.
+- Contact the [Sales team](https://www.azion.com/en/contact/) for more details on the Bot Manager subscription.
 6. [Monitor your application](/en/documentation/products/observe/monitor-applications/) and refine rules.
 
 ---

--- a/src/content/docs/en/pages/architectures/edge-firewall/waap-architecture.mdx
+++ b/src/content/docs/en/pages/architectures/edge-firewall/waap-architecture.mdx
@@ -73,7 +73,7 @@ This solution is ideal for organizations looking to safeguard their digital infr
 - [Create a network list in Network Shield](/en/documentation/products/guides/blocklists-ip-addresses-edge/).
     - Configure the IPs or countries that'll be blocked.
 - [Enable Bot Manager](/en/documentation/products/secure/firewall/bot-manager/).
-    - Contact the [Sales team](https://www.azion.com/en/contact-sales/) for more details on the Bot Manager subscription.
+    - Contact the [Sales team](https://www.azion.com/en/contact/) for more details on the Bot Manager subscription.
     - [Configure Bot Manager Lite](/en/documentation/products/guides/bot-manager-lite/) if you've decided to use this version.
 - [Create rules in Rules Engine for Firewall](/en/documentation/products/guides/secure/work-with-rules-engine/).
     - Configure the Set WAF Rule Set behavior.

--- a/src/content/docs/en/pages/architectures/security-automation/security-automation.mdx
+++ b/src/content/docs/en/pages/architectures/security-automation/security-automation.mdx
@@ -62,7 +62,7 @@ In this context, autonomous systems operate with minimal or no human interventio
   - [Rules Engine rules](/en/documentation/products/secure/firewall/rules-engine/), using criteria and behaviors to define how the request is handled. It includes rules related to network lists, WAF Rules, Custom Allowed Rules, rate limits, custom responses, blocking and dropping requests, and run functions.
   - [Functions](/en/documentation/products/secure/firewall/functions/), creating your own code or using [Marketplace Firewall integrations](/en/documentation/products/marketplace/integrations/#edge-firewall-functions).
 4. Enable Bot Manager:
-- Contact the [Sales team](https://www.azion.com/en/contact-sales/) for more details about the Bot Manager subscription.
+- Contact the [Sales team](https://www.azion.com/en/contact/) for more details about the Bot Manager subscription.
 - Configure [Bot Manager Lite](/en/documentation/products/guides/bot-manager-lite/) if you've decided to use this version.
 
 When saved, configurations are replicated across all edge nodes in the network. Whenever a request reaches Azion's platform, the rules and configurations are executed, and the system processes the request accordingly. You can use Observe products to monitor and track traffic.

--- a/src/content/docs/en/pages/devtools/api-graphql/features/metrics-fields.mdx
+++ b/src/content/docs/en/pages/devtools/api-graphql/features/metrics-fields.mdx
@@ -269,7 +269,7 @@ When a field is a result of any kind of calculation, such as a sum, they’re co
 ## botManagerMetrics
 
 :::note
-To retrieve this data, you must be subscribed to Azion Bot Manager. Contact the [Sales team](https://www.azion.com/en/contact-sales/) for more details on the subscription.
+To retrieve this data, you must be subscribed to Azion Bot Manager. Contact the [Sales team](https://www.azion.com/en/contact/) for more details on the subscription.
 :::
 
 | Field | Description |
@@ -315,7 +315,7 @@ When a field results from any kind of calculation, such as a sum, they're consid
 ## botManagerBreakdownMetrics
 
 :::note
-To retrieve this data, you must be subscribed to Azion Bot Manager. Contact the [Sales team](https://www.azion.com/en/contact-sales/) for more details on the subscription.
+To retrieve this data, you must be subscribed to Azion Bot Manager. Contact the [Sales team](https://www.azion.com/en/contact/) for more details on the subscription.
 :::
 
 | Field | Description |

--- a/src/content/docs/en/pages/guides/graphql/bot-manager-breakdown-data.mdx
+++ b/src/content/docs/en/pages/guides/graphql/bot-manager-breakdown-data.mdx
@@ -14,7 +14,7 @@ This information can be accessed through the GraphQL API. Additionally, this dat
 This guide explains how to query the top 5 URLs impacted by bot activity.
 
 :::note
-To retrieve this data, you must be subscribed to Azion Bot Manager and use the [GraphQL API](/en/documentation/devtools/graphql-api/overview/). Contact the [Sales team](https://www.azion.com/en/contact-sales/) for more details on the subscription.
+To retrieve this data, you must be subscribed to Azion Bot Manager and use the [GraphQL API](/en/documentation/devtools/graphql-api/overview/). Contact the [Sales team](https://www.azion.com/en/contact/) for more details on the subscription.
 :::
 
 ---

--- a/src/content/docs/en/pages/guides/graphql/query-bot-manager-data.mdx
+++ b/src/content/docs/en/pages/guides/graphql/query-bot-manager-data.mdx
@@ -14,7 +14,7 @@ This information can be accessed through the GraphQL API. Additionally, this dat
 This guide will explain how to query Bot Manager data using the GraphiQL playground.
 
 :::note
-To retrieve this data, you must be subscribed to Azion Bot Manager and use the [GraphQL API](/en/documentation/devtools/graphql-api/overview/). Contact the [Sales team](https://www.azion.com/en/contact-sales/) for more details on the subscription.
+To retrieve this data, you must be subscribed to Azion Bot Manager and use the [GraphQL API](/en/documentation/devtools/graphql-api/overview/). Contact the [Sales team](https://www.azion.com/en/contact/) for more details on the subscription.
 :::
 
 ---

--- a/src/content/docs/en/pages/guides/marketplace/integrations/bot-manager-lite.mdx
+++ b/src/content/docs/en/pages/guides/marketplace/integrations/bot-manager-lite.mdx
@@ -17,7 +17,7 @@ This integration enables the detection of suspicious traffic and bad bots, facil
 :::note
 This integration is a lite version of [Azion Bot Manager](https://www.azion.com/en/products/bot-manager/), a comprehensive solution for bot management.
 
-Contact the [Sales team](https://www.azion.com/en/contact-sales/) for more details on the Bot Manager subscription.
+Contact the [Sales team](https://www.azion.com/en/contact/) for more details on the Bot Manager subscription.
 :::
 
 ---

--- a/src/content/docs/en/pages/guides/marketplace/templates/bot-starter-kit.mdx
+++ b/src/content/docs/en/pages/guides/marketplace/templates/bot-starter-kit.mdx
@@ -19,7 +19,7 @@ The deployment automatically creates an application, an function, an Firewall, a
 :::note
 Bot Manager Lite integration is a [lite version](/en/documentation/products/guides/bot-manager-lite/) available in the Marketplace.
 
-Azion provides the Bot Manager add-on, a comprehensive solution for bot management. Contact the [Sales team](https://www.azion.com/en/contact-sales/) for more details on the Bot Manager subscription.
+Azion provides the Bot Manager add-on, a comprehensive solution for bot management. Contact the [Sales team](https://www.azion.com/en/contact/) for more details on the Bot Manager subscription.
 :::
 
 ---

--- a/src/content/docs/en/pages/guides/marketplace/templates/bot-with-firewall.mdx
+++ b/src/content/docs/en/pages/guides/marketplace/templates/bot-with-firewall.mdx
@@ -19,7 +19,7 @@ The **Bot Manager Lite Integration Kit** template provides an easy way to integr
 :::note
 Bot Manager Lite integration is a [lite version](/en/documentation/products/guides/bot-manager-lite/) available in the Marketplace.
 
-Azion provides the Bot Manager add-on, a comprehensive solution for bot management. Contact the [Sales team](https://www.azion.com/en/contact-sales/) for more details on the Bot Manager subscription.
+Azion provides the Bot Manager add-on, a comprehensive solution for bot management. Contact the [Sales team](https://www.azion.com/en/contact/) for more details on the Bot Manager subscription.
 :::
 
 ---

--- a/src/content/docs/en/pages/guides/marketplace/templates/bot-with-tor.mdx
+++ b/src/content/docs/en/pages/guides/marketplace/templates/bot-with-tor.mdx
@@ -21,7 +21,7 @@ This template automatically creates a new Firewall that includes the rules to ex
 :::note
 Bot Manager Lite integration is a [lite version](/en/documentation/products/guides/bot-manager-lite/) available in the Marketplace.
 
-Azion provides the Bot Manager add-on, a comprehensive solution for bot management. Contact the [Sales team](https://www.azion.com/en/contact-sales/) for more details on the Bot Manager subscription.
+Azion provides the Bot Manager add-on, a comprehensive solution for bot management. Contact the [Sales team](https://www.azion.com/en/contact/) for more details on the Bot Manager subscription.
 :::
 
 ---

--- a/src/content/docs/en/pages/guides/mtls/configure-mtls.mdx
+++ b/src/content/docs/en/pages/guides/mtls/configure-mtls.mdx
@@ -16,7 +16,7 @@ import Apiv4Rollout from '~/includes/snippets/apiv4Rollout/en/snippet.mdx'
 
 **Mutual Transport Layer Security (mTLS)** is an encryption protocol based on *Transport Layer Security (TLS)*, which validates the digital certificate on both ends of a request.
 
-To configure mTLS in your applications, you need to activate the service through [Azion Sales Team](https://www.azion.com/en/contact-sales/) in addition to having a digital certificate with mTLS support, provided by a third-party certificate authority. At Azion, this certificate is called **Trusted Certificate (Trusted CA)**.
+To configure mTLS in your applications, you need to activate the service through [Azion Sales Team](https://www.azion.com/en/contact/) in addition to having a digital certificate with mTLS support, provided by a third-party certificate authority. At Azion, this certificate is called **Trusted Certificate (Trusted CA)**.
 
 More information about requirements, certificate manager, Trusted CA, and how mTLS works at Azion is available on the [Support for mTLS page](/en/documentation/products/secure/firewall/mtls/).
 

--- a/src/content/docs/en/pages/guides/network-layer-protection/retrieve-azion-ip-ranges/index.mdx
+++ b/src/content/docs/en/pages/guides/network-layer-protection/retrieve-azion-ip-ranges/index.mdx
@@ -21,7 +21,7 @@ When your application's origin server sits behind Azion, all inbound requests ar
 ## Prerequisites
 
 - The [Network Shield module](/en/documentation/products/secure/firewall/network-shield/) enabled on your Firewall.
-- An active **Origin Shield** add-on subscription. Contact the [sales team](https://www.azion.com/en/contact-sales/) to subscribe.
+- An active **Origin Shield** add-on subscription. Contact the [sales team](https://www.azion.com/en/contact/) to subscribe.
 
 ---
 

--- a/src/content/docs/en/pages/main-menu/manage-accounts/create-accountd.mdx
+++ b/src/content/docs/en/pages/main-menu/manage-accounts/create-accountd.mdx
@@ -34,7 +34,7 @@ In the message, you'll find instructions to confirm your email address. Click th
 
 If you don't receive the email, check your *Spam* folder.
 
-If you have any questions, [contact the sales team](https://www.azion.com/en/contact-sales/).
+If you have any questions, [contact the sales team](https://www.azion.com/en/contact/).
 :::
 
 By clicking on the link sent by email, the [Azion Console](https://console.azion.com) page will open. To sign in:

--- a/src/content/docs/en/pages/main-menu/reference/build/edge-application/cache-settings.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/build/edge-application/cache-settings.mdx
@@ -43,7 +43,7 @@ With **Cache Settings** for **Applications**, you can edit cache configurations 
 
 ## Large File Optimization
 
-**Large File Optimization** works with a default fragment size of *1024 kB*. If you want to modify the fragmentation range, [contact the Sales team](https://www.azion.com/en/contact-sales/).
+**Large File Optimization** works with a default fragment size of *1024 kB*. If you want to modify the fragmentation range, [contact the Sales team](https://www.azion.com/en/contact/).
 
 <LinkButton link="/en/documentation/products/build/applications/cache/#large-file-optimization" label="go to Large File Optimization documentation" />
 

--- a/src/content/docs/en/pages/main-menu/reference/build/edge-application/domains/domains.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/build/edge-application/domains/domains.mdx
@@ -44,7 +44,7 @@ Before going operational, you can activate a testing configuration to preview se
 - **Global Infrastructure*: production environment of the application. The Azion domain will be in the format `xxxx.map.azionedge.net`.
 - **Staging Network**: environment for testing the application. This configuration won't impact the **Production** environment. The Azion domain will be in the format `xxxx.preview.azionedge.net`.
 
-To enable environment selection, contact the [Sales Team](https://www.azion.com/en/contact-sales/).
+To enable environment selection, contact the [Sales Team](https://www.azion.com/en/contact/).
 
 ---
 
@@ -72,7 +72,7 @@ Azion's Domains also have **Support for Mutual Transport Layer Security (mTLS)**
 You may need mTLS if your application deals with financial services and payments.
 :::
 
-To enable this feature, contact our [Sales Team](https://www.azion.com/en/contact-sales/).
+To enable this feature, contact our [Sales Team](https://www.azion.com/en/contact/).
 
 ---
 

--- a/src/content/docs/en/pages/main-menu/reference/build/edge-application/domains/mtls.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/build/edge-application/domains/mtls.mdx
@@ -27,7 +27,7 @@ It's necessary that your **Applications** is operating with the *Hypertext Trans
 Protocol options are available on your **Applications** configuration page in Azion Console.
 
 :::note
-mTLS will only be available if the service is activated. Contact our [Sales Team](https://www.azion.com/en/contact-sales/) to activate it.
+mTLS will only be available if the service is activated. Contact our [Sales Team](https://www.azion.com/en/contact/) to activate it.
 :::
 
 <LinkButton severity="secondary" link="/en/documentation/products/guides/secure/mtls/" label="go to associate mTLS certificate to domain guide" severity="secondary" /> 

--- a/src/content/docs/en/pages/main-menu/reference/build/edge-application/l2-caching.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/build/edge-application/l2-caching.mdx
@@ -21,7 +21,7 @@ When accessing your applications on Azion, your end-user accesses the edge netwo
 - Select the best region to keep cache closer to your users.
 
 :::note
-Tiered Cache is only available if the service has been activated for your account. To activate **Tiered Cache**, [contact the Sales team](https://www.azion.com/en/contact-sales/).
+Tiered Cache is only available if the service has been activated for your account. To activate **Tiered Cache**, [contact the Sales team](https://www.azion.com/en/contact/).
 :::
 
 ## Implementation
@@ -45,7 +45,7 @@ Tiered Cache is only available if the service has been activated for your accoun
 
 When you enable **Tiered Cache** as an extra caching layer, the edge servers of this second caching layer are hosted in the US (`na-united-states`) by default. 
 
-Azion also offers the option of hosting the Tiered Cache servers in Brazil (`sa-brazil`). To switch between regions in your applications, please contact the [Sales team](https://www.azion.com/en/contact-sales/).
+Azion also offers the option of hosting the Tiered Cache servers in Brazil (`sa-brazil`). To switch between regions in your applications, please contact the [Sales team](https://www.azion.com/en/contact/).
 
 ---
 

--- a/src/content/docs/en/pages/main-menu/reference/build/edge-application/v3/main-settings-v3.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/build/edge-application/v3/main-settings-v3.mdx
@@ -88,7 +88,7 @@ The **Transport Layer Security (TLS)** protocol allows you to encrypt web traffi
 
 You can choose the minimum version of TLS that'll be supported by your application. By choosing recent versions of the protocol, older devices or browsers might not be able to access the application.
 
-Azion blocks TLS Renegotiation and TLS Resumption by default. If you want to customize this setup, [contact the Sales team](https://www.azion.com/en/contact-sales/).
+Azion blocks TLS Renegotiation and TLS Resumption by default. If you want to customize this setup, [contact the Sales team](https://www.azion.com/en/contact/).
 
 :::note
 A TLS scan performed against an Azion data center IP or domain returns the TLS versions accepted at the **infrastructure level** — not the minimum TLS version configured for your application. Azion's shared infrastructure accepts TLS 1.0, 1.1, 1.2, and 1.3 at the network layer.

--- a/src/content/docs/en/pages/main-menu/reference/marketplace/permissions-marketplace.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/marketplace/permissions-marketplace.mdx
@@ -30,7 +30,7 @@ The **Main Settings** tab on your application includes the main configurations n
     - A traffic balancer to assure you the best-on-class reliability and network congestion control.
 
 :::note
-Some integrations on Azion Marketplace may require the Tiered Cache module. Contact the [Azion Sales team](https://www.azion.com/en/contact-sales/) to activate this module for your account.
+Some integrations on Azion Marketplace may require the Tiered Cache module. Contact the [Azion Sales team](https://www.azion.com/en/contact/) to activate this module for your account.
 :::
 
 ### Rules Engine

--- a/src/content/docs/en/pages/main-menu/reference/observe/data-stream/data-stream.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/observe/data-stream/data-stream.mdx
@@ -313,7 +313,7 @@ When you select **All Domains**, the platform automatically selects all current 
 In case you select the **All Domains** option, you can also set the percentage of data you want to receive randomly from your stream through the *Sampling* option. In addition to filtering by sampling, it can also reduce costs of data collection and analysis.
 
 :::note
-Currently, the *Sampling* option isn't available for all Azion Console accounts. If you'd like to use it on your account, [contact the sales team](https://www.azion.com/en/contact-sales/).
+Currently, the *Sampling* option isn't available for all Azion Console accounts. If you'd like to use it on your account, [contact the sales team](https://www.azion.com/en/contact/).
 :::
 
 The **Sampling (%)** field should contain the percentage of data you want to receive. This percentage will return the total data related to all your domains.

--- a/src/content/docs/en/pages/main-menu/reference/observe/data-stream/first-steps.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/observe/data-stream/first-steps.mdx
@@ -8,7 +8,7 @@ permalink: /documentation/products/observe/data-stream/first-steps/
 
 Before beginning to use **Data Stream**, make sure you have a [Azion Console](https://console.azion.com) account. You can find more information on creating one on the [documentation page](/en/documentation/products/accounts/creating-account/).
 
-As Data Stream is a billed product, you must also make sure you have it activated in your account. [Contact the Sales team](https://www.azion.com/en/contact-sales/) for more details.
+As Data Stream is a billed product, you must also make sure you have it activated in your account. [Contact the Sales team](https://www.azion.com/en/contact/) for more details.
 
 To access Data Stream:
 

--- a/src/content/docs/en/pages/main-menu/reference/observe/real-time-metrics/real-time-metrics.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/observe/real-time-metrics/real-time-metrics.mdx
@@ -525,7 +525,7 @@ By using Edge DNS, your domains are hosted and managed on Azion. Then, whenever 
 The **Bot Manager** tab displays metrics related to Bot Manager activity. It has two sections: **Overview** and **Breakdown**.
 
 :::note
-To visualize these graphs, you must be subscribed to Azion Bot Manager. Contact the [Sales team](https://www.azion.com/en/contact-sales/) for more details on the subscription.
+To visualize these graphs, you must be subscribed to Azion Bot Manager. Contact the [Sales team](https://www.azion.com/en/contact/) for more details on the subscription.
 :::
 
 Find out more about each chart:

--- a/src/content/docs/en/pages/main-menu/reference/secure/edge-dns/dnssec/dnssec.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/secure/edge-dns/dnssec/dnssec.mdx
@@ -88,7 +88,7 @@ To enable signature verification, DNSSEC requires the administration of new *Res
 - For the new settings to become effective, wait for a new publication by the person responsible for the TLD.
 - Effective propagation and global visibility of the change may take a few days, as it depends on updating the cache of resolvers administered by third parties.
 
-[Contact the Sales team](https://www.azion.com/en/contact-sales/) to host a DNS zone previously configured with DNSSEC at Azion.
+[Contact the Sales team](https://www.azion.com/en/contact/) to host a DNS zone previously configured with DNSSEC at Azion.
 
 
 

--- a/src/content/docs/en/pages/main-menu/reference/secure/edge-firewall/azion-bot-manager.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/secure/edge-firewall/azion-bot-manager.mdx
@@ -33,7 +33,7 @@ By using **Bot Manager**, you can:
 
 ## Implementation
 
-Azion provides the Bot Manager add-on, a comprehensive solution for bot management. Contact the [Sales team](https://www.azion.com/en/contact-sales/) for more details on the Bot Manager subscription.
+Azion provides the Bot Manager add-on, a comprehensive solution for bot management. Contact the [Sales team](https://www.azion.com/en/contact/) for more details on the Bot Manager subscription.
 
 Additionally, a [lite version](/en/documentation/products/guides/bot-manager-lite/) is also available in the Marketplace.
 

--- a/src/content/docs/en/pages/main-menu/reference/secure/edge-firewall/ddos-protection/ddos-protection.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/secure/edge-firewall/ddos-protection/ddos-protection.mdx
@@ -57,7 +57,7 @@ Azion's DNS servers get their configuration from the customer's origin server, w
 **DDoS Protection** offers complete visibility of application attacks through [Azion Console](https://console.azion.com) or [Azion API](https://api.azion.com) to be able to view the attack volume. In conjunction with the **Security Response Team (SRT)**, you'll have access to post-event analysis and investigations.
 
 :::tip
-Azion offers the [Security Response Team (SRT)](/en/documentation/services/security-response-team/) service, that can be activated during or after a DDoS attack to help track incidents, ascertain the root cause, and implement solutions alongside your business.  For more information on the Security Response Team (SRT), contact the [sales team](https://www.azion.com/en/contact-sales/).
+Azion offers the [Security Response Team (SRT)](/en/documentation/services/security-response-team/) service, that can be activated during or after a DDoS attack to help track incidents, ascertain the root cause, and implement solutions alongside your business.  For more information on the Security Response Team (SRT), contact the [sales team](https://www.azion.com/en/contact/).
 :::
 
 ---

--- a/src/content/docs/en/pages/main-menu/reference/secure/edge-firewall/mtls.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/secure/edge-firewall/mtls.mdx
@@ -27,7 +27,7 @@ It's necessary that your **Application** is operating with the *Hypertext Transf
 Protocol options are available on your **Application** configuration page in Azion Console.
 
 :::note
-mTLS will only be available if the service is activated. Contact our [Sales Team](https://www.azion.com/en/contact-sales/) to activate it.
+mTLS will only be available if the service is activated. Contact our [Sales Team](https://www.azion.com/en/contact/) to activate it.
 :::
 
 <LinkButton link="/en/documentation/products/guides/secure/mtls/" label="go to associate mTLS certificate to domain guide" severity="secondary" /> 

--- a/src/content/docs/en/pages/main-menu/reference/secure/worklads/workloads.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/secure/worklads/workloads.mdx
@@ -126,7 +126,7 @@ The **Transport Layer Security (TLS)** protocol allows you to encrypt web traffi
 
 You can choose the minimum version of TLS that'll be supported by your Workload. By choosing recent versions of the protocol, older devices or browsers might not be able to access the application.
 
-Azion blocks TLS Renegotiation and TLS Resumption by default. If you want to customize this setup, [contact the Sales team](https://www.azion.com/en/contact-sales/).
+Azion blocks TLS Renegotiation and TLS Resumption by default. If you want to customize this setup, [contact the Sales team](https://www.azion.com/en/contact/).
 
 
 ### TLS Ciphers
@@ -170,7 +170,7 @@ Azion Workloads also have **Support for Mutual Transport Layer Security (mTLS)**
 You may need mTLS if your Workload deals with financial services and payments.
 :::
 
-To enable this feature, contact our [Sales Team](https://www.azion.com/en/contact-sales/).
+To enable this feature, contact our [Sales Team](https://www.azion.com/en/contact/).
 
 ---
 

--- a/src/content/docs/en/pages/main-menu/reference/services/integration-services/instructor-led-training.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/services/integration-services/instructor-led-training.mdx
@@ -10,7 +10,7 @@ permalink: /documentation/services/instructor-led-training/
 
 **Instructor-Led Training** offers learning experiences adapted to your specific needs. Expand your knowledge and skills of Azion's platform and products with expert-led training in in-person or virtual classes.
 
-If you have an **Enterprise** or **Mission-Critical** Support service, you can request this service by contacting the [Sales team](https://www.azion.com/en/contact-sales/).
+If you have an **Enterprise** or **Mission-Critical** Support service, you can request this service by contacting the [Sales team](https://www.azion.com/en/contact/).
 
 For more detailed information, see [Azion Support](https://www.azion.com/en/professional-services/).
 

--- a/src/content/docs/en/pages/main-menu/reference/services/integration-services/security-response-team.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/services/integration-services/security-response-team.mdx
@@ -11,6 +11,6 @@ permalink: /documentation/services/security-response-team/
 
 The **Security Response Team (SRT)** is a managed service designed to control and mitigate workload failures and DDoS attacks. The SRT is available *24x7* and can be activated during or after a DDoS attack to help track incidents, ascertain the root cause, and implement solutions alongside your business. You may also mobilize the SRT for post-attack analysis.
 
-Customers with **Enterprise** or **Mission-Critical** Support have an hour package available for purchase and can request this service by contacting the [Sales](https://www.azion.com/en/contact-sales/) and Customer Success teams.
+Customers with **Enterprise** or **Mission-Critical** Support have an hour package available for purchase and can request this service by contacting the [Sales](https://www.azion.com/en/contact/) and Customer Success teams.
 
 For more detailed information, see [Azion Support](https://www.azion.com/en/professional-services/).

--- a/src/content/docs/en/pages/main-menu/reference/services/integration-services/technical-account-manager.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/services/integration-services/technical-account-manager.mdx
@@ -21,6 +21,6 @@ Customers with **Mission-Critical** Support service already have a package of up
 | Pool     | Up to 40 hours/month  | 
 | Dedicated | Up to 140 hours/month | 
 
-If you have an **Enterprise** or **Mission-Critical** Support, you can request this service by contacting the [Sales](https://www.azion.com/en/contact-sales/) team or through the Customer Success team.
+If you have an **Enterprise** or **Mission-Critical** Support, you can request this service by contacting the [Sales](https://www.azion.com/en/contact/) team or through the Customer Success team.
 
 For more detailed information, see [Azion Support](https://www.azion.com/en/professional-services/).

--- a/src/content/docs/en/pages/main-menu/reference/services/support/slack-channel.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/services/support/slack-channel.mdx
@@ -20,4 +20,4 @@ The **Slack Channel** service refers to support and assistance provided to assis
 This service doesn't support opening tickets directly, and there's no response time guarantee. Customers must have their own paid Slack account to use this service.
 :::
 
-If you have an **Enterprise** or **Mission-Critical** Support service, you can request this service by [contacting the Sales team](https://www.azion.com/en/contact-sales/). For more detailed information, [see the Azion Support page](https://www.azion.com/en/professional-services/).
+If you have an **Enterprise** or **Mission-Critical** Support service, you can request this service by [contacting the Sales team](https://www.azion.com/en/contact/). For more detailed information, [see the Azion Support page](https://www.azion.com/en/professional-services/).

--- a/src/content/docs/en/pages/observe-journey/data-stream/advanced-configurations/configure-sampling.mdx
+++ b/src/content/docs/en/pages/observe-journey/data-stream/advanced-configurations/configure-sampling.mdx
@@ -16,7 +16,7 @@ import JourneyAPI from '~/includes/snippets/JourneyAPI/en/snippet.mdx'
 When you [configure a stream](/en/documentation/products/guides/use-data-stream/) and choose to associate all of your domains, you can configure the **Sampling** option to filter the percentage of data you'll be streaming. It's a viable option to reduce the costs of data collection and analysis.
 
 :::caution[warning]
-To enable Sampling on your account, you must contact the [sales team](https://www.azion.com/en/contact-sales/) and request the feature.
+To enable Sampling on your account, you must contact the [sales team](https://www.azion.com/en/contact/) and request the feature.
 
 Once you enable the Sampling feature, you can only have one active stream. If you disable it, you'll be able to create more streams again.
 :::

--- a/src/content/docs/en/pages/secure-journey/firewall-advanced-configurations/monitor-and-calibrate-bot-manager.mdx
+++ b/src/content/docs/en/pages/secure-journey/firewall-advanced-configurations/monitor-and-calibrate-bot-manager.mdx
@@ -14,7 +14,7 @@ import Tag from 'primevue/tag'
 After deploying [Bot Manager](/en/documentation/products/secure/firewall/bot-manager/), the next step is to understand what the data tells you and adjust the configuration to match your application's traffic patterns. This guide walks you through reading logs, interpreting classifications, and calibrating thresholds and rules to reduce false positives while blocking real threats.
 
 :::note
-Bot Manager is a Firewall add-on. Contact the [Sales team](https://www.azion.com/en/contact-sales/) for subscription details. If you're using [Bot Manager Lite](/en/documentation/products/guides/bot-manager-lite/), the same observability tools apply, though some advanced configuration options differ.
+Bot Manager is a Firewall add-on. Contact the [Sales team](https://www.azion.com/en/contact/) for subscription details. If you're using [Bot Manager Lite](/en/documentation/products/guides/bot-manager-lite/), the same observability tools apply, though some advanced configuration options differ.
 :::
 
 ---

--- a/src/content/docs/en/pages/secure-journey/secure-infrastructure.mdx
+++ b/src/content/docs/en/pages/secure-journey/secure-infrastructure.mdx
@@ -30,7 +30,7 @@ To access the Origin Shield list, you must have:
 
 - The [Network Shield module](/en/documentation/products/guides/secure/firewall-configure-main-settings/#modules) enabled.
 - Be subscribed to the Origin Shield add-on.
-  - Contact the [sales team](https://www.azion.com/en/contact-sales/) to subscribe to this feature.
+  - Contact the [sales team](https://www.azion.com/en/contact/) to subscribe to this feature.
 
 ---
 

--- a/src/content/docs/pt-br/pages/menu-principal/referencia/build/edge-application/l2-caching.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/referencia/build/edge-application/l2-caching.mdx
@@ -21,7 +21,7 @@ Ao acessar sua application na Azion, o usuário acessa a edge network, onde o co
 - Selecionar a região para manter o cache mais próximo de seus usuários.
 
 :::note
-Tiered Cache só estará disponível se o serviço for ativado para a sua conta. Para ativar o **Tiered Cache**, [contate a equipe de Vendas](https://www.azion.com/en/contact-sales/).
+Tiered Cache só estará disponível se o serviço for ativado para a sua conta. Para ativar o **Tiered Cache**, [contate a equipe de Vendas](https://www.azion.com/pt-br/contato/).
 :::
 
 ## Implementação

--- a/src/content/docs/pt-br/pages/menu-principal/referencia/servicos/slack-channel.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/referencia/servicos/slack-channel.mdx
@@ -20,6 +20,6 @@ O serviço **Slack Channel** refere-se ao suporte e assistência fornecidos para
 Este serviço não suporta a abertura de tickets diretamente e não há garantia de tempo de resposta. Clientes devem ter sua própria conta paga do Slack para usar este serviço.
 :::
 
-Se você tiver o serviço de suporte **Enterprise** ou **Mission Critical**, é possível solicitar esse serviço [contatando o time de Vendas](https://www.azion.com/en/contact-sales/).
+Se você tiver o serviço de suporte **Enterprise** ou **Mission Critical**, é possível solicitar esse serviço [contatando o time de Vendas](https://www.azion.com/pt-br/contato/).
 
 Para obter informações mais detalhadas, consulte as opções de [Serviços de Suporte](https://www.azion.com/pt-br/servicos-profissionais/).

--- a/src/content/docs/pt-br/pages/secure-jornada/firewall-configuracoes-avancadas/monitorar-e-calibrar-bot-manager.mdx
+++ b/src/content/docs/pt-br/pages/secure-jornada/firewall-configuracoes-avancadas/monitorar-e-calibrar-bot-manager.mdx
@@ -14,7 +14,7 @@ import Tag from 'primevue/tag'
 Após implantar o [Bot Manager](/pt-br/documentacao/produtos/secure/firewall/bot-manager/), o próximo passo é entender o que os dados indicam e ajustar a configuração para corresponder aos padrões de tráfego da sua aplicação. Este guia mostra como ler logs, interpretar classificações e calibrar thresholds e regras para reduzir falsos positivos enquanto bloqueia ameaças reais.
 
 :::note
-O Bot Manager é um add-on do Firewall. Entre em contato com o [time de Vendas](https://www.azion.com/pt-br/contato-vendas/) para detalhes de assinatura. Se você estiver usando o [Bot Manager Lite](/pt-br/documentacao/produtos/guias/bot-manager-lite/), as mesmas ferramentas de observabilidade se aplicam, embora algumas opções avançadas de configuração sejam diferentes.
+O Bot Manager é um add-on do Firewall. Entre em contato com o [time de Vendas](https://www.azion.com/pt-br/contato/) para detalhes de assinatura. Se você estiver usando o [Bot Manager Lite](/pt-br/documentacao/produtos/guias/bot-manager-lite/), as mesmas ferramentas de observabilidade se aplicam, embora algumas opções avançadas de configuração sejam diferentes.
 :::
 
 ---

--- a/src/i18n/en/footer.ts
+++ b/src/i18n/en/footer.ts
@@ -62,7 +62,7 @@ const listData = [
       },
       {
         title: "Contact Sales",
-        link: "/en/contact-sales/"
+        link: "/en/contact/"
       },
       {
         title: "Professional Services",

--- a/src/i18n/en/header.ts
+++ b/src/i18n/en/header.ts
@@ -22,7 +22,7 @@ const menuSecondary = [
   {
     text: "Contact",
     title: "Contact Sales",
-    link: "/en/contact-sales/",
+    link: "/en/contact/",
     destak: false,
   },
   {
@@ -82,7 +82,7 @@ const bottomButtonsMobile = [
   },
   {
     label: 'Contact',
-    url: '/en/contact-sales/',
+    url: '/en/contact/',
     urlTitle: 'Contact Page',
     icon: 'pi pi-chevron-right text-xs'
   }

--- a/src/i18n/pt-br/footer.ts
+++ b/src/i18n/pt-br/footer.ts
@@ -64,7 +64,7 @@ const listData = [
       },
       {
         "title": "Contate Vendas",
-        "link": "/pt-br/contate-vendas/"
+        "link": "/pt-br/contato/"
       },
       {
         "title": "Serviços Profissionais",

--- a/src/i18n/pt-br/header.ts
+++ b/src/i18n/pt-br/header.ts
@@ -22,7 +22,7 @@ const menuSecondary = [
   {
     text: "Contato",
     title: "Contact Sales",
-    link: "/pt-br/contate-vendas/",
+    link: "/pt-br/contato/",
     destak: false,
   },
   {
@@ -82,7 +82,7 @@ const bottomButtonsMobile = [
   },
   {
     label: 'Contato',
-    url: '/pt-br/contate-vendas/',
+    url: '/pt-br/contato/',
     urlTitle: 'Contact Page',
     icon: 'pi pi-chevron-right text-xs'
   }

--- a/src/includes/docs_help_center/en/marketplace/solution/subscribe-for/index.md
+++ b/src/includes/docs_help_center/en/marketplace/solution/subscribe-for/index.md
@@ -7,4 +7,4 @@ At Marketplace, solutions can have two license models:
 - **Bring Your Own License (BYOL):** on this model, you can use your license from a partner, bringing this license to use at Azion's Platform.
 - **Free Model:** free of charge model. Everyone can use any solution under this model at no cost.
 
-> For other types of license, you can [contact the Azion Sales Team](https://www.azion.com/en/contact-sales).
+> For other types of license, you can [contact the Azion Sales Team](https://www.azion.com/en/contact/).


### PR DESCRIPTION
### Related issue:

No issue.

### Changes

- Update the shared English header and footer sales links to `/en/contact/`.
- Update the shared Portuguese header and footer sales links to `/pt-br/contato/`.
- Replace remaining hard-coded retired sales URLs in English and Portuguese documentation content, including Portuguese pages that previously linked to the English route.
- Keep historical redirect-report data unchanged.

The root cause was shared navigation configuration and older content that still referenced retired contact-sales routes. This change sends documentation visitors to the current locale-correct contact pages instead of 404 responses.

### Additional links

Validation completed:

- Production build: 1,494 pages built successfully.
- Frontmatter test: passed.
- Rendered-route scan: zero retired contact routes in source or generated HTML; the new English and Portuguese routes appear in 742 generated HTML files each.
- Independent diff review: no findings.

`npm run check` continues to report 141 pre-existing repository-wide type errors in unrelated files; none are in the changed URL lines.