### PR TITLE
feat(get-started): add Get started and First deploy pages

### DIFF
--- a/src/components/DocsCard.astro
+++ b/src/components/DocsCard.astro
@@ -1,0 +1,32 @@
+---
+/**
+ * Docs CTA card. Place inside a grid wrapper:
+ *   <div class="grid gap-3 my-6 grid-cols-[repeat(auto-fill,minmax(280px,1fr))]">
+ */
+interface Props {
+	link: string;
+	title: string;
+	icon?: string;
+	description?: string;
+	titleTag?: 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+}
+import CardBaseClickableSFC from 'azion-webkit/cardbaseclickable';
+import CardTitleSFC from 'azion-webkit/cardtitle';
+import CardDescriptionSFC from 'azion-webkit/carddescription';
+
+// azion-webkit's .d.ts files omit pass-through props (grid, hover, class, titleTag),
+// so the components are cast to keep `astro check` clean.
+const CardBaseClickable = CardBaseClickableSFC as any;
+const CardTitle = CardTitleSFC as any;
+const CardDescription = CardDescriptionSFC as any;
+
+const { link, title, icon, description, titleTag = 'h3' } = Astro.props;
+---
+
+<CardBaseClickable grid={true} hover="outlined" class="w-full" spacing="compact" link={link} title={title}>
+	<Fragment slot="content">
+		{icon && <i class={`${icon} text-xl`}></i>}
+		<CardTitle titleTag={titleTag} class="m-0 !text-lg">{title}</CardTitle>
+		{description && <CardDescription class="!text-sm line-clamp-3">{description}</CardDescription>}
+	</Fragment>
+</CardBaseClickable>

--- a/src/content/docs/en/pages/get-started/first-deploy/index.mdx
+++ b/src/content/docs/en/pages/get-started/first-deploy/index.mdx
@@ -1,0 +1,145 @@
+---
+title: 'First deploy in a few minutes'
+description: >-
+  Put an application live on the Azion Web Platform in a few minutes,
+  using a template, a GitHub repository, or the Azion CLI, and verify it
+  answers HTTP 200 on its own Azion domain.
+meta_tags: >-
+  Azion, first deploy, tutorial, quickstart, template, GitHub import, Azion
+  CLI, azion link, edge application, verification
+namespace: documentation_get_started_first_deploy
+permalink: /documentation/get-started/first-deploy/
+---
+
+import DocsCard from '~/components/DocsCard.astro';
+
+
+By the end of this tutorial, an application will be live on the Azion Web Platform, answering HTTP 200 on its own Azion domain. It takes a few minutes.
+
+Three complete paths get you there. Pick one. They all end in the same place:
+
+<div class="grid gap-3 my-6 grid-cols-[repeat(auto-fill,minmax(280px,1fr))]">
+    <DocsCard link="#deploy-a-template-via-console" title="Deploy a template via Console" icon="pi pi-th-large" description="You're starting from scratch and want a ready-made project." />
+    <DocsCard link="#import-a-project-from-github" title="Import a project from GitHub" icon="pi pi-github" description="Your project already lives in a GitHub repository." />
+    <DocsCard link="#deploy-with-azion-cli" title="Deploy with Azion CLI" icon="pi pi-wrench" description="Your project is on your machine and you prefer the terminal." />
+</div>
+
+Not sure which one? Take the template path: it needs no local tooling.
+
+## Before you start
+
+All you need is an Azion account. You can [create one for free](https://console.azion.com/signup/), and it doesn't ask for a credit card. Anything path-specific is listed in the path itself.
+
+---
+
+## Deploy a template via Console
+
+Templates are ready-made projects (e-commerce, blogs, APIs, full-stack SSR) that go live in a few clicks. You don't need any local tooling.
+
+:::note
+Some templates are integrated with third-party services, so you may need to create accounts, generate tokens, or activate Azion products before deploying. Templates integrated with GitHub ask you to connect your account: click **Connect with GitHub** when prompted and confirm the connection in the pop-up. Each [template's guide](/en/documentation/products/guides/#azion-templates) lists its specific prerequisites.
+:::
+
+1. [Access Azion Console](https://console.azion.com).
+2. Click **+ Create** on the homepage.
+3. In the modal, select **Templates**.
+4. Browse and pick the one you want to start with.
+5. Fill in the configuration page.
+6. Click **Deploy**, in the bottom-right corner.
+
+Follow the deploy through the logs window. When it finishes, the page shows your application's name, its deploy logs, and its **Azion domain**. Some templates also create a function and apply pre-defined configurations to optimize your application's performance. The template's guide lists what's included.
+
+### Test it
+
+Copy the Azion domain from the confirmation page:
+
+```bash
+curl -I https://<your-azion-domain>
+# HTTP/2 200
+```
+
+Open the same URL in the browser to see your application running.
+
+:::note
+New URLs can take a few minutes to propagate to Azion's edge locations. If you get an error right after deploying, wait a moment and try again.
+:::
+
+---
+
+## Import a project from GitHub
+
+**Before you start:** you need a GitHub account and a repository using one of the [supported frameworks](/en/documentation/products/devtools/azion-edge-runtime/frameworks-compatibility/).
+
+1. In [Azion Console](https://console.azion.com), click **+ Create**.
+2. Select **Import from GitHub**.
+3. Connect your GitHub account.
+4. Select your repository.
+5. Choose a name for the application and a **Framework Preset**.
+6. Enter the install command (usually `npm install`).
+7. Confirm and follow the logs until the **Azion domain** shows up.
+
+### Test it
+
+```bash
+curl -I https://<your-azion-domain>
+# HTTP/2 200
+```
+
+Open the Azion domain in the browser to see your application running. If you get an error right away, wait a few minutes: new URLs take a moment to propagate to Azion's edge locations.
+
+---
+
+## Deploy with Azion CLI
+
+**Before you start:** you need the Azion CLI (installed below) and a local project using one of the [supported frameworks](/en/documentation/products/devtools/azion-edge-runtime/frameworks-compatibility/), with its dependencies installed.
+
+:::tip
+Starting from scratch instead? Run `azion init` to create a new project from a framework template, then deploy it the same way. See the [CLI overview](/en/documentation/products/azion-cli/overview/) and the [link command reference](/en/documentation/products/cli/link-command/) for details.
+:::
+
+### Install the Azion CLI
+
+```bash
+curl -fsSL https://cli.azion.app/install.sh | bash
+```
+
+### Link and deploy
+
+Authenticate:
+
+```bash
+azion login
+```
+
+In the project's root folder, link it to Azion:
+
+```bash
+azion link
+```
+
+The CLI guides you from there: confirm the linking, accept or change the suggested application name, and pick a **preset** matching your framework. When it asks `Do you want to deploy your project?`, answer **yes**. (If you answer no, run `azion deploy` when you're ready.)
+
+At the end of the deploy, the CLI prints your application's **Azion domain**.
+
+### Test it
+
+```bash
+curl -I https://<your-azion-domain>
+# HTTP/2 200
+```
+
+If you get an error right away, wait a few minutes: new URLs take a moment to propagate to Azion's edge locations.
+
+---
+
+## What you built
+
+You deployed an application to Azion's global network and confirmed it answers on its own domain. The workflow is the same one you'll use for production projects.
+
+## Next steps
+
+<div class="grid gap-3 my-6 grid-cols-[repeat(auto-fill,minmax(280px,1fr))]">
+    <DocsCard link="/en/documentation/products/go-live-with-azion/" title="Go live with Azion" icon="ai ai-azion" description="Add a custom domain and point your traffic to the application you just deployed." />
+    <DocsCard link="/en/documentation/products/secure/overview/" title="Secure your application" icon="ai ai-secure-pillar" description="Enable Firewall and WAF protection." />
+    <DocsCard link="/en/documentation/products/observe/overview/" title="Observe your application" icon="ai ai-observe-pillar" description="Follow metrics and events in real time." />
+</div>

--- a/src/content/docs/en/pages/get-started/index.mdx
+++ b/src/content/docs/en/pages/get-started/index.mdx
@@ -1,0 +1,71 @@
+---
+title: Get started with Azion
+description: >-
+  Start here: deploy your first application on Azion in minutes using a
+  template, a GitHub repository, or the Azion CLI, and find the right path
+  for your goal.
+meta_tags: >-
+  Azion, get started, first deploy, quickstart, template, GitHub, CLI,
+  onboarding, edge computing
+namespace: documentation_get_started
+permalink: /documentation/get-started/
+---
+
+import LinkButton from 'azion-webkit/linkbutton';
+import DocsCard from '~/components/DocsCard.astro';
+
+**Azion Web Platform** lets you build, secure, and observe applications running on a global network. The fastest way to understand what that means is to put something live: the first deploy takes a few minutes and doesn't require a credit card.
+
+## Deploy your first application
+
+Three doors, same destination: an application answering on its own Azion domain. Pick the one that matches how you work.
+
+<div class="grid gap-3 my-6 grid-cols-[repeat(auto-fill,minmax(280px,1fr))]">
+    <DocsCard link="/en/documentation/get-started/first-deploy/#deploy-a-template-via-console" title="Deploy a template via Console" icon="pi pi-th-large" description="One-click start from ready-made projects: e-commerce, blogs, APIs, full-stack SSR." />
+    <DocsCard link="/en/documentation/get-started/first-deploy/#import-a-project-from-github" title="Import a project from GitHub" icon="pi pi-github" description="Connect your repository and deploy an existing project." />
+    <DocsCard link="/en/documentation/get-started/first-deploy/#deploy-with-azion-cli" title="Deploy with Azion CLI" icon="pi pi-wrench" description="Link a local project from your terminal with azion link." />
+</div>
+
+<LinkButton link="/en/documentation/get-started/first-deploy/" label="First deploy in a few minutes" />
+
+## Find your path
+
+<div class="grid gap-3 my-6 grid-cols-[repeat(auto-fill,minmax(280px,1fr))]">
+    <DocsCard link="/en/documentation/get-started/first-deploy/" title="I'm evaluating Azion" icon="pi pi-bolt" description="See what you can build and how much effort the first success takes." />
+    <DocsCard link="/en/documentation/products/guides/" title="I need to implement something specific" icon="pi pi-code" description="Browse how-to guides by product and by capability." />
+    <DocsCard link="/en/documentation/products/pricing/" title="I need to know what is included" icon="pi pi-chart-line" description="Check what's included in each plan and how real-world architectures look on Azion." />
+</div>
+
+Also useful: [Accounts and billing](/en/documentation/products/accounts/) · [Architectures](/en/documentation/architectures/)
+
+## Build with your framework
+
+Ready-made build paths for the stack you already use.
+
+<div class="grid gap-3 my-6 grid-cols-[repeat(auto-fill,minmax(280px,1fr))]">
+    <DocsCard link="/en/documentation/products/build/develop-with-azion/frameworks-specific/overview/" title="Frameworks overview" icon="pi pi-th-large" description="See every framework and build path supported on Azion." />
+    <DocsCard link="/en/documentation/products/cli/frameworks/angular/" title="Angular" icon="ai ai-angular" description="Enterprise-grade web apps with TypeScript and robust tooling." />
+    <DocsCard link="/en/documentation/products/cli/frameworks/astro/" title="Astro" icon="ai ai-astro" description="Content-focused sites with minimal client-side JavaScript." />
+    <DocsCard link="/en/documentation/products/cli/frameworks/docusaurus/" title="Docusaurus" icon="ai ai-docusaurus" description="Documentation sites with React and built-in versioning." />
+    <DocsCard link="/en/documentation/products/cli/frameworks/eleventy/" title="Eleventy" icon="ai ai-eleventy" description="Simple, fast static sites from plain templates." />
+    <DocsCard link="/en/documentation/products/cli/frameworks/gatsby/" title="Gatsby" icon="ai ai-gatsby" description="SEO-friendly React sites that pull content from any source." />
+    <DocsCard link="/en/documentation/products/cli/frameworks/hexo/" title="Hexo" icon="ai ai-hexo" description="Fast blogs generated from Markdown." />
+    <DocsCard link="/en/documentation/products/cli/frameworks/hono/" title="Hono" icon="ai ai-hono" description="Ultrafast web framework built for edge runtimes." />
+    <DocsCard link="/en/documentation/products/cli/frameworks/hugo/" title="Hugo" icon="ai ai-hugo" description="Static sites built in milliseconds with Go templates." />
+    <DocsCard link="/en/documentation/products/cli/frameworks/jekyll/" title="Jekyll" icon="ai ai-jekyll" description="Blog-aware static sites from Markdown, Ruby-based." />
+    <DocsCard link="/en/documentation/products/cli/frameworks/next/" title="Next.js" icon="ai ai-next" description="React with SSR, static generation, and powerful routing." />
+    <DocsCard link="/en/documentation/products/cli/frameworks/nextal/" title="Nextal" icon="pi pi-code" description="Lightweight starter for fast static pages." />
+    <DocsCard link="/en/documentation/products/cli/frameworks/react/" title="React" icon="ai ai-react" description="Interactive UIs with reusable components." />
+    <DocsCard link="/en/documentation/products/cli/frameworks/svelte/" title="Svelte" icon="pi pi-code" description="Compiled components, no virtual DOM, tiny bundles." />
+    <DocsCard link="/en/documentation/products/cli/frameworks/vite/" title="VitePress" icon="ai ai-vitepress" description="Vite-powered docs and static sites from Markdown." />
+    <DocsCard link="/en/documentation/products/cli/frameworks/vue/" title="Vue" icon="ai ai-vue" description="Progressive framework for approachable, flexible UIs." />
+    <DocsCard link="/en/documentation/products/build/develop-with-azion/language-specific/wasm/" title="WebAssembly" icon="pi pi-code" description="Run near-native code at the edge from any language." />
+</div>
+
+## After the first deploy
+
+<div class="grid gap-3 my-6 grid-cols-[repeat(auto-fill,minmax(280px,1fr))]">
+    <DocsCard link="/en/documentation/products/go-live-with-azion/" title="Go live with Azion" icon="ai ai-azion" description="Point a custom domain to your application." />
+    <DocsCard link="/en/documentation/products/secure/overview/" title="Secure your application" icon="ai ai-secure-pillar" description="Protect it with Firewall and WAF." />
+    <DocsCard link="/en/documentation/products/observe/overview/" title="Observe your application" icon="ai ai-observe-pillar" description="Monitor metrics and events in real time." />
+</div>

--- a/src/content/docs/pt-br/pages/get-started/first-deploy/index.mdx
+++ b/src/content/docs/pt-br/pages/get-started/first-deploy/index.mdx
@@ -1,0 +1,145 @@
+---
+title: 'Primeiro deploy em poucos minutos'
+description: >-
+  Coloque uma aplicação no ar na Azion Web Platform em poucos minutos,
+  usando um template, um repositório do GitHub ou a Azion CLI, e verifique
+  que ela responde HTTP 200 no seu próprio domínio Azion.
+meta_tags: >-
+  Azion, primeiro deploy, tutorial, quickstart, template, importar do
+  GitHub, Azion CLI, azion link, aplicação, verificação
+namespace: documentation_get_started_first_deploy
+permalink: /documentacao/get-started/first-deploy/
+---
+
+import DocsCard from '~/components/DocsCard.astro';
+
+
+Ao final deste tutorial, uma aplicação estará no ar na Azion Web Platform, respondendo HTTP 200 no seu próprio domínio Azion. Leva poucos minutos.
+
+Três caminhos completos levam você até lá. Escolha um. Todos terminam no mesmo lugar:
+
+<div class="grid gap-3 my-6 grid-cols-[repeat(auto-fill,minmax(280px,1fr))]">
+    <DocsCard link="#faça-deploy-de-um-template-via-console" title="Faça deploy de um template via Console" icon="pi pi-th-large" description="Você está começando do zero e quer um projeto pronto." />
+    <DocsCard link="#importe-um-projeto-do-github" title="Importe um projeto do GitHub" icon="pi pi-github" description="Seu projeto já vive em um repositório do GitHub." />
+    <DocsCard link="#faça-deploy-com-a-azion-cli" title="Faça deploy com a Azion CLI" icon="pi pi-wrench" description="Seu projeto está na sua máquina e você prefere o terminal." />
+</div>
+
+Na dúvida, vá pelo caminho do template: ele não precisa de nenhuma ferramenta local.
+
+## Antes de começar
+
+Você só precisa de uma conta Azion. Você pode [criar uma gratuitamente](https://console.azion.com/signup/), e ela não pede cartão de crédito. O que for específico de cada caminho está listado no próprio caminho.
+
+---
+
+## Faça deploy de um template via Console
+
+Templates são projetos prontos (e-commerce, blogs, APIs, SSR full-stack) que entram no ar em poucos cliques. Você não precisa de nenhuma ferramenta local.
+
+:::note
+Alguns templates são integrados a serviços de terceiros, então pode ser necessário criar contas, gerar tokens ou ativar produtos da Azion antes do deploy. Templates integrados ao GitHub pedem para conectar a sua conta: clique em **Connect with GitHub** quando solicitado e confirme a conexão no pop-up. O [guia de cada template](/pt-br/documentacao/produtos/guias/#azion-templates) lista os pré-requisitos específicos.
+:::
+
+1. [Acesse o Azion Console](https://console.azion.com).
+2. Clique em **+ Create** na página inicial.
+3. No modal, selecione **Templates**.
+4. Navegue e escolha o template com que deseja começar.
+5. Preencha a página de configuração.
+6. Clique em **Deploy**, no canto inferior direito.
+
+Acompanhe o deploy pela janela de logs. Ao concluir, a página mostra o nome da aplicação, os logs de deploy e o **domínio Azion**. Alguns templates também criam uma function e aplicam configurações predefinidas para otimizar a performance da sua aplicação. O guia do template lista o que está incluído.
+
+### Teste
+
+Copie o domínio Azion da página de confirmação:
+
+```bash
+curl -I https://<seu-dominio-azion>
+# HTTP/2 200
+```
+
+Abra a mesma URL no navegador para ver a aplicação rodando.
+
+:::note
+URLs novas podem levar alguns minutos para propagar para as edge locations da Azion. Se aparecer um erro logo após o deploy, aguarde um momento e tente de novo.
+:::
+
+---
+
+## Importe um projeto do GitHub
+
+**Antes de começar:** você precisa de uma conta no GitHub e de um repositório usando um dos [frameworks compatíveis](/pt-br/documentacao/produtos/devtools/azion-edge-runtime/compatibilidade-frameworks/).
+
+1. No [Azion Console](https://console.azion.com), clique em **+ Create**.
+2. Selecione **Import from GitHub**.
+3. Conecte sua conta do GitHub.
+4. Selecione seu repositório.
+5. Escolha um nome para a aplicação e um **Framework Preset**.
+6. Insira o comando de instalação (normalmente `npm install`).
+7. Confirme e acompanhe os logs até o **domínio Azion** aparecer.
+
+### Teste
+
+```bash
+curl -I https://<seu-dominio-azion>
+# HTTP/2 200
+```
+
+Abra o domínio Azion no navegador para ver a aplicação rodando. Se aparecer um erro logo de cara, aguarde alguns minutos: URLs novas levam um tempo para propagar para as edge locations da Azion.
+
+---
+
+## Faça deploy com a Azion CLI
+
+**Antes de começar:** você precisa da Azion CLI (instalada abaixo) e de um projeto local usando um dos [frameworks compatíveis](/pt-br/documentacao/produtos/devtools/azion-edge-runtime/compatibilidade-frameworks/), com as dependências instaladas.
+
+:::tip
+Começando do zero? Rode `azion init` para criar um projeto novo a partir de um template de framework e faça o deploy da mesma forma. Veja a [visão geral da CLI](/pt-br/documentacao/produtos/azion-cli/visao-geral/) e a [referência do comando link](/pt-br/documentacao/produtos/azion-cli/link-comando/) para mais detalhes.
+:::
+
+### Instale a Azion CLI
+
+```bash
+curl -fsSL https://cli.azion.app/install.sh | bash
+```
+
+### Vincule e faça o deploy
+
+Autentique-se:
+
+```bash
+azion login
+```
+
+Na pasta raiz do projeto, vincule-o à Azion:
+
+```bash
+azion link
+```
+
+A CLI guia você a partir daí: confirme o vínculo, aceite ou altere o nome sugerido para a aplicação e escolha um **preset** compatível com o seu framework. Quando perguntar `Do you want to deploy your project?`, responda **yes**. (Se responder no, rode `azion deploy` quando estiver pronto.)
+
+Ao final do deploy, a CLI imprime o **domínio Azion** da sua aplicação.
+
+### Teste
+
+```bash
+curl -I https://<seu-dominio-azion>
+# HTTP/2 200
+```
+
+Se aparecer um erro logo de cara, aguarde alguns minutos: URLs novas levam um tempo para propagar para as edge locations da Azion.
+
+---
+
+## O que você construiu
+
+Você fez o deploy de uma aplicação na rede global da Azion e confirmou que ela responde no seu próprio domínio. O fluxo é o mesmo que você vai usar em projetos de produção.
+
+## Próximos passos
+
+<div class="grid gap-3 my-6 grid-cols-[repeat(auto-fill,minmax(280px,1fr))]">
+    <DocsCard link="/pt-br/documentacao/produtos/ative-em-producao/" title="Ative em produção" icon="ai ai-azion" description="Adicione um domínio próprio e aponte o tráfego para a aplicação que você acabou de publicar." />
+    <DocsCard link="/pt-br/documentacao/produtos/secure/visao-geral/" title="Proteja a sua aplicação" icon="ai ai-secure-pillar" description="Ative a proteção do Firewall e do WAF." />
+    <DocsCard link="/pt-br/documentacao/produtos/observe/visao-geral/" title="Observe a sua aplicação" icon="ai ai-observe-pillar" description="Acompanhe métricas e eventos em tempo real." />
+</div>

--- a/src/content/docs/pt-br/pages/get-started/index.mdx
+++ b/src/content/docs/pt-br/pages/get-started/index.mdx
@@ -1,0 +1,71 @@
+---
+title: Comece com a Azion
+description: >-
+  Comece aqui: faça o deploy da sua primeira aplicação na Azion em minutos
+  usando um template, um repositório do GitHub ou a Azion CLI, e encontre o
+  caminho certo para o seu objetivo.
+meta_tags: >-
+  Azion, comece agora, primeiro deploy, quickstart, template, GitHub, CLI,
+  onboarding, edge computing
+namespace: documentation_get_started
+permalink: /documentacao/get-started/
+---
+
+import LinkButton from 'azion-webkit/linkbutton';
+import DocsCard from '~/components/DocsCard.astro';
+
+A **Azion Web Platform** permite construir, proteger e observar aplicações rodando em uma rede global. A forma mais rápida de entender o que isso significa é colocar algo no ar: o primeiro deploy leva poucos minutos e não exige cartão de crédito.
+
+## Faça o deploy da sua primeira aplicação
+
+Três portas, o mesmo destino: uma aplicação respondendo no seu próprio domínio Azion. Escolha a que combina com o seu jeito de trabalhar.
+
+<div class="grid gap-3 my-6 grid-cols-[repeat(auto-fill,minmax(280px,1fr))]">
+    <DocsCard link="/pt-br/documentacao/get-started/first-deploy/#faça-deploy-de-um-template-via-console" title="Faça deploy de um template via Console" icon="pi pi-th-large" description="Comece em um clique a partir de projetos prontos: e-commerce, blogs, APIs, SSR full-stack." />
+    <DocsCard link="/pt-br/documentacao/get-started/first-deploy/#importe-um-projeto-do-github" title="Importe um projeto do GitHub" icon="pi pi-github" description="Conecte seu repositório e faça o deploy de um projeto existente." />
+    <DocsCard link="/pt-br/documentacao/get-started/first-deploy/#faça-deploy-com-a-azion-cli" title="Faça deploy com a Azion CLI" icon="pi pi-wrench" description="Vincule um projeto local pelo terminal com azion link." />
+</div>
+
+<LinkButton link="/pt-br/documentacao/get-started/first-deploy/" label="Primeiro deploy em poucos minutos" />
+
+## Encontre o seu caminho
+
+<div class="grid gap-3 my-6 grid-cols-[repeat(auto-fill,minmax(280px,1fr))]">
+    <DocsCard link="/pt-br/documentacao/get-started/first-deploy/" title="Estou avaliando a Azion" icon="pi pi-bolt" description="Veja o que dá para construir e quanto esforço leva até o primeiro sucesso." />
+    <DocsCard link="/pt-br/documentacao/produtos/guias/" title="Preciso implementar algo específico" icon="pi pi-code" description="Navegue pelos guias práticos por produto e por capacidade." />
+    <DocsCard link="/pt-br/documentacao/produtos/precos/" title="Preciso saber o que está incluído" icon="pi pi-chart-line" description="Confira o que está incluído em cada plano e como arquiteturas reais ficam na Azion." />
+</div>
+
+Também úteis: [Contas e faturamento](/pt-br/documentacao/produtos/gestao-de-contas/) · [Arquiteturas](/pt-br/documentacao/arquiteturas/)
+
+## Construa com seu framework
+
+Caminhos de build prontos para a stack que você já usa.
+
+<div class="grid gap-3 my-6 grid-cols-[repeat(auto-fill,minmax(280px,1fr))]">
+    <DocsCard link="/pt-br/documentacao/produtos/build/develop-with-azion/frameworks-specific/visao-geral/" title="Visão geral de frameworks" icon="pi pi-th-large" description="Veja todos os frameworks e caminhos de build suportados na Azion." />
+    <DocsCard link="/pt-br/documentacao/produtos/cli/frameworks/angular/" title="Angular" icon="ai ai-angular" description="Aplicações corporativas com TypeScript e ferramentas robustas." />
+    <DocsCard link="/pt-br/documentacao/produtos/cli/frameworks/astro/" title="Astro" icon="ai ai-astro" description="Sites focados em conteúdo com o mínimo de JavaScript no cliente." />
+    <DocsCard link="/pt-br/documentacao/produtos/cli/frameworks/docusaurus/" title="Docusaurus" icon="ai ai-docusaurus" description="Sites de documentação com React e versionamento nativo." />
+    <DocsCard link="/pt-br/documentacao/produtos/cli/frameworks/eleventy/" title="Eleventy" icon="ai ai-eleventy" description="Sites estáticos simples e rápidos a partir de templates." />
+    <DocsCard link="/pt-br/documentacao/produtos/cli/frameworks/gatsby/" title="Gatsby" icon="ai ai-gatsby" description="Sites React amigáveis a SEO com conteúdo de qualquer fonte." />
+    <DocsCard link="/pt-br/documentacao/produtos/cli/frameworks/hexo/" title="Hexo" icon="ai ai-hexo" description="Blogs rápidos gerados a partir de Markdown." />
+    <DocsCard link="/pt-br/documentacao/produtos/cli/frameworks/hono/" title="Hono" icon="ai ai-hono" description="Framework web ultrarrápido feito para runtimes de edge." />
+    <DocsCard link="/pt-br/documentacao/produtos/cli/frameworks/hugo/" title="Hugo" icon="ai ai-hugo" description="Sites estáticos gerados em milissegundos com templates Go." />
+    <DocsCard link="/pt-br/documentacao/produtos/cli/frameworks/jekyll/" title="Jekyll" icon="ai ai-jekyll" description="Sites estáticos com Markdown, baseado em Ruby." />
+    <DocsCard link="/pt-br/documentacao/produtos/cli/frameworks/next/" title="Next.js" icon="ai ai-next" description="React com SSR, geração estática e roteamento avançado." />
+    <DocsCard link="/pt-br/documentacao/produtos/cli/frameworks/nextal/" title="Nextal" icon="pi pi-code" description="Starter leve para páginas estáticas rápidas." />
+    <DocsCard link="/pt-br/documentacao/produtos/cli/frameworks/react/" title="React" icon="ai ai-react" description="Interfaces interativas com componentes reutilizáveis." />
+    <DocsCard link="/pt-br/documentacao/produtos/cli/frameworks/svelte/" title="Svelte" icon="pi pi-code" description="Componentes compilados, sem virtual DOM, bundles mínimos." />
+    <DocsCard link="/pt-br/documentacao/produtos/cli/frameworks/vite/" title="VitePress" icon="ai ai-vitepress" description="Docs e sites estáticos com Vite e Markdown." />
+    <DocsCard link="/pt-br/documentacao/produtos/cli/frameworks/vue/" title="Vue" icon="ai ai-vue" description="Framework progressivo para interfaces simples e flexíveis." />
+    <DocsCard link="/pt-br/documentacao/produtos/build/desenvolvimento-azion/linguagens/wasm/" title="WebAssembly" icon="pi pi-code" description="Código quase nativo no edge, a partir de várias linguagens." />
+</div>
+
+## Depois do primeiro deploy
+
+<div class="grid gap-3 my-6 grid-cols-[repeat(auto-fill,minmax(280px,1fr))]">
+    <DocsCard link="/pt-br/documentacao/produtos/ative-em-producao/" title="Ative em produção" icon="ai ai-azion" description="Aponte um domínio próprio para a sua aplicação." />
+    <DocsCard link="/pt-br/documentacao/produtos/secure/visao-geral/" title="Proteja a sua aplicação" icon="ai ai-secure-pillar" description="Proteja com Firewall e WAF." />
+    <DocsCard link="/pt-br/documentacao/produtos/observe/visao-geral/" title="Observe a sua aplicação" icon="ai ai-observe-pillar" description="Monitore métricas e eventos em tempo real." />
+</div>


### PR DESCRIPTION
## What & why

Adds a new **Get started** section — a landing page plus a **First deploy** tutorial (EN/PT) — giving the docs a single entry point that takes a visitor from zero to a deployed application in a few minutes. Foundation PR: the docs-home redesign and the new sidebar both link to these pages.

**Related issue:** NO-ISSUE
**Pages affected:**
- `/documentation/get-started/` (new)
- `/documentation/get-started/first-deploy/` (new)
- `/documentacao/get-started/` (new)
- `/documentacao/get-started/first-deploy/` (new)
- `src/components/DocsCard.astro` (new — card component these pages use)

## Type of change

- [x] 🆕 New content (`feat`) — built from a content template
- [ ] 🩹 Fix (`fix`) — typo, broken link, wrong information
- [ ] ♻️ Content update (`docs`) — rewrite, expansion, upkeep
- [ ] 🌐 Translation sync (`i18n`)
- [ ] 🏗️ Platform / structure (`refactor` / `chore`) — UXE review, no content mixed in

## Author checklist

- [x] PR title follows `type(scope): summary` (GOVERNANCE §4)
- [x] Frontmatter complete: `title`, `description`, `meta_tags`, `namespace`, `permalink` (`last_reviewed` is not part of this repo's schema)
- [x] Style guide followed — no legacy "edge-" product names
- [x] How-to/tutorial includes ≥1 runnable, copy-paste-tested code block (curl verification + Azion CLI install/link/deploy)
- [x] Screenshots (if any) have alt text — n/a, no in-content screenshots
- [x] Internal links are relative and resolve locally (`lint:linkcheck`: zero issues)
- [x] **Permalink changed or page moved → redirect included in this PR** — n/a, net-new pages only
- [x] **i18n:** `pt-br` updated here — all four files mirrored
- [x] `npm run build:local` passes (build + frontmatter) — ran as `astro build` + `npm run test:frontmatter` to avoid the `src/consts.ts` swap `build:local` performs

## Reviewer checklist

- [ ] Technically accurate (SME, if technical claims changed)
- [ ] Right place in the IA; discoverable from the relevant journey
- [ ] Reads at the level of surrounding docs (editorial)

## Notes for reviewers

- All internal links point at existing production pages; `lint:linkcheck` passes with zero broken links.
- `DocsCard.astro` is a hard build dependency of these pages, ported together with them. Its `azion-webkit` card imports are cast to keep `astro check` clean (the webkit `.d.ts` files omit pass-through props).
- `astro check`/`tsc` fail on `main` today (141/78 pre-existing errors in `src/i18n/*` and a test file). This PR adds **zero** new errors — verified against a pristine-main baseline.
- These pages have no `menu_namespace`, so they render on the existing default sidebar; the redesigned sidebar arrives in a follow-up PR.

First Deploy Screen:

<img width="1568" height="722" alt="pr1a-first-deploy" src="https://github.com/user-attachments/assets/e363aac5-d08f-4084-98de-8c74646b321e" />

Get Started Screen:

<img width="1568" height="722" alt="pr1a-get-started-landing" src="https://github.com/user-attachments/assets/71cc9374-894c-4101-959f-9f4c71708768" />

