### PR TITLE
feat(home): persona-driven docs home + pillar overview cards

### DIFF
--- a/src/components/PageContent/PageContent.astro
+++ b/src/components/PageContent/PageContent.astro
@@ -17,7 +17,7 @@ import { getPageBreadcrumb } from '~/util/getBreadcrumb';
 
 
 export interface Props {
-	content: { title: string };
+	content: { title: string; hide_title?: boolean };
 	fileToGetContributors: string;
 	previous?: { text: string; link: string };
 	next?: { text: string; link: string };
@@ -58,7 +58,9 @@ const t = useTranslations(Astro);
 						<AskAISplitButton lang={lang} client:load />
 					  </div>
 				</div>
-				<h1 id="overview" set:html={title} />
+				{/* the h1 sits outside the .prose article, so Tailwind's preflight reset
+				    (font-size:inherit) applies — size it explicitly to match prose-lg h1 */}
+				{!content.hide_title && <h1 id="overview" class="text-4xl font-medium mb-8" set:html={title} />}
 			</header>
 			<ReadableContent>
 				{

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -8,6 +8,7 @@ export const baseSchema = z.object({
 	permalink: z.string().optional(),
 	namespace: z.string().optional(),
 	menu_namespace: z.string().optional().default('nav'),
+	hide_title: z.boolean().optional(),
 	meta_tags: z.string().optional(),
 	og_image: z.string().optional(),
 	i18nReady: z.boolean().default(false),

--- a/src/content/docs/en/homes/dev-tools.mdx
+++ b/src/content/docs/en/homes/dev-tools.mdx
@@ -46,7 +46,7 @@ product_cards:
       - icon: /assets/docs/images/uploads/vector.svg
         title: SDK
         description: Develop applications using the Azion SDK for the Go language.
-        link: /en/documentation/devtools/sdk/go/
+        link: /en/documentation/products/azion-lib/overview/
       - icon: /assets/docs/images/uploads/vector.svg
         title: Terraform
         description: Manage your infrastructure as code with the Azion Terraform Provider.

--- a/src/content/docs/en/homes/home-docs.mdx
+++ b/src/content/docs/en/homes/home-docs.mdx
@@ -1,262 +1,160 @@
 ---
 meta_tag_robots_no_index: false
+hide_title: true
 title: 'Documentation Home'
 description: >-
-  Azion is the full-stack edge computing platform that simplifies how you build, secure, and scale modern applications.
+  Explore the Azion Web Platform documentation: everything you need to build, secure, deliver, and observe modern applications, from first deploy to production scale.
 meta_tags: 'documentation, azion'
 namespace: documentation_home
 permalink: /documentation/
 ---
 
-import LinkButton from 'azion-webkit/linkbutton';
 import HeroHome from 'azion-webkit/herohome';
 import Container from 'azion-webkit/container';
+import LinkButton from 'azion-webkit/linkbutton';
+import DocsCard from '~/components/DocsCard.astro';
 
 <div class="[&_.flex.flex-col]:!gap-4 [&_.flex.flex-col]:md:!gap-8 [&_.flex.flex-col]:2xl:!gap-16">
   <HeroHome
     title="Welcome to <span style='color:#F3652B!important'>Azion Docs</span>"
     description="We make every application fast and reliable. Deploy your projects instantly on the most reliable global network, leverage enterprise-grade security, and scale from zero to peak without cold starts."
     logos={[]}
-    buttons={[
-      { label: "Create an account", link: "https://console.azion.com/signup/", outlined: false },
-      { label: "Platform overview", link: "/en/documentation/products/azion-platform-overview/", severity: "secondary" }
-    ]}
+    bottomSpacing="mb-8"
   />
+  <div class="flex flex-wrap gap-4 justify-center mb-16">
+    <LinkButton link="/en/documentation/get-started/first-deploy/" label="First deploy in a few minutes" />
+    <LinkButton link="https://console.azion.com/signup/" label="Create an account" outlined />
+    <LinkButton link="/en/documentation/products/azion-platform-overview/" label="Platform overview" outlined />
+  </div>
 </div>
 
-## Start Here: Kick Off Your Project with Ready-to-Use Templates
+## Start here, by profile
+
+<div class="grid gap-3 my-6 grid-cols-[repeat(auto-fill,minmax(280px,1fr))]">
+  <div id="persona-avaliador">
+      <DocsCard link="/en/documentation/get-started/first-deploy/" title="I'm evaluating Azion" icon="pi pi-bolt" description="See what you can build in a few minutes: deploy a real application and verify it's live, no sales call required." />
+  </div>
+  <div id="persona-implementador">
+      <DocsCard link="/en/documentation/products/guides/" title="I need to implement something specific" icon="pi pi-code" description="Find the feature by the term you already use—signed URLs, reports, live streaming—and follow a step-by-step guide to production." />
+  </div>
+  <div id="persona-decisor">
+      <DocsCard link="/en/documentation/products/pricing/" title="I need to know what's included" icon="pi pi-chart-line" description="Per-plan limits, pricing, and what each product covers—inside the documentation—plus reference architectures for your target scenario." />
+  </div>
+  <div id="persona-guardiao">
+      <DocsCard link="/en/documentation/products/secure/overview/" title="I'm responsible for security" icon="ai ai-secure-pillar" description="Configure WAF, DDoS protection, bot management, and firewall rules—then tune them against real traffic and send the events to your SIEM." />
+  </div>
+  <div id="persona-ciso">
+      <DocsCard link="/en/documentation/shared-responsibility/" title="I'm accountable for risk and compliance" icon="pi pi-verified" description="See what Azion covers and what stays yours, review the PCI DSS and SOC certifications, and find the evidence an audit asks for." />
+  </div>
+</div>
+
+Also useful: [billing and account management](/en/documentation/products/accounts/) · [reference architectures](/en/documentation/architectures/)
+
+## One-click deploy with ready-to-use templates
 
 The fastest way to start using the Azion Web Platform. Deploy instantly from dozens of templates, including e-commerce, blogs, APIs, full-stack SSR, and more; leverage integrations by connecting to Sanity, Cosmic, ButterCMS, Turso, or bringing your own RESTful CMS or database. CI/CD is auto-configured so you can focus on your code, not the pipeline.
 
-Here are a few of our most popular templates to get you started. For more information, you can visit our documentation page on [using templates](/en/documentation/products/use-a-template-via-azion-console/).
+Here are a few of our most popular templates to get you started. For more information, you can visit our documentation page on [using templates](/en/documentation/get-started/first-deploy/).
 
-### <i class='ai ai-astro'></i> Astro Boilerplate
-
-Astro is a modern web framework designed for building fast, content-focused websites such as blogs, marketing pages, and e-commerce stores, minimizing client-side JavaScript by default for edge-ready performance.
-
-To view the complete list of availiable Astro templates, [click here](/en/documentation/products/devtools/azion-edge-runtime/frameworks-compatibility/astro/#available-templates).
-
-<LinkButton link="/en/documentation/products/templates/astro-boilerplate/" label="Get Started" severity="secondary" />
-
-### <i class='ai ai-gatsby'></i> Gatsby Blog Starter Kit
-
-Create high-performance, SEO-friendly websites with Gatsby, a React-based static site generator that pulls content from any data source for quick and efficient delivery at the edge.
-
-To view the complete list of availiable Gatsby templates, [click here](/en/documentation/products/devtools/azion-edge-runtime/frameworks-compatibility/gatsby/#available-templates).
-
-<LinkButton link="/en/documentation/products/templates/gatsby-blog/" label="Get Started" severity="secondary" />
-
-### <i class='ai ai-react'></i> React Boilerplate
-
-Build interactive user interfaces using reusable components with React, one of the most popular JavaScript libraries for dynamic web applications—ideal for quick iteration and UI-centric development at the edge.
-
-To view the complete list of availiable React templates, [click here](/en/documentation/products/devtools/azion-edge-runtime/frameworks-compatibility/react/#available-templates).
-
-<LinkButton link="/en/documentation/products/templates/react-boilerplate/" label="Get Started" severity="secondary" />
-
-
-### <i class='ai ai-nextjs'></i> Next.js Static Boilerplate
-
-Leverage Next.js for server-side rendering, static site generation, and powerful routing built on React, enabling the creation of fast, scalable web apps optimized for edge deployment.
-
-To view the complete list of availiable Next.js templates, [click here](/en/documentation/products/devtools/azion-edge-runtime/frameworks-compatibility/nextjs/#available-templates).
-
-<LinkButton link="/en/documentation/products/templates/nextjs-static-boilerplate/" label="Get Started" severity="secondary" />
-
-### <i class='ai ai-vue'></i> Vue.js Boilerplate
-
-Develop responsive and maintainable web interfaces with Vue.js, a progressive JavaScript framework known for its simplicity, flexibility, and ease of integration—perfect for modern, scalable apps at the edge.
-
-<LinkButton
-    label="Deploy"
-    link="https://console.azion.com/create/vue/vue-boilerplate"
-    icon="ai ai-azion"
-    icon-pos="left"
-  />
-
-### <i class='ai ai-angular'></i> Angular Boilerplate
-
-Create enterprise-grade, feature-rich web applications with Angular, a comprehensive framework that uses TypeScript for robust structure, advanced tooling, and efficient deployment to edge infrastructure.
-
-To view the complete list of availiable Angular templates, [click here](/en/documentation/products/devtools/azion-edge-runtime/frameworks-compatibility/angular/#available-templates).
-
-<LinkButton link="/en/documentation/products/templates/angular-boilerplate/" label="Get Started" severity="secondary" />
-### More frameworks 
-
-We are continously expanding our framework support. Click below to see the full list.
-
-<LinkButton link="/en/documentation/products/devtools/azion-edge-runtime/frameworks-compatibility/" label="View details" severity="secondary" />
+<div class="grid gap-3 my-6 grid-cols-[repeat(auto-fill,minmax(280px,1fr))]">
+    <DocsCard link="/en/documentation/products/templates/astro-boilerplate/" title="Astro Boilerplate" icon="ai ai-astro" description="Fast, content-focused websites such as blogs, marketing pages, and e-commerce stores, with minimal client-side JavaScript." />
+    <DocsCard link="/en/documentation/products/templates/gatsby-blog/" title="Gatsby Blog Starter Kit" icon="ai ai-gatsby" description="High-performance, SEO-friendly websites with a React-based static site generator that pulls content from any data source." />
+    <DocsCard link="/en/documentation/products/templates/react-boilerplate/" title="React Boilerplate" icon="ai ai-react" description="Interactive user interfaces with reusable components—ideal for quick iteration and UI-centric development at the edge." />
+    <DocsCard link="/en/documentation/products/templates/nextjs-static-boilerplate/" title="Next.js Static Boilerplate" icon="ai ai-nextjs" description="Server-side rendering, static site generation, and powerful routing built on React, optimized for edge deployment." />
+    <DocsCard link="https://console.azion.com/create/vue/vue-boilerplate" title="Vue.js Boilerplate" icon="ai ai-vue" description="Responsive, maintainable web interfaces with a progressive JavaScript framework known for simplicity and flexibility." />
+    <DocsCard link="/en/documentation/products/templates/angular-boilerplate/" title="Angular Boilerplate" icon="ai ai-angular" description="Enterprise-grade web applications with TypeScript, robust structure, and advanced tooling for edge infrastructure." />
+    <DocsCard link="/en/documentation/products/devtools/azion-edge-runtime/frameworks-compatibility/" title="More frameworks" icon="pi pi-th-large" description="We're continuously expanding our framework support. See the full list of supported frameworks and their templates." />
+</div>
 
 ## Need to deploy an existing project?
 
-### Importing from GitHub
+Bring what you already have: connect a GitHub repository or link a local project from your terminal.
 
-You can use the Azion Console to quickly deploy a GitHub project compatible with our availiable frameworks.
+<div class="grid gap-3 my-6 grid-cols-[repeat(auto-fill,minmax(280px,1fr))]">
+    <DocsCard link="/en/documentation/get-started/first-deploy/#import-a-project-from-github" title="Import from GitHub" icon="pi pi-github" description="Connect your GitHub account, pick a repository, and deploy it from the Console in a few clicks." />
+    <DocsCard link="/en/documentation/get-started/first-deploy/#deploy-with-azion-cli" title="Deploy with the Azion CLI" icon="pi pi-wrench" description="Run azion link in your project folder and be live in a few minutes, straight from the terminal." />
+</div>
 
-1. In [Console](https://console.azion.com) click the **\+ Create** button.
-2. Select Import from Github.
-3. Connect your GitHub Account.
-4. Select your repository.
-5. Choose an application name and Framework Preset.
-6. Input the install command (typically `npm install`).
+Whichever door you choose, the [first deploy tutorial](/en/documentation/get-started/first-deploy/) walks through all three paths and ends with a verification step, so you know it worked.
 
-### Local project deploy with Azion CLI
+## Journeys: from zero to production
 
-You can use the Azion CLI to deploy a project compatible with our [availiable frameworks](/en/documentation/products/devtools/azion-edge-runtime/frameworks-compatibility/).
+<div class="grid gap-3 my-6 grid-cols-[repeat(auto-fill,minmax(280px,1fr))]">
+    <DocsCard link="/en/documentation/get-started/" title="Put an application live" icon="pi pi-code" description="From your first deploy to a working application on a real URL." />
+    <DocsCard link="/en/documentation/products/secure/overview/" title="Protect your application" icon="ai ai-edge-firewall" description="Add WAF, DDoS protection, and traffic rules in front of what you deployed." />
+    <DocsCard link="/en/documentation/products/observe/overview/" title="Observe your application" icon="pi pi-chart-line" description="Follow metrics, events, and data streams from your traffic in real time." />
+</div>
 
-:::tip
-Visit our [CLI guide](/en/documentation/products/azion-cli/overview/#installing-azion-cli) for detailed installation instructions.
-:::
+## Configure and operate protection
 
-1. Inside your existing project folder, use the command below to link your project to an application:
+Everything that sits in front of what you deployed: the rules, the tuning that keeps them from blocking real users, and the evidence that they fired.
 
-```shell
-azion link
-```
+<div class="grid gap-3 my-6 grid-cols-[repeat(auto-fill,minmax(280px,1fr))]">
+    <DocsCard link="/en/documentation/products/secure/firewall/web-application-firewall/" title="Web Application Firewall" icon="ai ai-edge-firewall" description="Protect applications against SQL injection, Cross-Site Scripting (XSS), Remote File Inclusion, and other threats with configurable rule sets." />
+    <DocsCard link="/en/documentation/products/guides/secure/tune-waf/" title="Tune WAF with real traffic" icon="pi pi-list-check" description="Filter the attacks your rules caught, separate real threats from false positives, and turn the exceptions into allowed rules." />
+    <DocsCard link="/en/documentation/products/secure/firewall/ddos-protection/" title="DDoS Protection" icon="pi pi-shield" description="Defend content and applications against Distributed Denial of Service attacks, absorbed by the network." />
+    <DocsCard link="/en/documentation/products/secure/firewall/bot-manager/" title="Bot Manager" icon="pi pi-microchip" description="Protect applications against automated attacks such as bad bot signatures and scripted bots." />
+    <DocsCard link="/en/documentation/products/secure/firewall/network-shield/" title="Network Shield" icon="pi pi-map" description="Granular filtering by IP address, ASN, and country, applied through network lists at the edge." />
+    <DocsCard link="/en/documentation/products/secure/firewall/certificate-manager/" title="Certificate Manager" icon="pi pi-key" description="Link TLS certificates to your HTTPS applications, including wildcard Let's Encrypt and mTLS for client authentication." />
+    <DocsCard link="/en/documentation/products/secure/automate/integrate-siems/" title="Integrate with your SIEM" icon="pi pi-arrow-right-arrow-left" description="Send WAF and firewall events to the SIEM your team already watches, for threat detection and response." />
+</div>
 
-2. You'll be prompted to choose a preset, which will be used to setup your project configurations.
+## Assess risk and prove compliance
 
-3. The CLI will guide you through the rest of the process. In less than five minutes, your application can be up and running on the Azion Web Platform.
+What the platform covers, what stays with you, and where the evidence lives when an auditor asks for it.
+
+<div class="grid gap-3 my-6 grid-cols-[repeat(auto-fill,minmax(280px,1fr))]">
+    <DocsCard link="/en/documentation/shared-responsibility/" title="Shared Responsibility Model" icon="pi pi-verified" description="The roles and responsibilities of each party when your organization runs on the Azion platform." />
+    <DocsCard link="/en/documentation/architectures/compliance/governance-risk-compliance/" title="Governance, Risk &amp; Compliance" icon="pi pi-id-card" description="How Azion supports compliance efforts through security tools, certifications, and a flexible infrastructure." />
+    <DocsCard link="/en/documentation/compliance/pci-dss-certification/" title="PCI DSS compliance" icon="pi pi-wallet" description="Azion is a PCI-DSS 4.0 Level 1 Service Provider: what that covers for workloads handling cardholder data." />
+    <DocsCard link="/en/documentation/compliance/soc/" title="SOC compliance" icon="pi pi-lock" description="Biannual SOC 2 Type 2 and SOC 3 reports, showing security controls audited continuously through the year." />
+    <DocsCard link="/en/documentation/products/guides/activity-history/" title="Activity History" icon="pi pi-history" description="The account audit trail: which actions were performed in the Console, by whom, and when." />
+    <DocsCard link="/en/documentation/services/security-response-team/" title="Security Response Team" icon="pi pi-users" description="A managed service that authorizes Azion to apply mitigation measures on your behalf during an attack." />
+</div>
+
+Access governance: [single sign-on](/en/documentation/products/guides/sso/) · [multi-factor authentication](/en/documentation/products/guides/multi-factor-authentication/) · [teams and permissions](/en/documentation/products/guides/teams-permissions/) · [conditional access by IP address](/en/documentation/products/guides/conditional-access-by-ip-address/)
+
+## Explore by area
+
+<div class="grid gap-3 my-6 grid-cols-[repeat(auto-fill,minmax(280px,1fr))]">
+    <DocsCard link="/en/documentation/products/azion-platform-overview/" title="Azion platform overview" icon="ai ai-azion" description="Get to know the Azion Web Platform and how to use it." />
+    <DocsCard link="/en/documentation/products/guides/build/overview/" title="Build" icon="ai ai-build-pillar" description="Create with powerful tools and frameworks." />
+    <DocsCard link="/en/documentation/products/store/overview/" title="Store" icon="ai ai-store" description="Manage and process data at the edge." />
+    <DocsCard link="/en/documentation/products/secure/overview/" title="Secure" icon="ai ai-secure-pillar" description="Fully protect your applications." />
+    <DocsCard link="/en/documentation/products/deploy/overview/" title="Deploy" icon="ai ai-deploy-pillar" description="Manage edge resources efficiently." />
+    <DocsCard link="/en/documentation/products/observe/overview/" title="Observe" icon="ai ai-observe-pillar" description="Monitor and gain analytics in real-time." />
+    <DocsCard link="/en/documentation/devtools/" title="Dev Tools" icon="pi pi-server" description="Build, automate, and integrate with Azion's developer tools." />
+</div>
 
 ## Get to know our Developer tools
 
-### Azion Console
+<div class="grid gap-3 my-6 grid-cols-[repeat(auto-fill,minmax(280px,1fr))]">
+    <DocsCard link="/en/documentation/products/guides/how-to-access-azion-console/" title="Azion Console" icon="ai ai-azion" description="Azion's configuration interface: create Applications, configure Functions, manage Firewall rules, set up Cache, and monitor metrics and events." />
+    <DocsCard link="https://api.azion.com/" title="Azion API" icon="pi pi-code" description="A RESTful API based on HTTPS requests that lets you fully interact with Azion products." />
+    <DocsCard link="/en/documentation/products/azion-cli/overview/" title="Azion CLI" icon="pi pi-wrench" description="Our open source command-line interface: initialize, build, and deploy applications, run a local dev server, and link existing projects." />
+    <DocsCard link="/en/documentation/products/azion-lib/overview/" title="Azion Lib & SDKs" icon="ai ai-edge-libraries" description="JavaScript/TypeScript tools for the Azion Runtime and REST APIs; for Go projects, the Azion SDK for Go covers the same operations." />
+    <DocsCard link="/en/documentation/devtools/console-kit/" title="Console Kit" icon="pi pi-th-large" description="A front-end kit to build your own Azion Console interfaces with Vue/Vite, Tailwind, and PrimeVue, with multi-tenancy support." />
+    <DocsCard link="/en/documentation/devtools/graphql-api/" title="GraphQL API" icon="pi pi-chart-line" description="A single endpoint for precise data retrieval: real-time metrics, events, billing, and accounting data without overfetching." />
+    <DocsCard link="/en/documentation/products/terraform-provider/" title="Terraform" icon="pi pi-server" description="Manage your Azion-hosted infrastructure as reusable, versioned code with the official Azion Terraform Provider." />
+</div>
 
-
-Console is Azion's configuration interface where you can access all the available products and their settings. It enables you to complete all tasks in Azion's platform, such as creating Applications, configuring Functions, managing Firewall rules, setting up Cache, and monitoring real-time metrics and events.
-
-
-<LinkButton link="/en/documentation/products/guides/how-to-access-azion-console/" label="View details" severity="secondary" />
-
-### Azion API
-
-The Azion API is a RESTful API based on HTTPS requests that allows users to fully interact with Azion products through API requests.
-
-<LinkButton link="https://api.azion.com/?_gl=1*kkolsv*_gcl_au*OTAxOTIzMjQ2LjE3NDc3NDYzNTkuMTk3ODMzMTk3LjE3NDg0NTUzNTYuMTc0ODQ1NjI4OQ.." label="View details" severity="secondary" />
-
-### Azion CLI
-
-Azion CLI is our [open source](https://github.com/aziontech/azion) command-line interface that allows you to interact with the Azion Web Platform via terminal. With it, you can initialize, build, and deploy applications, create Jamstack apps, manage your projects, run a local development server, and link existing projects to Azion applications.
-
-<LinkButton link="/en/documentation/products/azion-cli/overview/" label="View details" severity="secondary" />
-
-### Azion Lib
-
-Azion Lib are JavaScript/TypeScript tools designed to work inside the [Azion Runtime](https://www.azion.com/en/documentation/runtime/overview/), leveraging internal features for enhanced performance. They also function outside the runtime, accessing Azion services such as Purge, Object Storage, and Image Processor via REST APIs. The libraries support debug mode and environment variable configuration.
-
-<LinkButton link="/en/documentation/products/azion-lib/overview/" label="View details" severity="secondary" />
-
-### Console Kit
-
-Azion Console Kit is a front-end kit for building your own Azion Console interfaces using Vue/Vite, Tailwind, and PrimeVue. It connects to the Azion API, supports multi-tenancy, and lets you customize themes and UI for your business needs. The kit features a clean, organized structure for maintainable code.
-
-<LinkButton link="/en/documentation/devtools/console-kit/" label="View details" severity="secondary" />
-
-### GraphQL API
-
-GraphQL is a powerful API language that allows precise data retrieval, avoiding overfetching and enhancing performance. Unlike traditional REST APIs, it uses a single endpoint and delivers tailored JSON responses. At Azion, GraphQL is ideal for accessing real-time metrics, events, billing, and accounting data, enabling efficient monitoring and analysis.
-
-<LinkButton link="/en/documentation/devtools/graphql-api/" label="View details" severity="secondary" />
-
-### SDK
-
-The Azion SDK for Go simplifies developing applications that integrate with Azion's platform. It enables efficient management of Applications, interaction with Object Storage, advanced queries with SQL Database, task automation, and building serverless solutions, streamlining workflows and enhancing productivity for edge computing projects.
-
-<LinkButton link="/en/documentation/devtools/sdk/go/" label="View details" severity="secondary" />
-
-### Terraform
-
-Terraform is an infrastructure as code tool that enables efficient infrastructure management through reusable, versioned, and shareable code. The Azion Terraform Provider, available in the Terraform Registry, leverages the Azion SDK for Go to interact with Azion APIs, allowing you to manage your Azion-hosted infrastructure locally as code, ensuring a consistent and streamlined workflow.
-
-<LinkButton link="/en/documentation/products/terraform-provider/" label="View details" severity="secondary" />
-
+Related: [Azion Runtime](/en/documentation/runtime/overview/) · [Azion SDK for Go](/en/documentation/products/azion-lib/overview/) · [open source CLI on GitHub](https://github.com/aziontech/azion)
 
 ## Find the solution that fits you better
 
-### <i class='pi pi-code'></i> Application Development
-
-Build scalable, low-latency apps with edge computing and serverless functions.
-
-<LinkButton link="/en/documentation/architectures/by-solution/application-development/" label="View details" severity="secondary" />
-
-### <i class='pi pi-server'></i> Application and Infrastructure Automation
-
-Automate operations to optimize application performance and simplify infrastructure management.
-
-<LinkButton link="/en/documentation/architectures/by-solution/application-and-infrastructure-automation/" label="View details" severity="secondary" />
-
-### <i class='ai ai-edge-firewall'></i> Application and Network Security
-
-Protect applications and networks from threats with edge-native security and observability tools.
-
-<LinkButton link="/en/documentation/architectures/by-solution/application-and-network-security/" label="View details" severity="secondary" />
-
-### <i class='pi pi-bolt'></i> Artificial Intelligence (AI)
-
-Deploy AI at the edge for real-time insights, fast responses, and personalized experiences.
-
-<LinkButton link="/en/documentation/architectures/by-solution/artificial-intelligence/" label="View details" severity="secondary" />
-
-### <i class='pi pi-chart-line'></i> Service Performance and Reliability
-
-Enhance application performance, reduce latency, and ensure reliable service delivery at the edge.
-
-<LinkButton link="/en/documentation/architectures/by-solution/service-performance-and-reliability/" label="View details" severity="secondary" />
-
-### Find more
-
-View all architectures for use cases.
-
-<LinkButton link="/en/documentation/architectures/" label="View details" severity="secondary" />
-
-## Choose your journey
-
-### <i class='ai ai-azion'></i> Azion platform overview
-
-Get to know the Azion Web Platform and how to use it.
-
-<LinkButton link="/en/documentation/products/azion-platform-overview/" label="View details" severity="secondary" />
-
-### <i class='ai ai-build-pillar'></i> Build
-
-Create with powerful tools and frameworks.
-
-<LinkButton link="/en/documentation/products/guides/build/overview/" label="View details" severity="secondary" />
-
-### <i class='ai ai-store-pillar'></i> Store
-
-Manage and proccess data at the edge.
-
-<LinkButton link="/en/documentation/products/store/overview/" label="View details" severity="secondary" />
-
-### <i class='ai ai-secure-pillar'></i> Secure
-
-Fully protect your applications.
-
-<LinkButton link="/en/documentation/products/secure/overview/" label="View details" severity="secondary" />
-
-### <i class='ai ai-deploy-pillar'></i> Deploy
-
-Manage edge resources efficiently.
-
-<LinkButton link="/en/documentation/products/deploy/overview/" label="View details" severity="secondary" />
-
-### <i class='ai ai-observe-pillar'></i> Observe
-
-Monitor and gain analytics in real-time.
-
-<LinkButton link="/en/documentation/products/observe/overview/" label="View details" severity="secondary" />
+<div class="grid gap-3 my-6 grid-cols-[repeat(auto-fill,minmax(280px,1fr))]">
+    <DocsCard link="/en/documentation/architectures/by-solution/application-development/" title="Application Development" icon="pi pi-code" description="Build scalable, low-latency apps with edge computing and serverless functions." />
+    <DocsCard link="/en/documentation/architectures/by-solution/application-and-infrastructure-automation/" title="Application and Infrastructure Automation" icon="pi pi-server" description="Automate operations to optimize application performance and simplify infrastructure management." />
+    <DocsCard link="/en/documentation/architectures/by-solution/application-and-network-security/" title="Application and Network Security" icon="ai ai-edge-firewall" description="Protect applications and networks from threats with edge-native security and observability tools." />
+    <DocsCard link="/en/documentation/architectures/by-solution/artificial-intelligence/" title="Artificial Intelligence (AI)" icon="pi pi-bolt" description="Deploy AI at the edge for real-time insights, fast responses, and personalized experiences." />
+    <DocsCard link="/en/documentation/architectures/by-solution/service-performance-and-reliability/" title="Service Performance and Reliability" icon="pi pi-chart-line" description="Enhance application performance, reduce latency, and ensure reliable service delivery at the edge." />
+    <DocsCard link="/en/documentation/architectures/" title="Find more" icon="pi pi-compass" description="View all architectures for use cases." />
+</div>
 
 ## What's new?
 
-### <i class='pi pi-megaphone'></i> Release notes
+<div class="grid gap-3 my-6 grid-cols-[repeat(auto-fill,minmax(280px,1fr))]">
+    <DocsCard link="/en/documentation/products/release-notes/" title="Release notes" icon="pi pi-megaphone" description="Stay updated on the latest changes and releases in Azion products and services." />
+    <DocsCard link="https://discord.com/invite/Yp9N7RMVZy" title="Join the Community" icon="pi pi-discord" description="Share your experiences with the Azion community on Discord." />
+</div>
 
-Stay updated on the latest changes and releases in Azion products and services.
-
-<LinkButton link="/en/documentation/products/release-notes/" label="View details" severity="secondary" />
-
-### <i class='pi pi-discord'></i> Join the Community
-
-Share your experiences with the Azion community on Discord.
-
-<LinkButton link="https://discord.com/invite/Yp9N7RMVZy" label="Join" severity="secondary" />

--- a/src/content/docs/en/homes/platform-home.mdx
+++ b/src/content/docs/en/homes/platform-home.mdx
@@ -35,7 +35,7 @@ product_cards:
         title: Activity History
         description: Access the history of all activities performed on the account.
         link: /en/documentation/products/accounts/activity-history/
-  - title: Authentication
+  - title: Authentication and access security
     cards:
       - icon: /assets/docs/images/uploads/icon-sso.svg
         title: Single Sign-On (SSO)
@@ -45,6 +45,14 @@ product_cards:
         title: Multi-Factor Authentication (MFA)
         description: Add an extra layer of security to Azion Console.
         link: /en/documentation/products/accounts/multi-factor-authentication/
+      - icon: /assets/docs/images/uploads/icon-mfa.svg
+        title: Account Lockout Policy
+        description: Lock accounts after repeated failed sign-in attempts.
+        link: /en/documentation/products/accounts/account-lockout-policy/
+      - icon: /assets/docs/images/uploads/icon-account.svg
+        title: User Session Timeout
+        description: Set how long a Console session stays active before re-authentication.
+        link: /en/documentation/products/accounts/user-session-timeout/
       - icon: /assets/docs/images/uploads/icon-teams-permissions.svg
         title: Social Login
         description: Log in to Azion using your social network information.

--- a/src/content/docs/pt-br/homes/dev-tools.mdx
+++ b/src/content/docs/pt-br/homes/dev-tools.mdx
@@ -48,7 +48,7 @@ product_cards:
       - icon: /assets/docs/images/uploads/vector.svg
         title: SDK
         description: Desenvolva aplicações utilizando o Azion SDK para a linguagem Go.
-        link: /pt-br/documentacao/devtools/sdk/go/
+        link: /pt-br/documentacao/produtos/azion-lib/visao-geral/
       - icon: /assets/docs/images/uploads/vector.svg
         title: Terraform
         description: Gerencie sua infraestrutura como código com o Azion Terraform Provider.

--- a/src/content/docs/pt-br/homes/doc-home.mdx
+++ b/src/content/docs/pt-br/homes/doc-home.mdx
@@ -1,256 +1,159 @@
 ---
 meta_tag_robots_no_index: false
+hide_title: true
 title: 'Página Inicial da Documentação'
 description: >-
-  Azion é a plataforma de edge computing full-stack que simplifica como você constrói, protege e escala aplicações modernas.
+  Explore a documentação da Azion Web Platform: tudo o que você precisa para construir, proteger, entregar e observar aplicações modernas, do primeiro deploy à escala de produção.
 namespace: documentation_home
 permalink: /documentacao/
 ---
-import LinkButton from 'azion-webkit/linkbutton';
+
 import HeroHome from 'azion-webkit/herohome';
 import Container from 'azion-webkit/container';
+import LinkButton from 'azion-webkit/linkbutton';
+import DocsCard from '~/components/DocsCard.astro';
 
 <div class="[&_.flex.flex-col]:!gap-4 [&_.flex.flex-col]:md:!gap-8 [&_.flex.flex-col]:2xl:!gap-16">
   <HeroHome
     title="Bem-vindo à <span style='color:#F3652B!important'>Documentação Azion</span>"
     description="Tornamos toda aplicação rápida e confiável. Faça a implementação de seus projetos instantaneamente na rede global mais confiável, aproveite segurança em nível corporativo e escale do zero ao pico sem cold starts."
     logos={[]}
-    buttons={[
-      { label: "Crie a sua conta", link: "https://console.azion.com/signup/", outlined: false },
-      { label: "Visão geral da plataforma", link: "/pt-br/documentacao/produtos/visao-geral-da-plataforma-da-azion/",severity: "secondary" }
-    ]}
+    bottomSpacing="mb-8"
   />
+  <div class="flex flex-wrap gap-4 justify-center mb-16">
+    <LinkButton link="/pt-br/documentacao/get-started/first-deploy/" label="Primeiro deploy em poucos minutos" />
+    <LinkButton link="https://console.azion.com/signup/" label="Crie a sua conta" outlined />
+    <LinkButton link="/pt-br/documentacao/produtos/visao-geral-da-plataforma-da-azion/" label="Visão geral da plataforma" outlined />
+  </div>
 </div>
 
-## Comece aqui: seu ponto de partida para projetos com templates prontos para usar
+## Comece aqui, pelo seu perfil
+
+<div class="grid gap-3 my-6 grid-cols-[repeat(auto-fill,minmax(280px,1fr))]">
+  <div id="persona-avaliador">
+      <DocsCard link="/pt-br/documentacao/get-started/first-deploy/" title="Estou avaliando a Azion" icon="pi pi-bolt" description="Veja o que dá para construir em poucos minutos: faça o deploy de uma aplicação real e verifique que ela está no ar, sem falar com vendas." />
+  </div>
+  <div id="persona-implementador">
+      <DocsCard link="/pt-br/documentacao/produtos/guias/" title="Preciso implementar algo específico" icon="pi pi-code" description="Encontre a funcionalidade pelo termo que você já usa — URLs assinadas, relatórios, streaming ao vivo — e siga um guia passo a passo até a produção." />
+  </div>
+  <div id="persona-decisor">
+      <DocsCard link="/pt-br/documentacao/produtos/precos/" title="Preciso saber o que está incluído" icon="pi pi-chart-line" description="Limites por plano, preços e o que cada produto cobre — dentro da documentação — além de arquiteturas de referência para o seu cenário." />
+  </div>
+  <div id="persona-guardiao">
+      <DocsCard link="/pt-br/documentacao/produtos/secure/visao-geral/" title="Sou responsável pela segurança" icon="ai ai-secure-pillar" description="Configure WAF, proteção contra DDoS, gestão de bots e regras de firewall — depois faça o tuning com tráfego real e envie os eventos para o seu SIEM." />
+  </div>
+  <div id="persona-ciso">
+      <DocsCard link="/pt-br/documentacao/responsabilidade-compartilhada/" title="Respondo por risco e conformidade" icon="pi pi-verified" description="Veja o que a Azion cobre e o que continua sendo seu, consulte as certificações PCI DSS e SOC e encontre a evidência que a auditoria pede." />
+  </div>
+</div>
+
+Também úteis: [faturamento e gestão de contas](/pt-br/documentacao/produtos/gestao-de-contas/) · [arquiteturas de referência](/pt-br/documentacao/arquiteturas/)
+
+## Deploy em um clique com templates prontos para usar
 
 A maneira mais rápida de começar a utilizar a Azion Web Platform. Faça a implementação em instantes a partir de dezenas de modelos, incluindo e-commerce, blogs, APIs, SSR full-stack e mais; integre facilmente com Sanity, Cosmic, ButterCMS, Turso, utilize seu próprio CMS ou banco de dados RESTful. O CI/CD é configurado automaticamente para que você foque no seu código, não no pipeline.
 
-Aqui estão alguns dos nossos templates mais populares para você começar. Para mais informações, acesse nossa página de documentação sobre [como usar templates](/pt-br/documentacao/produtos/usar-um-template-via-azion-console/).
+Aqui estão alguns dos nossos templates mais populares para você começar. Para mais informações, acesse nossa página de documentação sobre [como usar templates](/pt-br/documentacao/get-started/first-deploy/).
 
-### <i class='ai ai-astro'></i> Astro Boilerplate
-
-Astro é um framework web moderno focado em construir sites rápidos e orientados a conteúdo, como blogs, páginas de marketing e lojas virtuais, minimizando por padrão o JavaScript do lado do cliente para desempenho otimizado no edge.
-
-Para ver a lista completa de templates Astro, [clique aqui](/pt-br/documentacao/produtos/devtools/azion-edge-runtime/compatibilidade-frameworks/astro/#templates-disponíveis).
-
-<LinkButton link="/pt-br/documentacao/produtos/templates/astro-boilerplate/" label="Comece agora" severity="secondary" />
-
-### <i class='ai ai-gatsby'></i> Gatsby Blog Starter Kit
-
-Crie sites de alto desempenho e otimizados para SEO com Gatsby, um gerador de sites estáticos baseado em React que integra conteúdo de qualquer fonte de dados para entrega rápida e eficiente no edge.
-
-Para ver a lista completa de templates Gatsby, [clique aqui](/pt-br/documentacao/produtos/devtools/azion-edge-runtime/compatibilidade-frameworks/gatsby/#templates-disponíveis).
-
-<LinkButton link="/pt-br/documentacao/produtos/templates/gatsby-blog/" label="Comece agora" severity="secondary" />
-
-### <i class='ai ai-react'></i> React Boilerplate
-
-Construa interfaces de usuário interativas usando componentes reutilizáveis com React, uma das bibliotecas JavaScript mais populares para aplicações web dinâmicas — ideal para iteração rápida e desenvolvimento orientado à UI no edge.
-
-Para ver a lista completa de templates React, [clique aqui](/pt-br/documentacao/produtos/devtools/azion-edge-runtime/compatibilidade-frameworks/react/#templates-disponíveis).
-
-<LinkButton link="/pt-br/documentacao/produtos/templates/react-boilerplate/" label="Comece agora" severity="secondary" />
-
-### <i class='ai ai-nextjs'></i> Next.js Static Boilerplate
-
-Aproveite o Next.js para renderização no servidor, geração de sites estáticos e roteamento avançado baseado em React, possibilitando a criação de apps web rápidos e escaláveis otimizados para deploy no edge.
-
-Para ver a lista completa de templates Next.js, [clique aqui](/pt-br/documentacao/produtos/devtools/azion-edge-runtime/compatibilidade-frameworks/nextjs/#templates-disponíveis).
-
-<LinkButton link="/pt-br/documentacao/produtos/templates/nextjs-static-boilerplate/" label="Comece agora" severity="secondary" />
-
-### <i class='ai ai-vue'></i> Vue.js Boilerplate
-
-Desenvolva interfaces web responsivas e fáceis de manter com Vue.js, um framework progressivo de JavaScript reconhecido por sua simplicidade, flexibilidade e facilidade de integração — perfeito para apps modernos e escaláveis no edge.
-
-<LinkButton
-    label="Deploy"
-    link="https://console.azion.com/create/vue/vue-boilerplate"
-    icon="ai ai-azion"
-    icon-pos="left"
-  />
-
-### <i class='ai ai-angular'></i> Angular Boilerplate
-
-Crie aplicações web corporativas e ricas em funcionalidades com Angular, um framework robusto que utiliza TypeScript para estrutura consistente, ferramentas avançadas e deploy eficiente para a infraestrutura de edge.
-
-Para ver a lista completa de templates Angular, [clique aqui](/pt-br/documentacao/produtos/devtools/azion-edge-runtime/compatibilidade-frameworks/angular/#templates-disponíveis).
-
-<LinkButton link="/pt-br/documentacao/produtos/templates/angular-boilerplate/" label="Comece agora" severity="secondary" />
-
-### Mais frameworks 
-
-Estamos expandindo continuamente o suporte a frameworks. Clique abaixo para ver a lista completa.
-
-<LinkButton link="/pt-br/documentacao/produtos/devtools/azion-edge-runtime/compatibilidade-frameworks/" label="Ver detalhes" severity="secondary" />
+<div class="grid gap-3 my-6 grid-cols-[repeat(auto-fill,minmax(280px,1fr))]">
+    <DocsCard link="/pt-br/documentacao/produtos/templates/astro-boilerplate/" title="Astro Boilerplate" icon="ai ai-astro" description="Sites rápidos e orientados a conteúdo, como blogs, páginas de marketing e lojas virtuais, com o mínimo de JavaScript no cliente." />
+    <DocsCard link="/pt-br/documentacao/produtos/templates/gatsby-blog/" title="Gatsby Blog Starter Kit" icon="ai ai-gatsby" description="Sites de alto desempenho e otimizados para SEO com um gerador de sites estáticos baseado em React que integra conteúdo de qualquer fonte." />
+    <DocsCard link="/pt-br/documentacao/produtos/templates/react-boilerplate/" title="React Boilerplate" icon="ai ai-react" description="Interfaces interativas com componentes reutilizáveis — ideal para iteração rápida e desenvolvimento orientado à UI no edge." />
+    <DocsCard link="/pt-br/documentacao/produtos/templates/nextjs-static-boilerplate/" title="Next.js Static Boilerplate" icon="ai ai-nextjs" description="Renderização no servidor, geração de sites estáticos e roteamento avançado baseado em React, otimizado para deploy no edge." />
+    <DocsCard link="https://console.azion.com/create/vue/vue-boilerplate" title="Vue.js Boilerplate" icon="ai ai-vue" description="Interfaces web responsivas e fáceis de manter com um framework progressivo reconhecido por simplicidade e flexibilidade." />
+    <DocsCard link="/pt-br/documentacao/produtos/templates/angular-boilerplate/" title="Angular Boilerplate" icon="ai ai-angular" description="Aplicações web corporativas com TypeScript, estrutura consistente e ferramentas avançadas para a infraestrutura de edge." />
+    <DocsCard link="/pt-br/documentacao/produtos/devtools/azion-edge-runtime/compatibilidade-frameworks/" title="Mais frameworks" icon="pi pi-th-large" description="Estamos expandindo continuamente o suporte a frameworks. Veja a lista completa de frameworks compatíveis e seus templates." />
+</div>
 
 ## Precisa implementar um projeto existente?
 
-### Importando do GitHub
+Traga o que você já tem: conecte um repositório do GitHub ou vincule um projeto local pelo terminal.
 
-Você pode usar o Azion Console para fazer implementações rapidamente de um projeto do GitHub compatível com os frameworks disponíveis.
+<div class="grid gap-3 my-6 grid-cols-[repeat(auto-fill,minmax(280px,1fr))]">
+    <DocsCard link="/pt-br/documentacao/get-started/first-deploy/#importe-um-projeto-do-github" title="Importe do GitHub" icon="pi pi-github" description="Conecte sua conta do GitHub, escolha um repositório e faça o deploy pelo Console em poucos cliques." />
+    <DocsCard link="/pt-br/documentacao/get-started/first-deploy/#faça-deploy-com-a-azion-cli" title="Faça deploy com a Azion CLI" icon="pi pi-wrench" description="Rode azion link na pasta do projeto e esteja no ar em poucos minutos, direto do terminal." />
+</div>
 
-1. No [Console](https://console.azion.com), clique no botão **\+ Create**.
-2. Selecione *Import from Github*.
-3. Conecte sua conta do GitHub.
-4. Selecione seu repositório.
-5. Escolha um nome para a aplicação e um Preset de Framework.
-6. Insira o comando de instalação (normalmente `npm install`).
+Qualquer que seja a porta escolhida, o [tutorial de primeiro deploy](/pt-br/documentacao/get-started/first-deploy/) percorre os três caminhos e termina com um passo de verificação, para você saber que funcionou.
 
-### Implementação de projeto local com Azion CLI
+## Jornadas: do zero à produção
 
-Você pode utilizar a Azion CLI para fazer o deploy de um projeto compatível com nossos [frameworks disponíveis](/pt-br/documentacao/produtos/devtools/azion-edge-runtime/compatibilidade-frameworks/).
+<div class="grid gap-3 my-6 grid-cols-[repeat(auto-fill,minmax(280px,1fr))]">
+    <DocsCard link="/pt-br/documentacao/get-started/" title="Coloque uma aplicação no ar" icon="pi pi-code" description="Do primeiro deploy a uma aplicação funcionando em uma URL real." />
+    <DocsCard link="/pt-br/documentacao/produtos/secure/visao-geral/" title="Proteja a aplicação" icon="ai ai-edge-firewall" description="Adicione WAF, proteção contra DDoS e regras de tráfego na frente do que você implantou." />
+    <DocsCard link="/pt-br/documentacao/produtos/observe/visao-geral/" title="Observe a aplicação" icon="pi pi-chart-line" description="Acompanhe métricas, eventos e streams de dados do seu tráfego em tempo real." />
+</div>
 
-:::tip[Dica]
-Consulte nosso [guia da CLI](/pt-br/documentacao/produtos/azion-cli/visao-geral/) para instruções detalhadas de instalação.
-:::
+## Configure e opere a proteção
 
-1. Dentro da pasta do seu projeto existente, utilize o comando abaixo para vincular seu projeto a uma application:
+Tudo o que fica na frente do que você implantou: as regras, o tuning que evita que elas bloqueiem usuários reais e a evidência de que dispararam.
 
-```shell
-azion link
-```
+<div class="grid gap-3 my-6 grid-cols-[repeat(auto-fill,minmax(280px,1fr))]">
+    <DocsCard link="/pt-br/documentacao/produtos/secure/firewall/web-application-firewall/" title="Web Application Firewall" icon="ai ai-edge-firewall" description="Proteja aplicações contra SQL Injection, Cross-Site Scripting (XSS), Remote File Inclusion e outras ameaças com rule sets configuráveis." />
+    <DocsCard link="/pt-br/documentacao/produtos/guias/secure/tune-waf/" title="Faça o tuning do WAF com tráfego real" icon="pi pi-list-check" description="Filtre os ataques que suas regras capturaram, separe ameaças reais de falsos positivos e transforme as exceções em allowed rules." />
+    <DocsCard link="/pt-br/documentacao/produtos/secure/firewall/ddos-protection/" title="DDoS Protection" icon="pi pi-shield" description="Defenda conteúdo e aplicações contra ataques de negação de serviço distribuída, absorvidos pela rede." />
+    <DocsCard link="/pt-br/documentacao/produtos/secure/firewall/bot-manager/" title="Bot Manager" icon="pi pi-microchip" description="Proteja aplicações contra ataques automatizados, como assinaturas de bots maliciosos e bots por script." />
+    <DocsCard link="/pt-br/documentacao/produtos/secure/firewall/network-shield/" title="Network Shield" icon="pi pi-map" description="Filtragem granular por endereço IP, ASN e país, aplicada por network lists no edge." />
+    <DocsCard link="/pt-br/documentacao/produtos/secure/firewall/certificate-manager/" title="Certificate Manager" icon="pi pi-key" description="Vincule certificados TLS às suas aplicações HTTPS, incluindo wildcard Let's Encrypt e mTLS para autenticação do cliente." />
+    <DocsCard link="/pt-br/documentacao/produtos/secure/automatizar/integrar-siems/" title="Integre com o seu SIEM" icon="pi pi-arrow-right-arrow-left" description="Envie eventos de WAF e firewall para o SIEM que seu time já acompanha, para detecção e resposta a ameaças." />
+</div>
 
-2. Você será solicitado a escolher um preset, que será utilizado para configurar o seu projeto.
-3. A CLI irá guiá-lo pelo restante do processo. Em menos de cinco minutos, sua aplicação pode estar ativa e rodando na Azion Web Platform.
+## Avalie risco e comprove conformidade
+
+O que a plataforma cobre, o que continua sendo seu e onde está a evidência quando a auditoria pergunta.
+
+<div class="grid gap-3 my-6 grid-cols-[repeat(auto-fill,minmax(280px,1fr))]">
+    <DocsCard link="/pt-br/documentacao/responsabilidade-compartilhada/" title="Modelo de Responsabilidade Compartilhada" icon="pi pi-verified" description="Os papéis e responsabilidades de cada parte quando a sua organização roda na plataforma da Azion." />
+    <DocsCard link="/pt-br/documentacao/arquiteturas/compliance/governanca-risco-conformidade/" title="Governança, Risco e Conformidade" icon="pi pi-id-card" description="Como a Azion apoia os esforços de conformidade com ferramentas de segurança, certificações e infraestrutura flexível." />
+    <DocsCard link="/pt-br/documentacao/compliance/pci-dss-certification/" title="Compliance PCI DSS" icon="pi pi-wallet" description="A Azion é PCI-DSS 4.0 Level 1 Service Provider: o que isso cobre para cargas de trabalho que lidam com dados de portadores de cartão." />
+    <DocsCard link="/pt-br/documentacao/compliance/soc/" title="Compliance SOC" icon="pi pi-lock" description="Relatórios SOC 2 Type 2 e SOC 3 semestrais, que demonstram controles de segurança auditados continuamente ao longo do ano." />
+    <DocsCard link="/pt-br/documentacao/produtos/guias/activity-history/" title="Activity History" icon="pi pi-history" description="A trilha de auditoria da conta: quais ações foram executadas no Console, por quem e quando." />
+    <DocsCard link="/pt-br/documentacao/servicos/security-response-team/" title="Security Response Team" icon="pi pi-users" description="Serviço gerenciado que autoriza a Azion a aplicar medidas de mitigação em seu nome durante um ataque." />
+</div>
+
+Governança de acesso: [single sign-on](/pt-br/documentacao/produtos/guias/sso/) · [autenticação multifator](/pt-br/documentacao/produtos/guias/multi-factor-authentication/) · [times e permissões](/pt-br/documentacao/produtos/guias/teams-permissions/) · [acesso condicional por endereço IP](/pt-br/documentacao/produtos/guias/conditional-access-by-ip-address/)
+
+## Explore por área
+
+<div class="grid gap-3 my-6 grid-cols-[repeat(auto-fill,minmax(280px,1fr))]">
+    <DocsCard link="/pt-br/documentacao/produtos/visao-geral-da-plataforma-da-azion/" title="Visão geral da plataforma Azion" icon="ai ai-azion" description="Conheça a Azion Web Platform e aprenda a utilizá-la." />
+    <DocsCard link="/pt-br/documentacao/produtos/guias/build/visao-geral/" title="Build" icon="ai ai-build-pillar" description="Construa aplicações com ferramentas e frameworks poderosos." />
+    <DocsCard link="/pt-br/documentacao/produtos/store/visao-geral/" title="Store" icon="ai ai-store" description="Gerencie e processe dados no edge." />
+    <DocsCard link="/pt-br/documentacao/produtos/secure/visao-geral/" title="Secure" icon="ai ai-secure-pillar" description="Proteja totalmente suas aplicações." />
+    <DocsCard link="/pt-br/documentacao/produtos/deploy/visao-geral/" title="Deploy" icon="ai ai-deploy-pillar" description="Gerencie recursos de edge de maneira eficiente." />
+    <DocsCard link="/pt-br/documentacao/produtos/observe/visao-geral/" title="Observe" icon="ai ai-observe-pillar" description="Monitore e obtenha análises em tempo real." />
+    <DocsCard link="/pt-br/documentacao/produtos/devtools/" title="Dev Tools" icon="pi pi-server" description="Construa, automatize e integre com as ferramentas para desenvolvedores da Azion." />
+</div>
 
 ## Conheça nossas ferramentas para desenvolvedores
 
-### Azion Console
+<div class="grid gap-3 my-6 grid-cols-[repeat(auto-fill,minmax(280px,1fr))]">
+    <DocsCard link="/pt-br/documentacao/produtos/guias/conhecendo-o-azion-console/" title="Azion Console" icon="ai ai-azion" description="A interface de configuração da Azion: crie Applications, configure Functions, gerencie regras do Firewall, defina Cache e monitore métricas e eventos." />
+    <DocsCard link="https://api.azion.com/" title="Azion API" icon="pi pi-code" description="Uma API RESTful baseada em requisições HTTPS que permite interagir totalmente com os produtos Azion." />
+    <DocsCard link="/pt-br/documentacao/produtos/azion-cli/visao-geral/" title="Azion CLI" icon="pi pi-wrench" description="Nossa interface de linha de comando open source: inicialize, construa e faça deploy de aplicações, rode um servidor local e vincule projetos existentes." />
+    <DocsCard link="/pt-br/documentacao/produtos/azion-lib/visao-geral/" title="Azion Lib e SDKs" icon="ai ai-edge-libraries" description="Ferramentas JavaScript/TypeScript para o Azion Runtime e APIs REST; para projetos em Go, o SDK da Azion para Go cobre as mesmas operações." />
+    <DocsCard link="/pt-br/documentacao/devtools/console-kit/" title="Console Kit" icon="pi pi-th-large" description="Um kit front-end para construir suas próprias interfaces do Console com Vue/Vite, Tailwind e PrimeVue, com suporte a multi-tenancy." />
+    <DocsCard link="/pt-br/documentacao/devtools/graphql-api/" title="GraphQL API" icon="pi pi-chart-line" description="Um endpoint único para obter dados precisos: métricas em tempo real, eventos, faturamento e cobrança, sem requisições excessivas." />
+    <DocsCard link="/pt-br/documentacao/produtos/terraform-provider/" title="Terraform" icon="pi pi-server" description="Gerencie sua infraestrutura na Azion como código reutilizável e versionado com o Azion Terraform Provider oficial." />
+</div>
 
-O Console é a interface de configuração da Azion, onde você acessa todos os produtos e suas configurações disponíveis. Permite realizar todas as tarefas na plataforma Azion, como criar Applications, configurar Functions, gerenciar regras do Firewall, definir Caching e monitorar métricas e eventos em tempo real.
-
-<LinkButton link="/pt-br/documentacao/produtos/guias/conhecendo-o-azion-console/" label="Ver detalhes" severity="secondary" />
-
-### Azion API
-
-A Azion API é uma API RESTful baseada em requisições HTTPS, permitindo interagir totalmente com os produtos Azion via requisições de API.
-
-<LinkButton link="https://api.azion.com/?_gl=1*kkolsv*_gcl_au*OTAxOTIzMjQ2LjE3NDc3NDYzNTkuMTk3ODMzMTk3LjE3NDg0NTUzNTYuMTc0ODQ1NjI4OQ.." label="Ver detalhes" severity="secondary" />
-
-### Azion CLI
-
-Azion CLI é nossa interface de linha de comando [open source](https://github.com/aziontech/azion), permitindo interação com a Azion Web Platform via terminal. Com ela, você pode inicializar, construir e fazer implementações de applications, criar apps Jamstack, gerenciar projetos, rodar servidor local de desenvolvimento e vincular projetos existentes a applications Azion.
-
-<LinkButton link="/pt-br/documentacao/produtos/azion-cli/visao-geral/" label="Ver detalhes" severity="secondary" />
-
-### Azion Lib
-
-Azion Lib são ferramentas JavaScript/TypeScript desenhadas para funcionar dentro do [Azion Runtime](/pt-br/documentacao/runtime/visao-geral/), aproveitando recursos internos para performance otimizada. Também compatível fora do runtime, acessando serviços Azion como Purge, Object Storage e Image Processor via APIs REST. Suporta modo de debug e configuração por variáveis de ambiente.
-
-<LinkButton link="/pt-br/documentacao/produtos/azion-lib/visao-geral/" label="Ver detalhes" severity="secondary" />
-
-### Console Kit
-
-Azion Console Kit é um kit front-end para construir suas próprias interfaces do Console Azion usando Vue/Vite, Tailwind e PrimeVue. Conecta-se à Azion API, suporta multi-tenancy e personalização de temas e interface conforme as necessidades do seu negócio. O kit é organizado e de fácil manutenção.
-
-<LinkButton link="/pt-br/documentacao/devtools/console-kit/" label="Ver detalhes" severity="secondary" />
-
-### GraphQL API
-
-GraphQL é uma poderosa linguagem de API que permite obter dados precisos, evitando requisições excessivas e melhorando a performance. Diferente de APIs REST tradicionais, usa um endpoint único e retorna respostas JSON sob medida. Na Azion, é ideal para acessar métricas em tempo real, eventos, faturamento e dados de cobrança, permitindo monitoramento eficiente e análise avançada.
-
-<LinkButton link="/pt-br/documentacao/devtools/graphql-api/" label="Ver detalhes" severity="secondary" />
-
-### SDK
-
-O SDK da Azion para Go simplifica o desenvolvimento de aplicações integradas à plataforma Azion. Permite gerenciar Applications, interagir com Object Storage, executar queries avançadas com SQL Database, automatizar tarefas e criar soluções serverless, otimizando fluxos de trabalho e produtividade para projetos de edge computing.
-
-<LinkButton link="/pt-br/documentacao/devtools/sdk/go/" label="Ver detalhes" severity="secondary" />
-
-### Terraform
-
-Terraform é uma ferramenta de infraestrutura como código que facilita a gestão da infraestrutura com código reutilizável, versionado e compartilhável. O Azion Terraform Provider, disponível no Terraform Registry, utiliza o SDK da Azion para Go para acessar as APIs Azion, possibilitando gerenciar sua infraestrutura Azion localmente como código, mantendo fluxos de trabalho consistentes e otimizados.
-
-<LinkButton link="/pt-br/documentacao/produtos/terraform-provider/" label="Ver detalhes" severity="secondary" />
+Relacionados: [Azion Runtime](/pt-br/documentacao/runtime/visao-geral/) · [SDK da Azion para Go](/pt-br/documentacao/produtos/azion-lib/visao-geral/) · [CLI open source no GitHub](https://github.com/aziontech/azion)
 
 ## Encontre a solução ideal para você
 
-### <i class='pi pi-code'></i> Desenvolvimento de Aplicações
-
-Construa aplicações escaláveis e com baixa latência usando edge computing e funções serverless.
-
-<LinkButton link="/pt-br/documentacao/arquiteturas/por-solucao/desenvolvimento-de-aplicacoes/" label="Ver detalhes" severity="secondary" />
-
-### <i class='pi pi-server'></i> Automação de Aplicações e Infraestrutura
-
-Automatize operações para otimizar a performance das aplicações e simplificar o gerenciamento da infraestrutura.
-
-<LinkButton link="/pt-br/documentacao/arquiteturas/por-solucao/automacao-de-aplicacoes-e-infraestrutura/" label="Ver detalhes" severity="secondary" />
-
-### <i class='ai ai-edge-firewall'></i> Segurança de Aplicações e Redes
-
-Proteja aplicações e redes contra ameaças com ferramentas de segurança e observabilidade nativas de edge.
-
-<LinkButton link="/pt-br/documentacao/arquiteturas/por-solucao/seguranca-de-aplicacoes-e-redes/" label="Ver detalhes" severity="secondary" />
-
-### <i class='pi pi-bolt'></i> Inteligência Artificial (AI)
-
-Implemente AI no edge para insights em tempo real, respostas rápidas e experiências personalizadas.
-
-<LinkButton link="/pt-br/documentacao/arquiteturas/por-solucao/inteligencia-artificial/" label="Ver detalhes" severity="secondary" />
-
-### <i class='pi pi-chart-line'></i> Performance e confiabilidade do serviço
-
-Melhore a performance das aplicações, reduza a latência e assegure a entrega confiável de serviços no edge.
-
-<LinkButton link="/pt-br/documentacao/arquiteturas/por-solucao/performance-e-confiabilidade-do-servico/" label="Ver detalhes" severity="secondary" />
-
-### Veja mais
-
-Consulte todas as soluções para casos de uso.
-
-<LinkButton link="/pt-br/documentacao/arquiteturas/" label="Ver detalhes" severity="secondary" />
-
-## Escolha sua jornada
-
-### <i class='ai ai-azion'></i> Visão geral da plataforma Azion
-
-Conheça a Azion Web Plataform e aprenda a utilizá-la.
-
-<LinkButton link="/pt-br/documentacao/produtos/visao-geral-da-plataforma-da-azion/" label="Ver detalhes" severity="secondary" />
-
-### <i class='ai ai-build-pillar'></i> Build
-
-Construa aplicações com ferramentas e frameworks poderosos.
-
-<LinkButton link="/pt-br/documentacao/produtos/guias/build/visao-geral/" label="Ver detalhes" severity="secondary" />
-
-### <i class='ai ai-store-pillar'></i> Store
-
-Gerencie e processe dados no edge.
-
-<LinkButton link="/pt-br/documentacao/produtos/store/visao-geral/" label="Ver detalhes" severity="secondary" />
-
-### <i class='ai ai-secure-pillar'></i> Secure
-
-Proteja totalmente suas aplicações.
-
-<LinkButton link="/pt-br/documentacao/produtos/secure/visao-geral/" label="Ver detalhes" severity="secondary" />
-
-### <i class='ai ai-deploy-pillar'></i> Deploy
-
-Gerencie recursos de edge de maneira eficiente.
-
-<LinkButton link="/pt-br/documentacao/produtos/deploy/visao-geral/" label="Ver detalhes" severity="secondary" />
-
-### <i class='ai ai-observe-pillar'></i> Observe
-
-Monitore e obtenha análises em tempo real.
-
-<LinkButton link="/pt-br/documentacao/produtos/observe/visao-geral/" label="Ver detalhes" severity="secondary" />
+<div class="grid gap-3 my-6 grid-cols-[repeat(auto-fill,minmax(280px,1fr))]">
+    <DocsCard link="/pt-br/documentacao/arquiteturas/por-solucao/desenvolvimento-de-aplicacoes/" title="Desenvolvimento de Aplicações" icon="pi pi-code" description="Construa aplicações escaláveis e com baixa latência usando edge computing e funções serverless." />
+    <DocsCard link="/pt-br/documentacao/arquiteturas/por-solucao/automacao-de-aplicacoes-e-infraestrutura/" title="Automação de Aplicações e Infraestrutura" icon="pi pi-server" description="Automatize operações para otimizar a performance das aplicações e simplificar o gerenciamento da infraestrutura." />
+    <DocsCard link="/pt-br/documentacao/arquiteturas/por-solucao/seguranca-de-aplicacoes-e-redes/" title="Segurança de Aplicações e Redes" icon="ai ai-edge-firewall" description="Proteja aplicações e redes contra ameaças com ferramentas de segurança e observabilidade nativas de edge." />
+    <DocsCard link="/pt-br/documentacao/arquiteturas/por-solucao/inteligencia-artificial/" title="Inteligência Artificial (AI)" icon="pi pi-bolt" description="Implemente AI no edge para insights em tempo real, respostas rápidas e experiências personalizadas." />
+    <DocsCard link="/pt-br/documentacao/arquiteturas/por-solucao/performance-e-confiabilidade-do-servico/" title="Performance e confiabilidade do serviço" icon="pi pi-chart-line" description="Melhore a performance das aplicações, reduza a latência e assegure a entrega confiável de serviços no edge." />
+    <DocsCard link="/pt-br/documentacao/arquiteturas/" title="Veja mais" icon="pi pi-compass" description="Consulte todas as soluções para casos de uso." />
+</div>
 
 ## O que há de novo?
 
-### <i class='pi pi-megaphone'></i> Release notes
+<div class="grid gap-3 my-6 grid-cols-[repeat(auto-fill,minmax(280px,1fr))]">
+    <DocsCard link="/pt-br/documentacao/produtos/release-notes/" title="Release notes" icon="pi pi-megaphone" description="Fique por dentro das últimas mudanças e lançamentos dos produtos e serviços Azion." />
+    <DocsCard link="https://discord.com/invite/Yp9N7RMVZy" title="Junte-se à Comunidade" icon="pi pi-discord" description="Participe: compartilhe experiências com a comunidade Azion no Discord." />
+</div>
 
-Fique por dentro das últimas mudanças e lançamentos dos produtos e serviços Azion.
-
-<LinkButton link="/pt-br/documentacao/produtos/release-notes/" label="Ver detalhes" severity="secondary" />
-
-### <i class='pi pi-discord'></i> Junte-se à Comunidade
-
-Compartilhe experiências com a comunidade Azion no Discord.
-
-<LinkButton link="https://discord.com/invite/Yp9N7RMVZy" label="Join" severity="secondary" />

--- a/src/content/docs/pt-br/homes/platform-home.mdx
+++ b/src/content/docs/pt-br/homes/platform-home.mdx
@@ -31,12 +31,12 @@ product_cards:
         title: Faturamento
         description: Contrate e ative produtos da Azion para sua conta.
         link: >-
-          /pt-br/documentacao/produtos/gestao-de-contas/billing-and-subscriptions/
+          /pt-br/documentacao/account/reference/billing-and-subscriptions/
       - icon: /assets/docs/images/uploads/icon-clients.svg
         title: Activity History
         description: Acesse o histórico de todas as atividades realizadas na conta.
         link: /pt-br/documentacao/produtos/gestao-de-contas/activity-history/
-  - title: Autenticação
+  - title: Autenticação e segurança de acesso
     cards:
       - icon: /assets/docs/images/uploads/icon-sso.svg
         title: Single Sign-On (SSO)
@@ -46,7 +46,15 @@ product_cards:
         title: Multi-Factor Authentication (MFA)
         description: Adicione uma camada extra de segurança de acesso ao Azion Console.
         link: >-
-          /pt-br/documentacao/produtos/gestao-de-contas/multi-factor-authentication/
+          /pt-br/documentacao/account/reference/multi-factor-authentication/
+      - icon: /assets/docs/images/uploads/icon-mfa.svg
+        title: Account Lockout Policy
+        description: Bloqueie contas após repetidas tentativas de login malsucedidas.
+        link: /pt-br/documentacao/produtos/gestao-de-contas/account-lockout-policy/
+      - icon: /assets/docs/images/uploads/icon-account.svg
+        title: User Session Timeout
+        description: Defina por quanto tempo uma sessão do Console permanece ativa antes de exigir nova autenticação.
+        link: /pt-br/documentacao/produtos/gestao-de-contas/user-session-timeout/
       - icon: /assets/docs/images/uploads/icon-teams-permissions.svg
         title: Social Login
         description: Faça login na Azion usando suas informações de outras redes sociais.


### PR DESCRIPTION
## What & why

Redesigns the documentation home (EN/PT) around visitor personas — hero with a first-deploy CTA, 5 "start here by profile" cards, and two new security-focused sections — plus the pillar-overview card strategy on the accounts and dev-tools homes. Also fixes page-title styling site-wide (h1s were being shrunk by the Tailwind preflight reset) and removes the redundant "Documentation Home" heading.

**Related issue:** NO-ISSUE
**Pages affected:**
- `/documentation/` + `/documentacao/` (`en/homes/home-docs.mdx`, `pt-br/homes/doc-home.mdx`)
- `/documentation/products/accounts/` + `/documentacao/produtos/gestao-de-contas/` (`platform-home.mdx`, both languages)
- `/documentation/devtools/` + `/documentacao/produtos/devtools/` (`dev-tools.mdx`, both languages)
- `src/components/PageContent/PageContent.astro`, `src/content/config.ts` (h1 sizing + `hide_title` support)

## Type of change

- [x] 🆕 New content (`feat`) — built from a content template
- [ ] 🩹 Fix (`fix`) — typo, broken link, wrong information
- [ ] ♻️ Content update (`docs`) — rewrite, expansion, upkeep
- [ ] 🌐 Translation sync (`i18n`)
- [x] 🏗️ Platform / structure (`refactor` / `chore`) — the PageContent h1 fix + `hide_title` schema flag

## Author checklist

- [x] PR title follows `type(scope): summary` (GOVERNANCE §4)
- [x] Frontmatter complete: `title`, `description`, `meta_tags`, `namespace`, `permalink` (`last_reviewed` is not part of this repo's schema); production permalinks unchanged
- [x] Style guide followed — no legacy "edge-" product names
- [x] How-to/tutorial includes ≥1 runnable code block — n/a, landing/overview pages
- [x] Screenshots (if any) have alt text — n/a, no in-content screenshots
- [x] Internal links are relative and resolve locally (`lint:linkcheck`: zero issues)
- [x] **Permalink changed or page moved → redirect included in this PR** — n/a, zero permalink changes (the accounts overview deliberately keeps its production permalink)
- [x] **i18n:** `pt-br` updated here — full parity, every card and section in both languages
- [x] `npm run build:local` passes (build + frontmatter) — ran as `astro build` + `npm run test:frontmatter` to avoid the `src/consts.ts` swap `build:local` performs

## Reviewer checklist

- [ ] Technically accurate (SME, if technical claims changed)
- [ ] Right place in the IA; discoverable from the relevant journey
- [ ] Reads at the level of surrounding docs (editorial)

## Notes for reviewers

- **Stacked on #2296 (Get started pages)** — merge that first (the home's CTA and persona cards link to those pages). Independent of the sidebar PR; they can land in either order.
- All internal links (124 distinct) resolve to existing production pages; `lint:linkcheck` passes with zero issues.
- Accounts overview gains two cards (**Account Lockout Policy**, **User Session Timeout**) and a renamed section ("Authentication and access security"); dev-tools' Go SDK card now points at the Azion Lib overview.
- The h1 fix (`text-4xl font-medium mb-8` in `PageContent.astro`) affects every docs page: the h1 sits outside the `.prose` article, so the Tailwind preflight reset was rendering titles at body size. The new `hide_title` frontmatter flag (declared in `config.ts`) lets the docs homes suppress the "Documentation Home" heading under the hero.
- `astro check`/`tsc` fail on `main` today (141/78 pre-existing errors); this PR adds zero new errors.

Accounts Overview:
<img width="1568" height="722" alt="pr2-accounts-overview-cards" src="https://github.com/user-attachments/assets/a3d1a6ca-08a8-48a2-a2a9-231f409074b1" />
Hero Personas: 
<img width="1568" height="722" alt="pr2-home-hero-personas" src="https://github.com/user-attachments/assets/9cf46ca1-08bc-4c00-938a-73ed4744b5f2" />
Home Sections:
<img width="1568" height="722" alt="pr2-home-new-security-sections" src="https://github.com/user-attachments/assets/29799b7a-a455-47e1-8b54-511d09b71bd2" />

