### PR TITLE
Feat(secure): add WAAP reference page

### DIFF
--- a/src/content/docs/en/pages/waap/index.mdx
+++ b/src/content/docs/en/pages/waap/index.mdx
@@ -1,0 +1,61 @@
+---
+title: Web Application and API Protection (WAAP)
+description: >-
+  Reference of Azion WAAP capabilities, covering mTLS for origins, automatic
+  API discovery, Shadow and Zombie API control, and OpenAPI/Swagger schema
+  validation.
+meta_tags: 'azion, waap, security, api security, mtls, api discovery'
+namespace: documentation_waap
+permalink: /documentation/products/secure/waap/
+---
+
+Azion **Web Application and API Protection (WAAP)** protects applications and APIs delivered through the Azion Web Platform. This page describes Azion's mTLS capabilities for origin authentication and the WAAP capabilities for API security: discovery, inventory control, and schema validation.
+
+## mTLS capabilities for origins; key management and rotation
+
+Azion supports **Mutual TLS (mTLS)** to authenticate connections between clients, the edge, and protected applications using digital certificates. Authentication is based on X.509 certificates and Trusted CAs: the certificate chain of trust is validated and only authorized identities are accepted.
+
+Certificates are managed centrally in **Azion Certificate Manager**, which registers, associates, updates, and controls the certificates used in mTLS policies. Certificates can be replaced periodically, so credentials rotate without changes to the protected application.
+
+The following attributes of the client certificate are available to security policies and can be forwarded to the origin application:
+
+- Fingerprint
+- Subject DN
+- Issuer
+- Serial number
+- Validity period
+
+## Automatic API discovery (API Discovery)
+
+**API Discovery** automatically discovers and maps the APIs exposed and used by protected applications, based on their traffic.
+
+For each API, discovery identifies:
+
+- Endpoints
+- HTTP methods
+- Request patterns and other traffic characteristics
+
+The result is a continuously updated inventory of the APIs in use, including APIs that aren't documented or weren't previously known (*Shadow APIs*). The inventory serves as input for monitoring, security analysis, and protection policies.
+
+## Shadow / Zombie API control
+
+Using API Discovery data, Azion WAAP identifies and monitors two categories of API exposure:
+
+- **Shadow APIs**: APIs that are undocumented, unknown, or in use outside the official inventory.
+- **Zombie APIs**: legacy endpoints, or endpoints that should have been deactivated but still respond.
+
+Both categories can be monitored, analyzed, and covered by protection policies. This makes it possible to detect unauthorized exposure, reduce the attack surface, and keep the API lifecycle under control.
+
+## Validation against OpenAPI/Swagger schema
+
+Azion WAAP validates incoming requests against the API contract defined in an **OpenAPI/Swagger schema**. Each request is compared with the specification expected for the API it targets.
+
+Validation covers:
+
+- Endpoints
+- HTTP methods
+- Parameters
+- Headers
+- Request structure and content
+
+Requests that don't conform to the schema can be blocked or handled by protection policies, preventing calls outside the defined contract, including malformed requests and misuse of endpoints.

--- a/src/content/docs/pt-br/pages/waap/index.mdx
+++ b/src/content/docs/pt-br/pages/waap/index.mdx
@@ -1,0 +1,61 @@
+---
+title: Web Application and API Protection (WAAP)
+description: >-
+  Referência das capacidades do Azion WAAP, cobrindo mTLS para origens,
+  descoberta automática de APIs, controle de Shadow e Zombie APIs e validação
+  contra schema OpenAPI/Swagger.
+meta_tags: 'azion, waap, segurança, api security, mtls, api discovery'
+namespace: documentation_waap
+permalink: /documentacao/produtos/secure/waap/
+---
+
+O **Web Application and API Protection (WAAP)** da Azion protege aplicações e APIs entregues pela Azion Web Platform. Esta página descreve as capacidades de mTLS da Azion para autenticação de origens e as capacidades do WAAP para segurança de APIs: descoberta, controle de inventário e validação de schema.
+
+## Capacidades de mTLS para origens; gestão e rotação de chaves
+
+A Azion oferece suporte a **Mutual TLS (mTLS)** para autenticar conexões entre clientes, o edge e as aplicações protegidas usando certificados digitais. A autenticação é baseada em certificados X.509 e Trusted CAs: a cadeia de confiança do certificado é validada e apenas identidades autorizadas são aceitas.
+
+Os certificados são gerenciados centralmente no **Azion Certificate Manager**, que cadastra, associa, atualiza e controla os certificados usados nas políticas de mTLS. Os certificados podem ser substituídos periodicamente, permitindo a rotação de credenciais sem alterações na aplicação protegida.
+
+Os seguintes atributos do certificado do cliente ficam disponíveis para as políticas de segurança e podem ser encaminhados à aplicação de origem:
+
+- Fingerprint
+- Subject DN
+- Emissor
+- Número de série
+- Período de validade
+
+## Descoberta automática de APIs (API Discovery)
+
+O **API Discovery** descobre e mapeia automaticamente as APIs expostas e utilizadas pelas aplicações protegidas, com base no tráfego delas.
+
+Para cada API, a descoberta identifica:
+
+- Endpoints
+- Métodos HTTP
+- Padrões de requisição e demais características do tráfego
+
+O resultado é um inventário continuamente atualizado das APIs em uso, incluindo APIs não documentadas ou até então desconhecidas (*Shadow APIs*). O inventário serve de insumo para monitoramento, análise de segurança e políticas de proteção.
+
+## Controle de Shadow / Zombie APIs
+
+A partir dos dados do API Discovery, o Azion WAAP identifica e monitora duas categorias de exposição de APIs:
+
+- **Shadow APIs**: APIs não documentadas, desconhecidas ou em uso fora do inventário oficial.
+- **Zombie APIs**: endpoints legados, ou que deveriam estar desativados mas ainda respondem.
+
+As duas categorias podem ser monitoradas, analisadas e cobertas por políticas de proteção. Isso permite detectar exposições não autorizadas, reduzir a superfície de ataque e manter o ciclo de vida das APIs sob controle.
+
+## Validação contra schema OpenAPI/Swagger
+
+O Azion WAAP valida as requisições recebidas contra o contrato da API definido em um **schema OpenAPI/Swagger**. Cada requisição é comparada com a especificação esperada para a API de destino.
+
+A validação cobre:
+
+- Endpoints
+- Métodos HTTP
+- Parâmetros
+- Headers
+- Estrutura e conteúdo da requisição
+
+Requisições que não estejam em conformidade com o schema podem ser bloqueadas ou tratadas por políticas de proteção, impedindo chamadas fora do contrato definido, incluindo requisições malformadas e uso indevido de endpoints.


### PR DESCRIPTION
## What & why

Adds a reference page describing Azion **Web Application and API Protection (WAAP)** capabilities — mTLS for origins with key management and rotation, automatic API discovery, Shadow/Zombie API control, and validation against OpenAPI/Swagger schemas — in EN and PT-BR.

The page is served at its URL but is not linked from any menu, page, or navigation.

**Related issue:** NO-ISSUE
**Pages affected:**
- `/documentation/products/secure/waap/` (new)
- `/documentacao/produtos/secure/waap/` (new)

## Type of change

- [x] 🆕 New content (`feat`) — built from a content template
- [ ] 🩹 Fix (`fix`) — typo, broken link, wrong information
- [ ] ♻️ Content update (`docs`) — rewrite, expansion, upkeep
- [ ] 🌐 Translation sync (`i18n`)
- [ ] 🏗️ Platform / structure (`refactor` / `chore`) — UXE review, no content mixed in

## Author checklist

- [x] PR title follows `type(scope): summary` (GOVERNANCE §4)
- [x] Frontmatter complete: `title`, `description`, `meta_tags`, `namespace`, `permalink`
- [x] Style guide followed — no legacy "edge-" product names
- [x] How-to/tutorial includes ≥1 runnable code block — n/a, reference page with no code
- [x] Screenshots (if any) have alt text — n/a, no screenshots
- [x] Internal links are relative and resolve locally — n/a, the page contains no internal links
- [x] **Permalink changed or page moved → redirect included in this PR** — n/a, net-new pages only
- [x] **i18n:** `pt-br` updated here — both languages mirrored
- [x] `npm run build:local` passes (build + frontmatter) — ran as `astro build` + `npm run test:frontmatter` to avoid the `src/consts.ts` swap `build:local` performs

## Reviewer checklist

- [ ] Technically accurate (SME, if technical claims changed)
- [ ] Right place in the IA; discoverable from the relevant journey
- [ ] Reads at the level of surrounding docs (editorial)

## Notes for reviewers

- Content-only PR: two new MDX files, no code or navigation changes.
- The page is intentionally not added to any sidebar menu.
