### PR TITLE
docs(sql-database): remove Preview tag from Vector Search reference

### DIFF
--- a/src/content/docs/en/pages/main-menu/reference/store/edge-sql/vector-search.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/store/edge-sql/vector-search.mdx
@@ -6,10 +6,6 @@ namespace: documentation_edge_sql_vector_search
 permalink: /documentation/products/store/sql-database/vector-search/
 ---
 
-import Tag from 'primevue/tag';
-
-<Tag severity="info" client:only="vue" value="Preview" />
-
 **Vector Search** is an **Azion SQL Database** feature that enables customers to implement semantic search engines. While traditional search models aim to find exact matches, such as keyword matches, vector search models use specialized algorithms to identify similar items based on their mathematical representations, or vector embeddings.
 
 By using Vector Search, you can implement various use cases:

--- a/src/content/docs/pt-br/pages/menu-principal/referencia/store/edge-sql/vector-search.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/referencia/store/edge-sql/vector-search.mdx
@@ -6,10 +6,6 @@ namespace: documentation_edge_sql_vector_search
 permalink: /documentacao/produtos/store/sql-database/vector-search/
 ---
 
-import Tag from 'primevue/tag';
-
-<Tag severity="info" client:only="vue" value="Preview" />
-
 **Vector Search** é um recurso do **SQL Database da Azion** que permite aos clientes implementar mecanismos de busca semântica. Enquanto os modelos de busca tradicionais visam encontrar correspondências exatas, como correspondências de palavras-chave, os modelos de busca vetorial usam algoritmos especializados para identificar itens semelhantes com base em suas representações matemáticas, ou embeddings vetoriais.
 
 Ao usar o Vector Search, você pode implementar vários casos de uso:


### PR DESCRIPTION
SQL Database Vector Search is no longer in Preview, so drop the badge from the EN and PT-BR reference pages.

<!--
Thank you for contributing to Azion Docs! Please fill out the information below.
Use the conventional commits standard to categorize the type of change in the PR title. We recommend:
- feat: adding new content
- refactor: making minor changes
- fix: fixing errors

Don't forget to add the Jira issue code to the PR title or the GitHub issue hash.
For example: 
- [EDU-3000] refactor: modify origins page to include load balancer
- [#34] feat: add new application CLI commands
- [NO-ISSUE] fix: fix broken link in Orch doc
-->

### Related issue: <!-- Link any existing GitHub or Jira issues related to the change. -->

### Changes

<!-- List and describe the major changes that this PR will implement. -->

### Additional links

<!-- You may add any links you believe relevant here, like message threads, external documentation, other issues, etc. -->


[EDU-3000]: https://aziontech.atlassian.net/browse/EDU-3000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ