### PR TITLE
chore(tooling): add release-notes-writer Claude Code skill

### DIFF
--- a/.claude/skills/release-notes-writer/SKILL.md
+++ b/.claude/skills/release-notes-writer/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: release-notes-writer
+description: Turn a raw set of changelogs, PR/commit titles, Jira-linked tickets, or internal engineering deploy digests into formatted, customer-facing release notes entries for the Azion docs site, in both published languages (en, pt-br). Use when the user provides changelog content and asks to draft, write, format, filter, or add release notes, or asks to update release-notes.mdx, for one or more dates.
+---
+
+# Release Notes Writer
+
+Converts raw/informal changelog input — including internal engineering digests with Jira ticket IDs and Slack noise — into the exact MDX shape used in this repo's live release notes page, for both `en` and `pt-br`, following fixed rules mined from the most recently published entries (see `references/formatting-rules.md`).
+
+## Non-negotiable rules
+
+1. **Only propose customer-facing items.** Internal-only engineering work (refactors, migrations, internal tooling) does not belong in release notes. If you're not sure whether something is customer-facing enough to include, **ask the user** — never guess silently in either direction. See `references/customer-facing-filter.md`.
+2. **Never expose internal information**: Jira/ticket IDs, person names (authors, assignees, reviewers), or component/service/variable names that aren't part of Azion's public product vocabulary. See `references/customer-facing-filter.md` for the redaction list and the grep-based check for "is this term actually public."
+3. **When a Jira issue is referenced, look it up** to understand the real customer-facing scope of the change before writing the note — a terse commit message is rarely enough on its own. Apply rules 1 and 2 to whatever you learn from the ticket; the ticket's internal detail is context for you, not content for the note. See `references/jira-enrichment.md`.
+4. **Never run `git commit` (or `git push`) as part of this skill unless the user explicitly asks for a commit in this conversation.** Editing `release-notes.mdx` in the working tree is in scope; staging and committing is not. Leave the changes uncommitted so the user can review the diff themselves — do not treat "insert into the files" as implied permission to also commit them.
+
+## Files this skill maintains
+
+| Language | Path |
+|---|---|
+| en | `src/content/docs/en/pages/main-menu/release-notes/release-notes.mdx` |
+| pt-br | `src/content/docs/pt-br/pages/menu-principal/release-notes/release-notes.mdx` |
+
+Only these two languages exist in this repo (`src/i18n/languages.ts`). If the user asks for Spanish or another language, tell them there is no `es` content collection yet — adding one is a separate, larger task (new collection, nav entry, i18n config), not something this skill does.
+
+## Workflow
+
+1. **Strip noise and triage the raw input** per `references/customer-facing-filter.md`: drop Slack emoji/process labels, then classify every item as **Include** / **Exclude** / **Ask**. Collect every "Ask" item into a single short list for the user — do not proceed to drafting individual ambiguous items until the user has answered, but you can draft the unambiguous "Include" items in the same turn.
+
+2. **Enrich Jira-linked items** per `references/jira-enrichment.md`: detect issue keys (`[A-Z][A-Z0-9]{1,9}-\d+`), look up each via the Jira MCP tools when the commit message alone doesn't clearly convey customer impact, and use the ticket only to understand the real-world scenario — never to source ticket IDs, names, or internal fields for the output.
+
+3. **Redact** per `references/customer-facing-filter.md` step 2: no ticket IDs, no person names, no internal component/service/variable names. When a name's public-ness is unclear, grep `src/content/docs/en` for it before deciding.
+
+4. **Read `references/formatting-rules.md` fully before drafting anything.** It contains the fixed heading formats, canonical product/category names, translation rules, and what must stay untranslated. These rules were extracted directly from the live file's most recent entries — do not deviate from them or invent new conventions unless the raw input clearly needs a new product-area heading (rule 4 allows exactly one degree of freedom there).
+
+5. **Structure the surviving (Include) items** into:
+   - date(s) — one dated section per distinct date, newest last if the user gives multiple (you'll place them newest-first in the file)
+   - product/area per item → map to the canonical H3 list in rules §4
+   - category per item → map to one of `Features` / `Improvements` / `Bug Fixes` / `Updates` / `Versions shipped` (rules §5), or a free-form H4 if it's a single named feature announcement
+   - version number, if the product/change is versioned
+   - whether it needs a `<Tag>` badge (`Preview`, `Deprecated`, `Breaking Changes` — rules §6)
+
+6. **Draft the English MDX block first.** Follow rules §3 (date heading), §4 (H3 + optional version line), §5 (H4 category), §6 (`<Tag>`), §7 (bullet/prose style). Check `references/worked-example.md` for concrete before/after shapes if unsure how to structure a multi-product or versioned entry.
+
+7. **Translate to pt-br from the drafted English block** (not from the raw input again) so both languages stay structurally identical section-by-section. Apply the translation table in rules §5/§6 and the "never translate" list in rules §8 (product names, package names, version numbers, code identifiers, URLs, and the specific terms `Updates` / `Breaking Changes` which stay in English by convention).
+
+8. **Show both drafted blocks to the user for review** before touching the files, unless they've explicitly asked you to insert directly.
+
+9. **Insert into both files** at the point described in rules §2 (prepend as a new `---`-led block, right after the `import Tag ...` line and before the file's current first `---`). Use the Edit tool on both files. Do not touch the frontmatter, the import line, or any existing dated section — this is a pure prepend.
+
+10. **Sanity check after inserting**: grep the new H2/H3/H4 headings back out of both files to confirm they match between languages and that no stray separator or duplicate `---` was introduced.
+
+11. **Stop there.** Report what was inserted and leave the working tree as an uncommitted change (per non-negotiable rule 4) — do not run `git add`/`git commit`/`git push` unless the user asks for it in this conversation.
+
+## Notes
+
+- If the raw changelog spans multiple dates, create one full dated block per date, most recent date inserted closest to the top (i.e., processed/inserted last, or inserted first in reverse order — either way, verify the final file has newest date first).
+- If an item doesn't cleanly map to an existing canonical product/category, ask the user only if genuinely ambiguous; otherwise pick the closest canonical match per the rules rather than inventing a new taxonomy.
+- Never fabricate details (version numbers, endpoint paths, metrics) not present in the raw input — ask the user if something needed for the fixed format (e.g. a version number for a versioned product) is missing.
+- A short, accurate list of release notes is correct output for a noisy engineering digest — don't pad it with excluded/uncertain items to look complete.

--- a/.claude/skills/release-notes-writer/references/customer-facing-filter.md
+++ b/.claude/skills/release-notes-writer/references/customer-facing-filter.md
@@ -1,0 +1,81 @@
+# Customer-facing filter and redaction rules
+
+These rules apply to raw input that looks like an internal engineering digest (Slack deploy summary, PR/commit list, sprint changelog) — the kind of input that mixes customer-visible changes with pure internal engineering work, ticket IDs, and Slack noise. They are mandatory, not optional style advice.
+
+## Step 0 — strip formatting noise
+
+Before classifying anything, discard: Slack emoji shortcodes (`:sparkles:`, `:bug:`, `:hmm:`, `:tada:`, etc.), section labels that are just process categories (`Feat:`, `Fix:`, `Refactor:`, `Chore:`), and any `[TICKET-ID]` or `[NO-ISSUE]` prefix. None of this is customer-facing content — it's raw material to classify, not text to reuse.
+
+## Step 1 — classify every remaining item: Include / Exclude / Ask
+
+| Classify as | When |
+|---|---|
+| **Include** | The item describes a behavior, UI, API, or capability change an Azion customer can observe or is directly affected by — a new feature, a visible bug fix, a documented API/CLI change. |
+| **Exclude by default** | The item is a pure internal refactor, code migration, internal service rename, test hardening, or internal tooling change with no stated customer-visible effect. Commit labeled `Refactor:` / `Chore:` is a strong signal, but not automatic — read the description for a customer-visible side effect before excluding. |
+| **Ask the user** | Anything you cannot confidently place in the two rows above: cosmetic/low-severity fixes where "is this release-note worthy" is a product-owner call, infra/routing changes where customer impact is unclear, or a `Refactor:`-labeled item that also mentions a UI/behavior change. **Do not guess — surface these to the user as a short list and let them decide include/exclude**, per the skill's rule 1. |
+
+Never silently include something you're unsure about, and never silently pad the notes with internal work to look more comprehensive — a shorter, accurate list is correct behavior, not an incomplete one.
+
+## Step 2 — redact/never expose
+
+Strip these from the final release note text even when they appear in the raw input or in a linked Jira ticket:
+
+- **Ticket/issue IDs** — `ENG-46685`, `NO-ISSUE`, Jira keys of any project prefix. Look up the ticket for context (see `jira-enrichment.md`), but the key itself never appears in the published note.
+- **Person names** — commit authors, Jira reporters/assignees, reviewer names, Slack handles/@mentions. Customer-facing notes describe what changed, never who changed it.
+- **Internal-only component/service/variable names** — internal microservice names, internal library/vendor integrations, internal feature-flag names, internal file/variable identifiers (e.g. "DeviceAtlas variable", "feedback service v2", internal queue/table names). If the raw text names something like this, either omit the detail entirely or restate the change in terms of customer-visible effect only.
+- **Internal implementation reasoning** that isn't needed to understand the fix, e.g. "single source of truth for account identity" — keep the customer-visible symptom and resolution, drop the internal design rationale.
+
+### How to tell "public Azion term" from "internal-only name" — grep, don't guess
+
+Before using any product/feature/component name in a release note, confirm it's real Azion public vocabulary by grepping the docs tree itself:
+
+```bash
+grep -rl "<term>" src/content/docs/en
+```
+
+- If it shows up in public docs (e.g. `WAF Tuning`, `Real-Time Events`, `Single Sign-On`) — safe to use verbatim.
+- If it returns nothing (e.g. `DeviceAtlas`, `feedback service`) — treat it as internal. Either drop that detail or, only if truly needed to explain customer impact, describe it generically without the internal name (e.g. instead of "removed DeviceAtlas variable from rules engine form fields," you'd need a customer-visible reason to write anything at all — if there isn't one, this item is **Exclude**, not a rewording exercise).
+
+This grep is the fixed, repeatable check — don't rely on judgment alone for whether a name is "public enough."
+
+## Worked triage — the Console deploy digest example
+
+Given a raw digest like:
+
+```
+Azion Console - DEPLOY :hmm:
+:sparkles: Feat:
+Feat: Real Time Events Improvements
+:bug: Fix:
+[ENG-46685] Fix: switch account keeps stale account (single source of truth for account identity)
+[ENG-46609] Fix: prevent long email overflow in profile menu
+[ENG-46594] Fix: resolve search returning error
+[NO-ISSUE] Fix: exclude /sse from index.html redirect rule
+[ENG-37279] Fix: render external sidebar links as anchors to avoid 404 on current tab
+[ENG-37439] Fix: Domain not showing in WAF Tuning listing due to pagination
+[ENG-46386] Fix: unsaved changes prompt shown on domain edit without modifications
+[ENG-37379] fix: send active federated IdP id on Azion SSO rollback
+:sparkles: Refactor:
+[ENG-46254] Refactor: migrate feedback service to v2 and improve feedback dialog
+[ENG-46653] Refactor: remove DeviceAtlas variable from rules engine form fields
+[ENG-46968] Refactor: harden real-time-events filters and WAF domain pagination
+```
+
+Triage:
+
+| Item | Classification | Why |
+|---|---|---|
+| Real Time Events Improvements | Include (enrich if a ticket existed — here there isn't one, so ask the user for specifics if too vague to write a concrete bullet) | Matches existing public "Real-Time Events" area, customer-visible |
+| switch account keeps stale account | Include | Customer sees wrong account data after switching — clear customer impact. Drop "(single source of truth for account identity)" — internal rationale |
+| prevent long email overflow in profile menu | **Ask** | Cosmetic/low-severity UI fix — relevance is a judgment call, ask before including |
+| resolve search returning error | Include | Broken customer-facing search feature |
+| exclude /sse from index.html redirect rule | **Ask** | Infra/routing-level change, unclear if customers ever hit this — surface it rather than guessing |
+| render external sidebar links as anchors to avoid 404 | Include | Customer-visible broken link/404 fixed |
+| Domain not showing in WAF Tuning listing due to pagination | Include | `WAF Tuning` is public vocabulary (confirmed via grep); pagination bug hid real customer data |
+| unsaved changes prompt shown without modifications | Include | Annoying but real, observable UX bug |
+| send active federated IdP id on Azion SSO rollback | Include, but look up the Jira ticket first | Commit message is too technical to write a customer-facing sentence from directly — needs enrichment (see `jira-enrichment.md`) to state the actual customer-visible SSO symptom |
+| migrate feedback service to v2 and improve feedback dialog | **Ask** (lean Exclude for the migration half) | "feedback service" is internal (not in public docs); "improve feedback dialog" might be customer-visible — ask the user whether the dialog change is worth a note |
+| remove DeviceAtlas variable from rules engine form fields | Exclude | `DeviceAtlas` is internal (not in public docs), no stated customer-visible effect |
+| harden real-time-events filters and WAF domain pagination | **Ask** | Could overlap with the pagination bug already fixed above, or be internal-only hardening — ask rather than risk a duplicate or an internal-only entry |
+
+Note how many items end up **Ask** or **Exclude** here — that's expected for a raw engineering digest. A high inclusion rate is a signal you didn't filter carefully enough.

--- a/.claude/skills/release-notes-writer/references/formatting-rules.md
+++ b/.claude/skills/release-notes-writer/references/formatting-rules.md
@@ -1,0 +1,103 @@
+# Release notes formatting rules
+
+Derived from the actual published entries in both language files as of 2026-07. When in doubt, grep the live file for a precedent before inventing a new convention:
+
+```bash
+grep -n "^### " src/content/docs/en/pages/main-menu/release-notes/release-notes.mdx | sort | uniq -c | sort -rn
+```
+
+## 1. File locations (single source of truth per language — no per-date files)
+
+| Language | Path |
+|---|---|
+| en | `src/content/docs/en/pages/main-menu/release-notes/release-notes.mdx` |
+| pt-br | `src/content/docs/pt-br/pages/menu-principal/release-notes/release-notes.mdx` |
+
+Only these two languages are published in this repo (see `src/i18n/languages.ts`). There is no `es` collection — do not create one unless the user explicitly asks to add Spanish as a new locale (that's a larger, separate task: new content collection, nav entry, i18n config).
+
+## 2. Insertion point (always prepend, never append)
+
+Entries are in reverse-chronological order. The file starts with:
+
+```
+---
+title: Release notes
+...
+---
+import Tag from 'primevue/tag'
+
+
+---
+## <newest existing date heading>
+...
+```
+
+To add a new dated entry, insert a new block **between the blank lines after `import Tag ...` and the existing first `---`**, following this exact shape:
+
+```
+---
+## <New Date Heading>
+
+<body>
+
+```
+
+The existing first `---` then becomes the separator before the *previous* newest entry — do not duplicate it or remove it.
+
+## 3. Date heading (H2, `##`)
+
+- English: `## Month D, YYYY` — e.g. `## July 10, 2026`. Full month name, no leading zero on day, comma before year.
+- pt-br: `## D de month, YYYY` — e.g. `## 10 de julho, 2026`. Month name lowercase, no leading zero on day, comma before year.
+- If a single push covers more than one date, give each date its own `##` section (do not merge dates), each preceded by its own `---` separator, newest first.
+
+## 4. Product/area heading (H3, `###`)
+
+Canonical names — reuse verbatim in **both** languages (product names are proper nouns, not translated):
+
+Azion CLI · Azion Console · Azion API (use singular "API", not "APIs", for new entries — "Azion APIs" appears once historically but singular is now the dominant form) · Marketplace · Terraform Provider · Edge Functions · Edge Application · Edge Firewall · Data Stream · GraphQL API · Real-Time Metrics · Real-Time Events · DevTools & Integrations · Object Storage · API v4 (Preview)
+
+Rules:
+- Match an existing heading exactly if the change belongs to a product already in the list above (fixes prior casing drift like "Console" vs "Azion Console" or "Bug fixes" vs "Bug Fixes" — always use the canonical form).
+- If the change is versioned (CLI, Terraform Provider), add a `**Version X.Y.Z**` line directly under the H3, on its own line, before the first H4.
+- If the change is a set of package releases (e.g. DevTools & Integrations), list them under an H4 `#### Versions shipped` (pt-br: `#### Versões lançadas`) as `- **@scope/pkg-name**: X.Y.Z`.
+- One new product area not on the canonical list is fine (the corpus keeps growing) — pick a short, title-cased, human name consistent with the others; do not invent a category system beyond this.
+
+## 5. Category heading (H4, `####`) and its EN → pt-br translation
+
+Only these four are standardized; use them whenever the change fits:
+
+| English | pt-br | Meaning |
+|---|---|---|
+| `#### Features` | `#### Recursos` | New capability |
+| `#### Improvements` | `#### Melhorias` | Enhancement to existing behavior |
+| `#### Bug Fixes` | `#### Correções de Bugs` | Fix |
+| `#### Updates` | `#### Updates` | General/miscellaneous change — **left untranslated in pt-br by established convention**, do not translate it |
+| `#### Versions shipped` | `#### Versões lançadas` | Package/dependency version list |
+
+If a change doesn't fit any of these, use the specific feature/product name itself as the H4 (as seen in the corpus, e.g. `#### Send Event function`, `#### Solution deprecations`) — translate this free-form H4 text into pt-br like normal prose, keeping any product/code names untouched.
+
+## 6. `<Tag>` badges
+
+Only use for these three statuses, exact component shape (props are never translated, only the label text is):
+
+```mdx
+<Tag severity="info" client:only="vue">Preview</Tag>          → <Tag severity="info" client:only="vue">Preview</Tag>
+<Tag severity="info" client:only="vue">Deprecated</Tag>        → <Tag severity="info" client:only="vue">Descontinuado</Tag>
+<Tag severity="warning" client:only="vue">Breaking Changes</Tag> → <Tag severity="warning" client:only="vue">Breaking Changes</Tag>
+```
+
+(Note: "Breaking Changes" has historically been left untranslated too — keep it as-is in pt-br.) Place the tag on its own line, directly under the H4 it qualifies, before the descriptive paragraph. Requires `import Tag from 'primevue/tag'` at the top of the file — already present, do not duplicate the import.
+
+## 7. Body prose and bullet style
+
+- Bullets: `- **Short Name**: Sentence in past tense, ending with a period.` — bold lead-in noun phrase, colon, then a plain-English/plain-Portuguese description of what shipped. Standardize this even though older entries are inconsistent about trailing punctuation.
+- Use past tense verbs for what changed: Added, Improved, Fixed, Released, Updated, Removed, Deprecated — never imperative ("Add X"), never future tense.
+- When a product needs a one-line scope statement before its bullets (common for API entries), use the established phrasing pattern: `Updates deployed to \`api.azion.com/v4/\`:` (pt-br: `Atualizações implementadas em \`api.azion.com/v4/\`:`).
+- Inline code (`` `field_name` ``, endpoints, flags, config keys), version numbers, URLs, and product/company names are never translated and never reformatted — copy verbatim into the pt-br block.
+- Links: `[link text](url)` — translate the link text, keep the URL unchanged.
+- Nested sub-bullets (e.g. old-name → new-name alias mappings) are indented two spaces under their parent bullet, same format in both languages.
+- Section separator between dated entries is a bare `---` line, with exactly one blank line before it and none after (before the next `##`).
+
+## 8. What never changes between languages
+
+Product names, package names (`@aziontech/...`), version numbers, endpoint paths, config/field/flag identifiers in backticks, URLs, `<Tag>` component props (only the label text translates), and the `Updates`/`Breaking Changes` heading/tag text (kept in English by convention).

--- a/.claude/skills/release-notes-writer/references/jira-enrichment.md
+++ b/.claude/skills/release-notes-writer/references/jira-enrichment.md
@@ -1,0 +1,36 @@
+# Jira enrichment
+
+When raw input references a Jira issue (e.g. `[ENG-46685]`, `ENG-37379`), look it up before writing the note whenever the commit-message text alone isn't enough to describe the customer-visible impact clearly. Terse engineering shorthand ("send active federated IdP id on Azion SSO rollback") almost never is — enrich it.
+
+## Detecting issue keys
+
+Match `[A-Z][A-Z0-9]{1,9}-\d+` in the raw input. This naturally excludes placeholders like `[NO-ISSUE]` (no trailing digits). Strip the brackets to get the key, e.g. `[ENG-46685]` → `ENG-46685`.
+
+## Looking up the issue
+
+Use the Jira MCP tools (load schemas first with `ToolSearch("select:mcp__jira__getJiraIssue")` or search by key with `mcp__jira__searchJiraIssuesUsingJql`). Fetch the issue's summary and description to understand:
+
+- What the actual user-facing symptom was (not just the internal fix description)
+- Whether it's customer-facing at all — some tickets that look like bugs from the commit message turn out to be pure internal/infra work once you read the full description, and vice versa
+- Any acceptance criteria or repro steps that clarify the real-world scenario a customer hit
+
+If the lookup fails (no access, issue not found, or the MCP tools aren't available in this session), fall back to the commit message alone, and if it's still too ambiguous to state a clear customer impact, treat the item as **Ask** per `customer-facing-filter.md` rather than inventing detail.
+
+## What to carry over from the ticket — and what never to carry over
+
+Carry over: the plain-language description of the customer-visible symptom and the fix, translated into the same past-tense bullet style as the rest of the release notes (see `formatting-rules.md` §7).
+
+Never carry over, even though it's sitting right there in the ticket:
+- The issue key itself (`ENG-46685`) — never appears in the published note (`customer-facing-filter.md` step 2)
+- Reporter, assignee, or any commenter names
+- Internal component/service names that don't grep-match in `src/content/docs/en` (same check as `customer-facing-filter.md`)
+- Internal-only fields: sprint name, story points, internal Slack thread links, linked internal tickets
+- Root-cause engineering detail that isn't needed to understand the customer impact (stack traces, internal variable names, internal architecture rationale)
+
+## Example
+
+Ticket `ENG-37379`, summary/description (hypothetical shape of what you'd read back): "During SSO rollback, the app sent the previously active federated IdP's ID instead of the newly selected one, causing some users to be authenticated against the wrong identity provider after an admin reverted an SSO configuration change."
+
+Customer-facing rewrite: `- **SSO Rollback**: Fixed an issue where rolling back an SSO configuration change could authenticate users against the wrong identity provider.`
+
+No ticket ID, no internal field/variable names, no reporter — just the customer-visible symptom and that it's fixed.

--- a/.claude/skills/release-notes-writer/references/worked-example.md
+++ b/.claude/skills/release-notes-writer/references/worked-example.md
@@ -1,0 +1,132 @@
+# Worked example
+
+Input the user might give (raw, informal changelog dump for one date):
+
+```
+July 10, 2026
+- marketplace: removed Saffe Liveness Detection, Saffe Face Detection, Saffe ID Matching integrations,
+  they're deprecated, existing installs keep working, just no new installs
+- Bot Manager 1.3.0 / Bot Manager Lite 0.2.0 released. 9 new static rules, new good_fingerprint_list arg
+  (bypass validation for listed fingerprints), new block_ai_bots arg (auto-block known AI user agents).
+  Lite available via marketplace console link, standard version on request via Service Delivery
+```
+
+## Expected English output block
+
+```mdx
+---
+## July 10, 2026
+
+### Marketplace
+
+#### Solution deprecations
+
+<Tag severity="info" client:only="vue">Deprecated</Tag>
+
+The following integrations have been deprecated and removed from Azion Marketplace:
+
+- Saffe Liveness Detection
+- Saffe Face Detection
+- Saffe ID Matching
+
+These integrations are being retired because they no longer integrate with the platform as well as they used to. If you already have any of them installed, they'll continue working as expected — only new installations are blocked.
+
+#### Bot Manager 1.3.0 and Bot Manager Lite 0.2.0
+
+New versions of **Bot Manager** are available for both the Lite and standard (formerly "Advanced") plans. Highlights include:
+
+- Nine new static rules.
+- A new `good_fingerprint_list` argument, which allows listed fingerprints to bypass Bot Manager validation.
+- A new `block_ai_bots` argument, which blocks known AI user agents automatically.
+
+To get the new Lite version, launch it through the [Marketplace](https://console.azion.com/marketplace/solution/azion/bot-manager-lite). The standard version remains available on demand, upon request to the Service Delivery team.
+
+```
+
+## Expected pt-br output block
+
+```mdx
+---
+## 10 de julho, 2026
+
+### Marketplace
+
+#### Descontinuação de soluções
+
+<Tag severity="info" client:only="vue">Descontinuado</Tag>
+
+As seguintes integrações foram descontinuadas e removidas do Marketplace da Azion:
+
+- Saffe Liveness Detection
+- Saffe Face Detection
+- Saffe ID Matching
+
+Essas integrações estão sendo desativadas porque não se integram mais à plataforma tão bem quanto antes. Se você já utiliza alguma delas, ela continuará funcionando normalmente — apenas novas instalações estão bloqueadas.
+
+#### Bot Manager 1.3.0 e Bot Manager Lite 0.2.0
+
+Novas versões do **Bot Manager** estão disponíveis tanto para o plano Lite quanto para o padrão (antigo "Advanced"). Os destaques incluem:
+
+- Nove novas regras estáticas.
+- Um novo argumento `good_fingerprint_list`, que permite que fingerprints listados sejam ignorados na validação do Bot Manager.
+- Um novo argumento `block_ai_bots`, que bloqueia automaticamente User-Agents conhecidos de IA.
+
+Para obter a nova versão Lite, basta ativá-la pelo [Marketplace](https://console.azion.com/marketplace/solution/azion/bot-manager-lite). A versão padrão continua disponível sob demanda, mediante solicitação à equipe de Service Delivery.
+
+```
+
+Notes on what to observe here:
+- Free-form H4 (`Solution deprecations` / product+version name) translated as normal prose.
+- Product name `Bot Manager`, arg names in backticks, and the URL are untouched in pt-br.
+- `<Tag>` label translates (`Deprecated` → `Descontinuado`); props don't.
+- Both blocks open with a `---` and a blank line before the closing of the block (matching the separator that will sit between this new entry and the next-older one already in the file).
+
+## Multi-product, multi-category example (versioned product + package list)
+
+Raw input:
+
+```
+June 15
+- terraform provider 2.7.0: improved http3/quic_ports handling, improved retry for 500 errors
+- CLI 4.22.1: updated support for latest devtools/integrations improvements
+- devtools packages shipped: @aziontech/unenv-preset 1.0.1, @aziontech/presets 1.1.0,
+  @aziontech/builder 1.0.2, @aziontech/bundler 1.1.0. also added Nitro dev preset + typescript
+  package updates to support it
+```
+
+Expected English shape (shows H3 → optional version line → H4 category grouping, repeated per product):
+
+```mdx
+### Terraform Provider
+
+**Version 2.7.0**
+
+#### Improvements
+
+- **Workloads**: Improved management of `http3` and `quic_ports`.
+- **Retry Handling**: Improved retry functionality with retry options for `500` errors.
+
+### Azion CLI
+
+**Version 4.22.1**
+
+#### Improvements
+
+- Updated CLI support for the latest DevTools and integrations improvements.
+
+### DevTools & Integrations
+
+#### Versions shipped
+
+- **@aziontech/unenv-preset**: 1.0.1
+- **@aziontech/presets**: 1.1.0
+- **@aziontech/builder**: 1.0.2
+- **@aziontech/bundler**: 1.1.0
+
+#### Features
+
+- **Nitro preset**: Added a development preset for Nitro, enabling builds for applications and frameworks that run on the Nitro server.
+- **TypeScript packages**: Published updates across multiple TypeScript packages to support the new Nitro preset.
+```
+
+pt-br mirrors this exactly, translating only prose and the `Improvements`/`Features`/`Versions shipped` headings — product names, package names, and version numbers stay identical.


### PR DESCRIPTION
## Summary
- Adds a project Claude Code skill (`.claude/skills/release-notes-writer/`) that turns raw changelogs/engineering digests into formatted `release-notes.mdx` entries for both published languages (en, pt-br).
- Formatting rules were mined directly from the most recently published entries (heading formats, canonical product/category names, `<Tag>` usage, translation conventions).
- Includes mandatory customer-facing filtering (excludes internal-only refactors, asks when relevance is unclear), redaction of internal info (ticket IDs, person names, non-public component names), and Jira enrichment for linked tickets.
- Never commits/pushes on its own — only edits the working tree, leaving review/commit to the user.

## Test plan
- [x] Validated with the skill-creator quick validator (frontmatter + structure)
- [x] Dry-ran the skill against a real internal deploy digest with Jira-linked tickets to confirm triage, redaction, and formatting output match repo conventions