### PR TITLE
[NO-ISSUE] docs(release-notes): add release notes for July 29, 2026

### DIFF
--- a/src/content/docs/en/pages/main-menu/release-notes/release-notes.mdx
+++ b/src/content/docs/en/pages/main-menu/release-notes/release-notes.mdx
@@ -11,6 +11,28 @@ import Tag from 'primevue/tag'
 
 
 ---
+## July 29, 2026
+
+### Azion Console
+
+#### Features
+
+- **Real-Time Events**: Improved the Real-Time Events experience.
+
+#### Improvements
+
+- **Rules Engine Criteria**: Removed legacy criteria variables that had not been functional for several years from the Rules Engine configuration screen.
+
+#### Bug Fixes
+
+- **Account Switching**: Fixed an issue where switching accounts could keep the previous account active instead of switching.
+- **Activity History Search**: Fixed an issue where searching in Activity History could return an error.
+- **Unsaved Changes Prompt**: Fixed an issue where the unsaved changes prompt could appear on a domain without any modifications.
+- **Send Feedback**: Fixed an issue where submitting feedback through the console could fail with a server error.
+- **WAF Tuning Domain Listing**: Fixed an issue where some domains could be missing from the WAF Tuning list due to a pagination issue.
+- **SSO**: Fixed an issue where reverting from a custom SSO configuration back to Azion's default SSO could fail with a 404 error.
+
+---
 ## July 10, 2026
 
 ### Marketplace

--- a/src/content/docs/pt-br/pages/menu-principal/release-notes/release-notes.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/release-notes/release-notes.mdx
@@ -11,6 +11,28 @@ import Tag from 'primevue/tag'
 
 
 ---
+## 29 de julho, 2026
+
+### Azion Console
+
+#### Recursos
+
+- **Real-Time Events**: Melhorada a experiência do Real-Time Events.
+
+#### Melhorias
+
+- **Critérios do Rules Engine**: Removidas variáveis de critérios legadas que não funcionavam há vários anos da tela de configuração do Rules Engine.
+
+#### Correções de Bugs
+
+- **Troca de Conta**: Corrigido um problema em que a troca de conta podia manter a conta anterior ativa em vez de trocar.
+- **Busca no Histórico de Atividades**: Corrigido um problema em que a busca no Histórico de Atividades podia retornar um erro.
+- **Prompt de Alterações Não Salvas**: Corrigido um problema em que o prompt de alterações não salvas podia aparecer em um domínio mesmo sem nenhuma modificação.
+- **Envio de Feedback**: Corrigido um problema em que o envio de feedback pelo console podia falhar com um erro de servidor.
+- **Listagem de Domínios no WAF Tuning**: Corrigido um problema em que alguns domínios podiam ficar ausentes na listagem do WAF Tuning devido a um problema de paginação.
+- **SSO**: Corrigido um problema em que reverter de uma configuração de SSO personalizada para o SSO padrão da Azion podia falhar com um erro 404.
+
+---
 ## 10 de julho, 2026
 
 ### Marketplace


### PR DESCRIPTION
### Related issue: ENG-46685, ENG-46609 (not included, see below), ENG-46594, ENG-46386, ENG-46254, ENG-37439, ENG-37379, ENG-37279, ENG-46653

### Changes

Adds a new **July 29, 2026** dated section to `release-notes.mdx` (en and pt-br), under **Azion Console**:

- **Features**: Real-Time Events experience improvements.
- **Improvements**: removed legacy criteria variables (unsupported for several years) from the Rules Engine configuration screen.
- **Bug Fixes**: account switching keeping the previous account active, Activity History search returning an error, unsaved-changes prompt appearing without modifications, Send Feedback failing with a server error, domains missing from the WAF Tuning list due to pagination, and SSO rollback to Azion's default provider failing with a 404.

Content was drafted from the underlying Jira tickets (not the raw commit-message shorthand) and filtered for customer relevance — internal-only refactors and a security-review ticket (ENG-46968) were intentionally excluded, along with a cosmetic email-overflow fix and an unticketed `/sse` redirect change, per review.

### Additional links

Generated with the repo's `release-notes-writer` Claude Code skill (`.claude/skills/release-notes-writer/`), added in #2303.