### PR TITLE
fix(build): bump azion-theme to 1.18.3 to restore light mode prose styles

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
         version: 0.5.2(nanostores@0.10.3)(preact@10.29.1)
       azion-theme:
         specifier: ^1.15.3
-        version: 1.17.0
+        version: 1.18.3
       azion-webkit:
         specifier: ^1.271.5
         version: 1.277.0(vue@3.5.25(typescript@5.9.3))
@@ -2173,8 +2173,8 @@ packages:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
-  azion-theme@1.17.0:
-    resolution: {integrity: sha512-agZYek1UMU/zuZT33K/p6OjsqkX4DqJhHKCgPvpo1SaMDNrIsLfAWf5EQOBZcnRSLur7XuXB5yLbQUvtRyvc1w==}
+  azion-theme@1.18.3:
+    resolution: {integrity: sha512-jTSHwjuM1HSmIN/uErunbTJyi2JGnXL/xXhZ81aF310iT83xKOhXHsLAuANroQvxnv0Bdt55QzBoYVHl0PDvkg==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   azion-webkit@1.277.0:
@@ -7744,7 +7744,7 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
-  azion-theme@1.17.0: {}
+  azion-theme@1.18.3: {}
 
   azion-webkit@1.277.0(vue@3.5.25(typescript@5.9.3)):
     dependencies:


### PR DESCRIPTION
## What

Bumps `azion-theme` from 1.17.0 to 1.18.3 in `pnpm-lock.yaml` (4-line, lockfile-only change — the `^1.15.3` range in `package.json` already allows it).

## Why

Since #2305 switched the prod pipeline from `npm install` (package-lock.json → azion-theme@1.15.3) to `pnpm install --frozen-lockfile` (pnpm-lock.yaml → azion-theme@1.17.0), doc pages render washed-out headings, bold text, and links in light mode.

Root cause: azion-webkit's `ReadableContent` applies dark-only Tailwind prose classes (`prose-headings:text-white`, `prose-strong:text-white`, `prose-a:text-white`, all `!important`). Light mode depends entirely on azion-theme's `extended-components/_markdown.scss` compat layer (`.azion .prose *:not(p, a, li, span) { color: var(--text-color) !important }`), which overrides those classes with theme-aware colors. That file exists in every azion-theme release except 1.17.0 — exactly the version pinned in pnpm-lock.yaml — and was restored in 1.18.3.

1.18.3 was chosen over 1.20.0 because it has the same zero-dependency footprint as 1.17.0 (1.20.0 adds a `tailwindcss` peer dependency that re-keys ~600 lines of the lockfile).