### PR TITLE
chore: move Algolia search keys to environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Algolia DocSearch (search-only credentials, exposed to the client)
+PUBLIC_ALGOLIA_APP_ID=
+PUBLIC_ALGOLIA_SEARCH_KEY=
+
+# GitHub token used to fetch contributors/authors lists
+PUBLIC_GITHUB_TOKEN=

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -31,6 +31,8 @@ jobs:
         run: |
           export NODE_OPTIONS="--max-old-space-size=8120"
           export PUBLIC_GITHUB_TOKEN="${{ secrets.GH_PACKAGES_SECRET }}"
+          export PUBLIC_ALGOLIA_APP_ID="${{ secrets.PUBLIC_ALGOLIA_APP_ID }}"
+          export PUBLIC_ALGOLIA_SEARCH_KEY="${{ secrets.PUBLIC_ALGOLIA_SEARCH_KEY }}"
           pnpm run build:dev
       - name: 'AUTH Google Cloud'
         uses: 'google-github-actions/auth@v2'

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -39,6 +39,8 @@ jobs:
         run: |
           export NODE_OPTIONS="--max-old-space-size=8120"
           export PUBLIC_GITHUB_TOKEN="${{ secrets.GH_PACKAGES_SECRET }}"
+          export PUBLIC_ALGOLIA_APP_ID="${{ secrets.PUBLIC_ALGOLIA_APP_ID }}"
+          export PUBLIC_ALGOLIA_SEARCH_KEY="${{ secrets.PUBLIC_ALGOLIA_SEARCH_KEY }}"
           pnpm run build:prod
 
       - name: UPDATE Algolia data

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -31,6 +31,8 @@ jobs:
         run: |
           export NODE_OPTIONS="--max-old-space-size=8120"
           export PUBLIC_GITHUB_TOKEN="${{ secrets.GH_PACKAGES_SECRET }}"
+          export PUBLIC_ALGOLIA_APP_ID="${{ secrets.PUBLIC_ALGOLIA_APP_ID }}"
+          export PUBLIC_ALGOLIA_SEARCH_KEY="${{ secrets.PUBLIC_ALGOLIA_SEARCH_KEY }}"
           pnpm run build:stage
       - name: 'AUTH Google Cloud'
         uses: 'google-github-actions/auth@v2'

--- a/env/consts.development.ts
+++ b/env/consts.development.ts
@@ -4,9 +4,6 @@ export const ASSETS_URL = 'https://z4azz7gp65.map.azionedge.net';
 export const FAVICON_URL = 'https://z4azz7gp65.map/assets/images/favicon.png';
 export const FONTS_URL = 'https://fonts.azion.com';
 
-export const ALGOLIA_ID = 'PYJUZH6VNQ';
-export const ALGOLIA_APIKEY = '7c1795c333053265edd2aeb199745797';
-
 // Analytics Configuration
 export const ANALYTICS_WRITE_KEY = 'YUr3hmFXyFN1n2dXL7pp1DXilTzgUAIT';
 export const ANALYTICS_PROXY_URL = 'https://www.azion.com/api/segment-proxy';

--- a/env/consts.localhost.ts
+++ b/env/consts.localhost.ts
@@ -4,9 +4,6 @@ export const ASSETS_URL = 'http://localhost:4321';
 export const FAVICON_URL = 'https://www.azion.com/assets/images/favicon.png';
 export const FONTS_URL = 'https://fonts.azion.com';
 
-export const ALGOLIA_ID = 'PYJUZH6VNQ';
-export const ALGOLIA_APIKEY = '7c1795c333053265edd2aeb199745797';
-
 // Analytics Configuration
 export const ANALYTICS_WRITE_KEY = '';
 export const ANALYTICS_PROXY_URL = '';

--- a/env/consts.production.ts
+++ b/env/consts.production.ts
@@ -4,9 +4,6 @@ export const ASSETS_URL = 'https://www.azion.com';
 export const FAVICON_URL = 'https://www.azion.com/assets/images/favicon.png';
 export const FONTS_URL = 'https://fonts.azion.com';
 
-export const ALGOLIA_ID = 'PYJUZH6VNQ';
-export const ALGOLIA_APIKEY = '7c1795c333053265edd2aeb199745797';
-
 // Analytics Configuration
 export const ANALYTICS_WRITE_KEY = 'YUr3hmFXyFN1n2dXL7pp1DXilTzgUAIT';
 export const ANALYTICS_PROXY_URL = 'https://www.azion.com/api/segment-proxy';

--- a/env/consts.stage.ts
+++ b/env/consts.stage.ts
@@ -4,9 +4,6 @@ export const ASSETS_URL = 'https://52082s.ha.azioncdn.net';
 export const FAVICON_URL = 'https://52082s.ha.azioncdn.net/assets/images/favicon.png';
 export const FONTS_URL = 'https://fonts.azion.com';
 
-export const ALGOLIA_ID = 'PYJUZH6VNQ';
-export const ALGOLIA_APIKEY = '7c1795c333053265edd2aeb199745797';
-
 // Analytics Configuration
 export const ANALYTICS_WRITE_KEY = 'YUr3hmFXyFN1n2dXL7pp1DXilTzgUAIT';
 export const ANALYTICS_PROXY_URL = 'https://www.azion.com/api/segment-proxy';

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -4,9 +4,6 @@ export const ASSETS_URL = 'http://localhost:4321';
 export const FAVICON_URL = 'https://www.azion.com/assets/images/favicon.png';
 export const FONTS_URL = 'https://fonts.azion.com';
 
-export const ALGOLIA_ID = 'PYJUZH6VNQ';
-export const ALGOLIA_APIKEY = '7c1795c333053265edd2aeb199745797';
-
 // Analytics Configuration
 export const ANALYTICS_WRITE_KEY = '';
 export const ANALYTICS_PROXY_URL = '';

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -245,8 +245,8 @@ const translatedPages = await (async (c) => {
 			<Fragment slot="dialog">
 						<AlgoliaDialog
 							client:only="vue"
-							algoliaAppId="PYJUZH6VNQ"	
-							algoliaApiKey="7c1795c333053265edd2aeb199745797"
+							algoliaAppId={import.meta.env.PUBLIC_ALGOLIA_APP_ID}
+							algoliaApiKey={import.meta.env.PUBLIC_ALGOLIA_SEARCH_KEY}
 							algoliaIndex={algoliaIndex}
 							algoliaModel={algoliaModel}
 							inputPlaceholder={algoliaInputPlaceholder}


### PR DESCRIPTION
## What

Moves the hardcoded Algolia DocSearch credentials out of source code into environment variables (`PUBLIC_ALGOLIA_APP_ID` and `PUBLIC_ALGOLIA_SEARCH_KEY`), per [MM-15902](https://aziontech.atlassian.net/browse/MM-15902) (Fase 0 — Docs Modernização).

- `BaseLayout.astro`: `AlgoliaDialog` now reads the app id and search key from `import.meta.env` instead of inline literals
- Removed the dead `ALGOLIA_ID` / `ALGOLIA_APIKEY` exports from `src/consts.ts` and all four `env/consts.*.ts` variants (nothing imported them)
- Added `.env.example` documenting the required variables
- `dev.yml` / `stage.yml` / `prod.yml` workflows export both variables from GitHub secrets in the build step

## Action required before merge

The repository secrets `PUBLIC_ALGOLIA_APP_ID` and `PUBLIC_ALGOLIA_SEARCH_KEY` must be registered in GitHub (Settings → Secrets → Actions), otherwise the search dialog will render without credentials on the next deploy.

## Validation

- Full `astro build` passes locally (1494 pages) with the variables set via `.env`
- Rendered HTML confirms the values are injected from the environment; `grep` confirms zero hardcoded keys left in `src/`, `env/` and `cicd/`
- Note: the search dialog does not hydrate in local dev mode on `main` either (pre-existing `algoliasearch` ESM interop issue in Vite dev, unrelated to this change)

## Notes

The key being moved is Algolia's public search-only key, so this is hygiene/config cleanup rather than a secret leak remediation. The `PUBLIC_` prefix is required by Astro to expose the values to the client-side dialog.


[MM-15902]: https://aziontech.atlassian.net/browse/MM-15902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
