### PR TITLE
chore(weekly ci): removes pnpm 10 from the ci workflow, and makes it use the package.json version

### DIFF
--- a/.github/workflows/weekly-linkcheck.yml
+++ b/.github/workflows/weekly-linkcheck.yml
@@ -19,8 +19,6 @@ jobs:
         
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Set up Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
## What & why

MM-15964: The previous CI follow had a fixed pnpm 10 version which conflicted with package.json version. Removing it makes the ci to use the package.json pnpm version. 

<img width="753" height="115" alt="image" src="https://github.com/user-attachments/assets/442a1179-810c-474f-8b69-37888492e103" />

## Type of change

- [ ] 🆕 New content (`feat`)
- [ ] 🩹 Fix (`fix`) — typo, broken link, wrong information
- [ ] ♻️ Content update (`docs`) — rewrite, expansion, upkeep
- [ ] 🌐 Translation sync (`i18n`)
- [x] 🏗️ Platform / structure (`refactor` / `chore`)

## Author checklist

- [x] PR title follows `type(scope): summary` (see [GOVERNANCE.md §4](GOVERNANCE.md))
- [x] Frontmatter complete: `title`, `description`, `meta_tags`, `namespace`, `permalink`, `last_reviewed`
- [x] No legacy "edge-" product names in the copy
- [x] How-to/tutorial content includes at least one runnable, copy-paste-tested code block
- [x] Screenshots (if any) have alt text and follow image standards
- [x] Internal links are relative and resolve locally
- [ ] **If any permalink changed or page moved: redirect added in this PR**
- [ ] **i18n:** `pt-br` updated in this PR **or** follow-up `i18n` issue created: <!-- link -->
- [x] I ran `pnpm build:local` (build + frontmatter check) without errors