### PR TITLE
feat(header): adopt webkit's NavigationMenu, and compile the button type scale

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -90,7 +90,13 @@ export default defineConfig({
 				if (name === 'client') return null;
 				return {
 					resolve: {
-						noExternal: ['@astrojs/vue', '@aziontech/theme'],
+						// `@aziontech/webkit` has to be bundled, not externalised:
+						// its `navigation-menu` entry is an `index.js` that imports
+						// `.vue` files, and Node cannot load those on its own
+						// ("Unknown file extension .vue"). Components whose entry is
+						// itself a `.vue` or a `.ts` happen to work either way, which
+						// is why this only surfaced when NavigationMenu was adopted.
+						noExternal: ['@astrojs/vue', '@aziontech/theme', '@aziontech/webkit'],
 						external: ['vue']
 					}
 				};
@@ -106,7 +112,7 @@ export default defineConfig({
 		})
 	],
 	ssr: {
-      noExternal: ['@astrojs/vue', '@aziontech/theme'],
+      noExternal: ['@astrojs/vue', '@aziontech/theme', '@aziontech/webkit'],
       external: ['vue']
     },
 		optimizeDeps: {

--- a/src/components/HeaderMenuNav.vue
+++ b/src/components/HeaderMenuNav.vue
@@ -1,417 +1,117 @@
 <template>
-  <nav class="hidden lg:flex">
-    <ul class="flex gap-2">
-      <li
-        v-for="(menuitem, index) in menuData.items"
-        :key="index"
-      >
-        <a
-          v-if="!menuitem.items || !menuitem.items.length"
-          :href="menuitem.href || ''"
-          :title="menuitem.label || ''"
-          class="wk-nav-button whitespace-nowrap text-default active:bg-[var(--bg-active)] hover:bg-hover"
-          :class="getBreakpointClass(menuitem)"
-        >
-          <span class="">
-            {{ menuitem.label }}
-          </span>
-        </a>
+	<!--
+		The header's primary navigation, rebuilt on @aziontech/webkit's
+		NavigationMenu. What this file used to be: ~420 lines that hand-rolled a
+		mega-menu -- open/close state, an outside-click listener, an Escape
+		handler, hover intent, rotating chevrons, panel positioning and a
+		`.wk-nav-button*` CSS block ported from azion-theme's PrimeVue button.
+		NavigationMenu owns every one of those concerns, so all of it is gone.
 
-        <div
-          v-if="menuitem.items && menuitem.items.length"
-          ref="menuRootRefs"
-        >
-          <button
-            @click="
-              (event) => {
-                toggle(event, menuitem.ref)
-              }
-            "
-            tabindex="0"
-            class="wk-nav-button whitespace-nowrap active:bg-[var(--bg-active)] hover:bg-hover"
-            :class="activeMenu == menuitem.ref && 'bg-hover'"
-          >
-            <div class="flex flex-row gap-2 text-default items-center">
-              <span>
-                {{ menuitem.label }}
-              </span>
-              <i
-                class="pi pi-angle-down text-sm"
-                :class="activeMenu == menuitem.ref && 'rotate-180'"
-              />
-            </div>
-          </button>
+		The composition mirrors the design system's own reference usage
+		(apps/webkit-sample, SiteNav.vue): a `List` is the bar, each entry is an
+		`Item`, and an entry either renders a plain `Trigger` with an `href` or a
+		`Trigger` + `Content` panel whose columns are nested `List`s of
+		`layout="entry"` items.
 
-          <div
-            v-if="activeMenu === menuitem.ref"
-            :id="menuitem.ref"
-            class="fixed p-0 hidden lg:flex flex-row border border-default rounded-md bg-surface max-w-[calc(100%-8.5rem)] xl:max-w-6xl 2xl:max-w-screen-xl w-full left-8 lg:left-[8.5rem] top-12 z-50"
-          >
-            <div
-              class="flex flex-col gap-1 border-r border-default p-3 bg-surface-raised rounded-l-md min-w-56"
-            >
-              <template
-                v-for="(subitem, index) in menuitem.items"
-                v-bind:key="index"
-              >
-                <template v-if="subitem.items">
-                  <button
-                    type="button"
-                    :class="{ 'bg-hover': active === index }"
-                    class="wk-nav-button-text flex gap-2 justify-between w-full text-nowrap text-left min-w-52"
-                    @click="active = index"
-                  >
-                    <span class="flex gap-2 items-center">
-                      {{ subitem.label }}
-                      <i :class="subitem.icon"></i>
-                    </span>
-                    <i class="pi pi-angle-right"></i>
-                  </button>
-                </template>
-                <template v-else>
-                  <a
-                    class="wk-nav-button-text hover:bg-hover flex gap-2 hover:bg-hover justify-between w-full items-centerm min-w-52"
-                    :href="subitem.href"
-                    :target="subitem.external ? '_blank' : '_self'"
-                  >
-                    <span class="w-full flex gap-2 items-center justify-between">
-                      {{ subitem.label }}
-                      <i
-                        :class="subitem.icon"
-                        class="text-sm"
-                      ></i>
-                    </span>
-                  </a>
-                </template>
-              </template>
-            </div>
+		Both shapes are kept even though the docs' current header data only ever
+		takes the first one -- `src/i18n/*/header.ts` ships three entries with
+		`items: []`, i.e. three plain links. The panel branch is what makes
+		adding a submenu a data change rather than a component change.
 
-            <div class="w-full">
-              <div
-                v-for="(subitem, jIndex) in menuitem.items"
-                v-show="active === jIndex"
-                :key="jIndex"
-              >
-                <div
-                  v-if="subitem.overline"
-                  class="pt-3 pl-6 pr-3 max-w-[627px] w-full"
-                >
-                  <Overline :label="subitem.overline" />
-                </div>
-                <div class="flex flex-row justify-between min-h-56 min-w-full">
-                  <ul
-                    class="grid m-0 p-3 h-fit min-h-20 w-full"
-                    :class="
-                      menuitem.rightBlock
-                        ? 'grid-cols-1 xl:grid-cols-2 max-w-[627px]'
-                        : 'grid-cols-2 xl:grid-cols-3'
-                    "
-                  >
-                    <li
-                      v-for="(link, index) in subitem.items"
-                      :key="index"
-                      class="flex flex-col gap-2"
-                    >
-                      <a
-                        v-bind="link.href ? { href: link.href } : {}"
-                        :title="link.label"
-                        class="wk-nav-button-text w-full p-3 flex flex-col justify-start items-start"
-                        :class="
-                          link.href ? 'hover:bg-hover' : 'cursor-default hover:bg-inherit'
-                        "
-                      >
-                        <div class="flex gap-3">
-                          <div v-if="link.icon">
-                            <span class="py-1 px-1.5 flex rounded-md bg-selected">
-                              <i
-                                :class="link.icon"
-                                class="text-xs"
-                              ></i>
-                            </span>
-                          </div>
-                          <div class="flex flex-col gap-1">
-                            <div class="flex gap-2 items-center min-h-[1.625rem]">
-                              <p class="text-left font-medium">
-                                {{ link.label }}
-                              </p>
-                              <template v-if="link.tag">
-                                <Tag :value="link.tag" />
-                              </template>
-                            </div>
-                            <p
-                              v-if="link.description"
-                              class="font-normal text-xs text-muted text-left"
-                            >
-                              {{ link.description }}
-                            </p>
-                          </div>
-                        </div>
-                      </a>
-                      <div
-                        class="flex flex-col gap-2"
-                        :class="{ 'pl-9': link.overline }"
-                        v-if="link.subitems"
-                      >
-                        <template v-if="!link.overline">
-                          <ul
-                            class="pb-3"
-                            :class="{ 'pl-9': link.icon }"
-                          >
-                            <li
-                              v-for="(sublink, subIndex) in link.subitems.length >= 4
-                                ? [
-                                    ...link.subitems.slice(0, 3),
-                                    link.subitems[link.subitems.length - 1]
-                                  ]
-                                : link.subitems"
-                              :key="subIndex"
-                              class="flex flex-col gap-2"
-                            >
-                              <a
-                                :href="sublink.href"
-                                :title="sublink.label"
-                                class="wk-nav-button-sm w-full text-xs"
-                                :class="[
-                                  sublink.isLink
-                                    ? 'wk-nav-button-link hover:underline'
-                                    : 'hover:bg-hover text-default wk-nav-button-text',
-                                  sublink.isLink && link.subitems.length <= 4 ? 'hidden' : ''
-                                ]"
-                              >
-                                <p class="text-left font-medium">
-                                  {{ sublink.label }}
-                                </p>
-                              </a>
-                            </li>
-                          </ul>
-                        </template>
-                        <template v-else>
-                          <template v-if="link.overline">
-                            <Overline
-                              :label="link.overline"
-                              class="px-[10.5px]"
-                            />
-                          </template>
-                          <ul>
-                            <li
-                              v-for="(sublink, subIndex) in link.subitems"
-                              :key="subIndex"
-                              class="flex- flex-col gap-2"
-                            >
-                              <a
-                                :href="sublink.href"
-                                :title="sublink.label"
-                                class="wk-nav-button-text hover:bg-hover w-full text-xs hover:bg-hover"
-                              >
-                                <div class="flex gap-3">
-                                  <div v-if="sublink.icon">
-                                    <span class="py-1 px-1.5 flex rounded-md bg-selected">
-                                      <i
-                                        :class="sublink.icon"
-                                        class="text-xs"
-                                      ></i>
-                                    </span>
-                                  </div>
-                                  <div>
-                                    <p class="text-left font-medium">
-                                      {{ sublink.label }}
-                                    </p>
-                                  </div>
-                                </div>
-                              </a>
-                            </li>
-                          </ul>
-                        </template>
-                      </div>
-                    </li>
-                  </ul>
-                  <div
-                    v-if="menuitem.rightBlock"
-                    class="border-l border-default p-6 gap-3 flex-col min-h-52 hidden lg:flex w-full max-w-[340px] bg-surface-raised rounded-r-md"
-                  >
-                    <div v-if="menuitem.rightBlock.type === 'cases'">
-                      <Overline
-                        :label="menuitem.rightBlock.label"
-                        class="mb-6 flex"
-                      />
-                      <div class="flex flex-col gap-4 m-0 w-full">
-                        <article
-                          v-for="(block, idx) in menuitem.rightBlock.items"
-                          :key="idx"
-                          class="flex gap-4 w-full"
-                        >
-                          <div class="w-full">
-                            <a
-                              :href="block.link.href"
-                              target="_blank"
-                              :title="block.link.label"
-                              class="flex gap-4 group"
-                            >
-                              <figure
-                                class="mb-4 overflow-hidden rounded-sm border border-default h-fit w-[280px] grayscale group-hover:grayscale-0"
-                              >
-                                <img
-                                  :src="`${block.img.src}`"
-                                  :alt="block.img.alt"
-                                  class="w-full"
-                                  lazy
-                                />
-                              </figure>
-                              <div class="w-full flex flex-col">
-                                <p class="text-xs leading-relaxed text-muted">
-                                  {{ block.description }}
-                                </p>
-                                <p class="wk-nav-button-link px-0">
-                                  {{ block.link.label }}
-                                  <i class="pi pi-angle-right"></i>
-                                </p>
-                              </div>
-                            </a>
-                          </div>
-                        </article>
-                      </div>
-                    </div>
+		Visibility classes go on the Item wrapper, never on the Trigger: the
+		design system's own note on this (SiteNav.vue) is that a control's base
+		`inline-flex` outranks a `hidden` passed in as a class, so an element
+		told to hide itself stays visible. Same cascade trap the header CTAs hit.
+	-->
+	<NavigationMenu>
+		<NavigationMenu.List class="items-center gap-[var(--spacing-xxs)] hidden lg:flex">
+			<NavigationMenu.Item
+				v-for="(menuitem, index) in menuData?.items || []"
+				:key="menuitem.label || index"
+				:value="menuitem.ref || menuitem.label || index"
+				:class="getBreakpointClass(menuitem)"
+			>
+				<!-- Leaf entry: a link in the bar, no panel. -->
+				<NavigationMenu.Trigger
+					v-if="!menuitem.items || !menuitem.items.length"
+					:href="menuitem.href || ''"
+				>
+					{{ menuitem.label }}
+				</NavigationMenu.Trigger>
 
-                    <div v-if="menuitem.rightBlock.type === 'featured'">
-                      <Overline
-                        :label="menuitem.rightBlock.label"
-                        class="mb-6 flex"
-                      />
-                      <div class="grid gap-4 m-0 w-full">
-                        <a
-                          :href="block.link.href"
-                          :title="block.link.label"
-                          v-for="(block, idx) in menuitem.rightBlock.items"
-                          :key="idx"
-                          class="w-full"
-                        >
-                          <figure
-                            class="w-[160px] h-[90px] mb-4 overflow-hidden rounded-sm border border-default"
-                          >
-                            <img
-                              :src="`${block.img.src}`"
-                              :alt="block.img.alt"
-                              class="w-full"
-                              width="160"
-                              height="90"
-                              lazy
-                            />
-                          </figure>
-                          <div class="w-full flex flex-col gap-1">
-                            <p class="text-base font-medium text-default mb-2 leading-normal">
-                              {{ block.title }}
-                            </p>
-                            <p class="text-xs text-muted leading-relaxed">
-                              {{ block.description }}
-                            </p>
-                            <p class="wk-nav-button-link px-0">
-                              {{ block.link.label }}
-                              <i class="pi pi-angle-right"></i>
-                            </p>
-                          </div>
-                        </a>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </li>
-    </ul>
-  </nav>
+				<!-- Branch entry: label + chevron opening a grouped panel. -->
+				<template v-else>
+					<NavigationMenu.Trigger>
+						{{ menuitem.label }}
+						<NavigationMenu.Icon>
+							<i
+								class="pi pi-angle-down text-sm"
+								aria-hidden="true"
+							/>
+						</NavigationMenu.Icon>
+					</NavigationMenu.Trigger>
+
+					<NavigationMenu.Content class="w-full p-0">
+						<div class="grid gap-[var(--spacing-md)] p-[var(--spacing-sm)] grid-cols-1 md:grid-cols-2 xl:grid-cols-4">
+							<NavigationMenu.List
+								v-for="(group, groupIndex) in menuitem.items"
+								:key="group.label || groupIndex"
+								:label="group.overline || group.label"
+							>
+								<NavigationMenu.Item
+									v-for="(entry, entryIndex) in group.items || [group]"
+									:key="entry.label || entryIndex"
+									layout="entry"
+									:href="entry.href || '#'"
+									:description="entry.description"
+									close-on-click
+								>
+									<template
+										v-if="entry.icon"
+										#icon
+									>
+										<i
+											:class="entry.icon"
+											aria-hidden="true"
+										/>
+									</template>
+									{{ entry.label }}
+								</NavigationMenu.Item>
+							</NavigationMenu.List>
+						</div>
+					</NavigationMenu.Content>
+				</template>
+			</NavigationMenu.Item>
+		</NavigationMenu.List>
+	</NavigationMenu>
 </template>
 
 <script setup>
-  import { ref, onMounted, onBeforeUnmount } from 'vue'
-  import Overline from '~/components/webkit/Overline.vue'
-  import Tag from '~/components/webkit/Tag.vue'
+	import NavigationMenu from '@aziontech/webkit/navigation-menu'
 
-  const props = defineProps({
-    menuData: {
-      type: Object
-    }
-  })
+	defineProps({
+		menuData: {
+			type: Object
+		}
+	})
 
-  const { menuData } = props
-  const active = ref(0)
-  const activeMenu = ref(null)
-  const menuRootRefs = ref([])
+	/*
+		Unchanged from the previous implementation: an entry may declare a
+		`minBreakpoint` and only appear from that width up. It lands on the Item
+		wrapper (see the template note).
+	*/
+	const getBreakpointClass = (menu) => {
+		const breakpoint = menu?.minBreakpoint
+		if (!breakpoint) return ''
 
-  const toggle = (event, refAttr) => {
-    if (!refAttr) return
-    active.value = 0
-    activeMenu.value = activeMenu.value === refAttr ? null : refAttr
-  }
+		const breakpoints = {
+			sm: 'block',
+			md: 'hidden md:block',
+			lg: 'hidden lg:block',
+			xl: 'hidden xl:block',
+			'2xl': 'hidden 2xl:block'
+		}
 
-  function onDocumentClick(event) {
-    if (activeMenu.value === null) return
-    const clickedInsideOpenMenu = menuRootRefs.value.some((el) => el?.contains(event.target))
-    if (!clickedInsideOpenMenu) activeMenu.value = null
-  }
-
-  function onDocumentKeydown(event) {
-    if (event.key === 'Escape' && activeMenu.value !== null) activeMenu.value = null
-  }
-
-  onMounted(() => {
-    document.addEventListener('click', onDocumentClick)
-    document.addEventListener('keydown', onDocumentKeydown)
-  })
-
-  onBeforeUnmount(() => {
-    document.removeEventListener('click', onDocumentClick)
-    document.removeEventListener('keydown', onDocumentKeydown)
-  })
-
-  const getBreakpointClass = (menu) => {
-    const breakpoint = menu?.minBreakpoint
-    if (!breakpoint) return ''
-
-    const breakpoints = {
-      sm: 'block',
-      md: 'hidden md:block',
-      lg: 'hidden lg:block',
-      xl: 'hidden xl:block',
-      '2xl': 'hidden 2xl:block'
-    }
-
-    return breakpoints[breakpoint] || ''
-  }
+		return breakpoints[breakpoint] || ''
+	}
 </script>
-
-<style scoped>
-  /*
-    Visual port of azion-theme's PrimeVue `.p-button` variants (text, small),
-    self-contained so this component no longer depends on PrimeVue classes.
-    Same values as src/components/webkit/LinkButton.vue's `!important`-free
-    base -- this file never sits inside ReadableContent's `.prose` wrapper,
-    so it doesn't need the `.prose a:not(.p-button)` escape hatch there.
-  */
-  .wk-nav-button,
-  .wk-nav-button-text,
-  .wk-nav-button-sm {
-    display: inline-flex;
-    align-items: center;
-    cursor: pointer;
-    user-select: none;
-    background: transparent;
-    border: none;
-    border-radius: 6px;
-    color: var(--text-default);
-    font-size: 0.875rem;
-    font-weight: 500;
-  }
-  .wk-nav-button,
-  .wk-nav-button-text,
-  .wk-nav-button-sm {
-    padding: 0.301rem 0.65625rem;
-  }
-  .wk-nav-button-link {
-    color: var(--text-link);
-  }
-  .wk-nav-button-link:hover {
-    color: var(--text-link-hover);
-  }
-</style>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -18,6 +18,48 @@
 
 @plugin '@tailwindcss/typography';
 
+/*
+  SHIM -- remover quando o import do @aziontech/theme mudar de lugar.
+
+  These two blocks are copied verbatim from @aziontech/theme's own globals.css.
+  They exist here because the theme is loaded as a standalone stylesheet (a JS
+  `import '@aziontech/theme'` in BaseLayout.astro), so Tailwind never sees its
+  `@utility` declarations and none of the design system's typography classes are
+  compiled into the build. The `:root` tokens still resolve -- only the classes
+  are missing.
+
+  Consequence for buttons specifically: webkit's Button and IconButton emit
+  `text-button-lg` / `text-button-md` on their root, so with the class absent
+  every button label fell back to *inheriting* the surrounding font size --
+  16px in the chrome and 18px inside the article's prose, against the 14px /
+  12px the tokens prescribe. That is why the buttons read as oversized: a label
+  2-4px too large inside a fixed-height box.
+
+  Defining the utilities here (rather than passing `text-[length:var(--…)]` at
+  each call site) keeps the canonical class name working, so the fix reaches
+  every webkit component that already references it without touching a single
+  component. Same tokens, same values: when the theme is imported through this
+  entry, its own definitions take over and these become redundant.
+
+  The rest of the scale (`text-body-*`, `text-heading-*`, `text-label-*`,
+  `text-tag-*`) is still uncompiled -- see the typography plan.
+*/
+@utility text-button-lg {
+	font-family: var(--text-button-lg-font-family);
+	font-size: var(--text-button-lg-font-size);
+	font-weight: var(--text-button-lg-font-weight);
+	line-height: var(--text-button-lg-line-height);
+	letter-spacing: var(--text-button-lg-letter-spacing);
+}
+
+@utility text-button-md {
+	font-family: var(--text-button-md-font-family);
+	font-size: var(--text-button-md-font-size);
+	font-weight: var(--text-button-md-font-weight);
+	line-height: var(--text-button-md-line-height);
+	letter-spacing: var(--text-button-md-letter-spacing);
+}
+
 /* Dark mode is driven by the `.dark` class on <html> (set by
    DropdownThemeSwitcher, alongside @aziontech/theme's own `.azion-dark`),
    not by the OS preference that Tailwind v4 defaults to. */


### PR DESCRIPTION
## What

Eighth PR in the docs modernization stack (base: #2321). Two changes that came out of the same root cause.

## 1. Buttons were rendering oversized

webkit's Button and IconButton emit `text-button-lg` / `text-button-md` on their root, but **neither class existed in the build**. Every button label fell back to *inheriting* the surrounding font size:

| | before | after |
|---|---|---|
| content CTA (`size="large"`) | 18px | **14px / 17.5px** |
| header buttons (`size="medium"`) | 16px | **12px / 15px** |
| `text-button-lg` on a bare div | 16px (no rule applied) | **14px** |

A label 2-4px larger than designed, inside a fixed-height box, is why they read as inflated — `Contato` measured 91px wide against 75px now. Cross-checked against the design system's own sample (`apps/webkit-sample`): its Button measures 14px / 17.5px / 40px, which is exactly what the content CTAs now measure.

### Root cause

`@aziontech/theme` is loaded through a JS-side `import '@aziontech/theme'` in `BaseLayout.astro` — a standalone stylesheet. Tailwind only compiles `@utility` declarations that are part of the stylesheet graph it processes, so the `:root` tokens resolve (colour and spacing always worked) while **none of the design system's generated typography classes are emitted**.

Verified by injecting `<div class="text-button-lg">` into the page: 16px/24px, no rule applied, while `--text-button-lg-font-size` resolves to `0.875rem`.

### Fix, and why it is scoped this way

The two `@utility` blocks added to `main.css` are **copied verbatim from the theme's own globals.css** and reference the same tokens — not a fork of the values. Defining the canonical class names, rather than passing `text-[length:var(--…)]` at each call site, means the fix reaches every webkit component that already references them **without touching a single component**.

Marked as a shim: once the theme is imported through the Tailwind entry, its own definitions take over and these become redundant.

**Deliberately not fixed here:** moving that import. It was attempted and reverted — putting `@import '@aziontech/theme'` in `main.css` makes `cssnano` 6.1.2 throw `Lexical error: Unrecognized text — infinity * 1px` on Tailwind v4's `calc(infinity * 1px)` output, and the entire utility layer is dropped (body background, prose colours, everything). That warning already appears on every CSS rebuild today; it just was not fatal until the theme's sheet went through it. So the rest of the scale (`text-body-*`, `text-heading-*`, `text-label-*`, `text-tag-*`) is still uncompiled, which is why article typography still rides on `@tailwindcss/typography`. Untangling that needs a `cssnano` decision first and is its own PR.

## 2. The header nav is now webkit's NavigationMenu

**417 lines → 117.** The nav hand-rolled a mega-menu: open/close state, an outside-click listener, an Escape handler, hover intent, rotating chevrons, panel positioning and a `.wk-nav-button*` block ported from azion-theme's PrimeVue button. NavigationMenu owns all of it.

Composition follows the design system's own reference usage (`apps/webkit-sample`, `SiteNav.vue`): a `List` is the bar, each entry an `Item`, and an entry renders either a plain `Trigger` with an `href` or a `Trigger` + `Content` panel whose columns are nested `List`s of `layout="entry"` items.

Both shapes are kept even though this repo's data only ever takes the first: `src/i18n/*/header.ts` ships **three entries with `items: []`** — three plain links. The whole panel apparatus was unreachable, and so were the `rightBlock`, `overline`, `external` and `icon` keys its template read, none of which appear in any header data file. Keeping the panel branch makes adding a submenu a data change rather than a component change.

### Config change this required

`@aziontech/webkit` joins the two `noExternal` lists in `astro.config.ts`, alongside the entry already there for `@aziontech/theme`. The `navigation-menu` export is an `index.js` that imports `.vue` files, and Node cannot load those during SSR — `Unknown file extension ".vue"`, with Astro's own hint naming this fix. Components whose entry is itself a `.vue` or `.ts` work either way, which is why this only surfaced now, after Button, Tag, Brand and Dropdown had already been adopted.

Visibility classes stay on the `Item` wrapper rather than the `Trigger`: a control's base `inline-flex` outranks a `hidden` passed in as a class. Same cascade trap the header CTAs hit in #2321, and the design system's sample carries a note about it.

## Verification

- `pnpm run build` — 1494 pages, exit 0 (validated separately for each change).
- Built HTML carries `<nav data-testid="navigation-menu">` with the three `navigation-menu__trigger` anchors and the correct hrefs; **zero** `wk-nav-button` classes remain.
- `.text-button-lg` / `.text-button-md` are present in the emitted CSS, resolving through the theme's tokens.
- Button sizes measured in the browser against the webkit sample at the same viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)