### PR TITLE
fix(docs): update region hosting information for Tiered Cache

### DIFF
--- a/src/content/docs/en/pages/main-menu/reference/build/edge-application/l2-caching.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/build/edge-application/l2-caching.mdx
@@ -45,7 +45,7 @@ Tiered Cache is only available if the service has been activated for your accoun
 
 When you enable **Tiered Cache** as an extra caching layer, the edge servers of this second caching layer are hosted in the US (`na-united-states`) by default. 
 
-Azion also offers the option of hosting the Tiered Cache servers in Brazil (`sa-brazil`). To switch between regions in your applications, please contact the [Sales team](https://www.azion.com/en/contact/).
+Azion also offers the option of hosting the Tiered Cache servers in other regions. To switch between regions in your applications, please contact the [Sales team](https://www.azion.com/en/contact/).
 
 ---
 


### PR DESCRIPTION
## What & why

Changed "hosting the Tiered Cache servers in Brazil (sa-brazil)" to "hosting the Tiered Cache servers in other locations" for better localization in our EN pages.


## Type of change

- [ ] 🆕 New content (`feat`)
- [X] 🩹 Fix (`fix`) — typo, broken link, wrong information
- [ ] ♻️ Content update (`docs`) — rewrite, expansion, upkeep
- [ ] 🌐 Translation sync (`i18n`)
- [ ] 🏗️ Platform / structure (`refactor` / `chore`) — reviewed by UXE, no content mixed in

## Author checklist

- [ ] PR title follows `type(scope): summary` (see [GOVERNANCE.md §4](GOVERNANCE.md))
- [ ] Frontmatter complete: `title`, `description`, `meta_tags`, `namespace`, `permalink`, `last_reviewed`
- [ ] No legacy "edge-" product names in the copy
- [ ] How-to/tutorial content includes at least one runnable, copy-paste-tested code block
- [ ] Screenshots (if any) have alt text and follow image standards
- [ ] Internal links are relative and resolve locally
- [ ] **If any permalink changed or page moved: redirect added in this PR**
- [ ] **i18n:** `pt-br` updated in this PR **or** follow-up `i18n` issue created: <!-- link -->
- [ ] I ran `pnpm build:local` (build + frontmatter check) without errors