### PR TITLE
fix(docs): update geolocation country codes and names

### DIFF
--- a/src/content/docs/en/pages/main-menu/reference/build/edge-application/rules-engine.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/build/edge-application/rules-engine.mdx
@@ -100,12 +100,12 @@ Check the full list of variables available and their processing phase:
 | `${domain}` | Similar to the `${host}` variable. Stores the host name or the Host header from the request, excluding the last subdomain after the second-level domain | `${domain}` assumes `blog.domain.com` for `az.blog.domain.com` | Request <br />Response |
 | `${geoip_city}` | Name of the city, using the geolocation base `geoip_city` | `Sao Paulo` | Request <br />Response |
 | `${geoip_city_continent_code}` | 2-letter continent code, using the geolocation base `geoip_city` | `EU` for Europe | Request <br />Response |
-| `${geoip_city_country_code}` | 2-letter country code, using the geolocation base `geoip_city` | `BR` for Brazil | Request <br />Response |
+| `${geoip_city_country_code}` | 2-letter country code, using the geolocation base `geoip_city` | `IN` for India | Request <br />Response |
 | `${geoip_city_country_name}` | Name of the country, using the geolocation base `geoip_city` | `United States` | Request <br />Response |
 | `${geoip_continent_code}` | 2-letter continent code | `NA` for North America | Request <br />Response |
 | `${geoip_country_code}` | 2-letter country code, using the geolocation base `geoip_country` | `RU` for Russia | Request <br />Response |
-| `${geoip_country_name}` | Name of the country, using the geolocation base `geoip_country` | `Brazil` | Request <br />Response |
-| `${geoip_region}` | 2-letter region code | `RS` for Rio Grande do Sul | Request <br />Response |
+| `${geoip_country_name}` | Name of the country, using the geolocation base `geoip_country` | `France` | Request <br />Response |
+| `${geoip_region}` | 2-letter region code | `FL` for Florida | Request <br />Response |
 | `${geoip_region_name}` | Name of the region, using the geolocation base `geoip_region` | `Ontario` | Request <br />Response |
 | `${host}` | In order of precedence: the host name of the request line, or the value of the `Host` header, or the name of the server serving the request | `blog.domain.com` | Request <br />Response |
 | `${http_name}` | The value of a request header. `name` must be a valid [HTTP request header](https://developer.mozilla.org/en-US/docs/Glossary/Request_header) converted to lowercase; hyphens must be converted to underscore | `${http_accept}` assumes `image/webp,image/apng` for `Accept: image/webp,image/apng` | Request <br />Response |


### PR DESCRIPTION
## What & why

Replaced geoip_city and regions from Brazilian mentions with global ones for better localization

## Type of change

- [ ] 🆕 New content (`feat`)
- [x] 🩹 Fix (`fix`) — typo, broken link, wrong information
- [ ] ♻️ Content update (`docs`) — rewrite, expansion, upkeep
- [ ] 🌐 Translation sync (`i18n`)
- [ ] 🏗️ Platform / structure (`refactor` / `chore`) — reviewed by UXE, no content mixed in

## Author checklist

- [ ] PR title follows `type(scope): summary` (see [GOVERNANCE.md §4](GOVERNANCE.md))
- [ ] Frontmatter complete: `title`, `description`, `meta_tags`, `namespace`, `permalink`, `last_reviewed`
- [ ] No legacy "edge-" product names in the copy
- [ ] How-to/tutorial content includes at least one runnable, copy-paste-tested code block
- [ ] Screenshots (if any) have alt text and follow image standards
- [ ] Internal links are relative and resolve locally
- [ ] **If any permalink changed or page moved: redirect added in this PR**
- [ ] **i18n:** `pt-br` updated in this PR **or** follow-up `i18n` issue created: <!-- link -->
- [ ] I ran `pnpm build:local` (build + frontmatter check) without errors