### PR TITLE
docs(waf): remove unimplemented Unwanted Access and Identified Attack flags

### DIFF
--- a/src/content/docs/en/pages/devtools/cli/azion-cli/config/azion-config-js.mdx
+++ b/src/content/docs/en/pages/devtools/cli/azion-cli/config/azion-config-js.mdx
@@ -339,10 +339,6 @@ Type definition for the Web Application Firewall (WAF) configuration.
   - `sensitivity: string` - Sensitivity level (low, medium, high).
 - `fileUpload?: object` - File Upload settings.
   - `sensitivity: string` - Sensitivity level (low, medium, high).
-- `unwantedAccess?: object` - Unwanted Access settings.
-  - `sensitivity: string` - Sensitivity level (low, medium, high).
-- `identifiedAttack?: object` - Identified Attack settings.
-  - `sensitivity: string` - Sensitivity level (low, medium, high).
 - `bypassAdresses?: string[]` - List of IP addresses to bypass the WAF.
 
 </Fragment>
@@ -674,7 +670,7 @@ Type definition for Web Application Firewall (WAF) configuration.
   - `attributes: WafEngineAttributes` - Engine attributes.
     - `rulesets: 1[]` - Rule sets.
     - `thresholds: WafThreshold[]` - Threat thresholds.
-      - `threat: 'cross_site_scripting' | 'directory_traversal' | 'evading_tricks' | 'file_upload' | 'identified_attack' | 'remote_file_inclusion' | 'sql_injection' | 'unwanted_access'` - Threat type.
+      - `threat: 'cross_site_scripting' | 'directory_traversal' | 'evading_tricks' | 'file_upload' | 'remote_file_inclusion' | 'sql_injection'` - Threat type.
       - `sensitivity: 'lowest' | 'low' | 'medium' | 'high' | 'highest'` - Sensitivity level.
 
 ### `AzionFunction`

--- a/src/content/docs/en/pages/main-menu/reference/secure/edge-firewall/web-application-firewall/waf-rule-sets.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/secure/edge-firewall/web-application-firewall/waf-rule-sets.mdx
@@ -37,8 +37,6 @@ The **Threat Type Configuration** table is available in the [Main Settings tab](
 | Cross-Site Scripting (XSS) | Prevents the injection of client-side scripts into pages viewed by your visitors |
 | File Upload | Detects the attempt to upload files to the web server |
 | Evading Tricks | Protects against some coding tricks used to try to evade protective mechanisms |
-| Unwanted Access | Detects attempts to access administrative or vulnerable pages, bots, and security scanning tools |
-| Identified Attack | Prevents several types of common attacks and known vulnerabilities that should certainly be blocked |
 
 
 

--- a/src/content/docs/en/pages/main-menu/reference/secure/edge-firewall/web-application-firewall/web-application-firewall.mdx
+++ b/src/content/docs/en/pages/main-menu/reference/secure/edge-firewall/web-application-firewall/web-application-firewall.mdx
@@ -58,7 +58,7 @@ Learn more about [Firewall modules](/en/documentation/products/secure/firewall/)
 
 ## WAF Main Settings
 
-The **Main Settings** section is configured by activating protection against specific threat families: SQL Injection, Remote File Inclusions (RFI), Directory Traversal, Cross-Site Scripting (XSS), File upload, Evading tricks, Unwanted Access, and Identified Attack, and setting a sensitivity level: Lowest, Low, Medium, High, and Highest.
+The **Main Settings** section is configured by activating protection against specific threat families: SQL Injection, Remote File Inclusions (RFI), Directory Traversal, Cross-Site Scripting (XSS), File upload, and Evading tricks, and setting a sensitivity level: Lowest, Low, Medium, High, and Highest.
 
 The **Threat Type Configuration** table categorizes threats into families, according to the purpose of the attack.
 

--- a/src/content/docs/en/pages/secure-journey/firewall-advanced-configurations/add-waf-rule-set.mdx
+++ b/src/content/docs/en/pages/secure-journey/firewall-advanced-configurations/add-waf-rule-set.mdx
@@ -70,10 +70,8 @@ curl --request POST \
           { "threat": "directory_traversal",  "sensitivity": "medium" },
           { "threat": "evading_tricks",       "sensitivity": "medium" },
           { "threat": "file_upload",          "sensitivity": "medium" },
-          { "threat": "identified_attack",    "sensitivity": "medium" },
           { "threat": "remote_file_inclusion","sensitivity": "medium" },
-          { "threat": "sql_injection",        "sensitivity": "medium" },
-          { "threat": "unwanted_access",      "sensitivity": "medium" }
+          { "threat": "sql_injection",        "sensitivity": "medium" }
         ]
       }
     }

--- a/src/content/docs/pt-br/pages/devtools/cli/azion-cli/configs/azion-config-js.mdx
+++ b/src/content/docs/pt-br/pages/devtools/cli/azion-cli/configs/azion-config-js.mdx
@@ -338,10 +338,6 @@ Definição de tipo para a configuração do Web Application Firewall (WAF).
   - `sensitivity: string` - Nível de sensibilidade (low, medium, high).
 - `fileUpload?: object` - Configurações de File Upload.
   - `sensitivity: string` - Nível de sensibilidade (low, medium, high).
-- `unwantedAccess?: object` - Configurações de Unwanted Access.
-  - `sensitivity: string` - Nível de sensibilidade (low, medium, high).
-- `identifiedAttack?: object` - Configurações de Identified Attack.
-  - `sensitivity: string` - Nível de sensibilidade (low, medium, high).
 - `bypassAdresses?: string[]` - Lista de endereços IP para ignorar o WAF.
 
 </Fragment>
@@ -673,7 +669,7 @@ Definição de tipo para a configuração do Web Application Firewall (WAF).
   - `attributes: WafEngineAttributes` - Atributos do motor.
     - `rulesets: 1[]` - Conjuntos de regras.
     - `thresholds: WafThreshold[]` - Limiares de ameaças.
-      - `threat: 'cross_site_scripting' | 'directory_traversal' | 'evading_tricks' | 'file_upload' | 'identified_attack' | 'remote_file_inclusion' | 'sql_injection' | 'unwanted_access'` - Tipo de ameaça.
+      - `threat: 'cross_site_scripting' | 'directory_traversal' | 'evading_tricks' | 'file_upload' | 'remote_file_inclusion' | 'sql_injection'` - Tipo de ameaça.
       - `sensitivity: 'lowest' | 'low' | 'medium' | 'high' | 'highest'` - Nível de sensibilidade.
 
 ### `AzionFunction`

--- a/src/content/docs/pt-br/pages/menu-principal/referencia/secure/edge-firewall/web-application-firewall/waf-rule-sets.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/referencia/secure/edge-firewall/web-application-firewall/waf-rule-sets.mdx
@@ -37,8 +37,6 @@ A tabela **Threat Type Configuration** está disponível na aba [Main Settings](
 | Cross-Site Scripting (XSS) | Previne a injeção de *scripts client-side* em páginas vistas por seus visitantes |
 | File Upload | Detecta a tentativa de envio de arquivos para o servidor web |
 | Evading Tricks | Protege contra alguns truques de codificação utilizados para tentar escapar dos mecanismos de proteção |
-| Unwanted Access | Detecta as tentativas de acesso a páginas administrativas ou vulneráveis, bots e ferramentas de *scanning* de segurança |
-| Identified Attacks | Previne vários tipos de ataques comuns e vulnerabilidades conhecidas que certamente deverão ser bloqueados |
 
 ---
 

--- a/src/content/docs/pt-br/pages/menu-principal/referencia/secure/edge-firewall/web-application-firewall/web-application-firewall.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/referencia/secure/edge-firewall/web-application-firewall/web-application-firewall.mdx
@@ -56,7 +56,7 @@ Saiba mais sobre os [módulos do Firewall](/pt-br/documentacao/produtos/secure/f
 
 ## WAF Main Settings
 
-A seção de **Main Settings** é configurada ativando a proteção contra famílias específicas de ameaças: SQL Injection, Remote File Inclusions (RFI), Directory Traversal, Cross-Site Scripting (XSS), File upload, Evading tricks, Unwanted Access e Identified Attack, e definindo um nível de sensibilidade: Lowest, Low, Medium, High e Highest.
+A seção de **Main Settings** é configurada ativando a proteção contra famílias específicas de ameaças: SQL Injection, Remote File Inclusions (RFI), Directory Traversal, Cross-Site Scripting (XSS), File upload e Evading tricks, e definindo um nível de sensibilidade: Lowest, Low, Medium, High e Highest.
 
 A tabela de **Threat Type Configuration** categoriza as ameaças em famílias, de acordo com o propósito do ataque.
 

--- a/src/content/docs/pt-br/pages/secure-jornada/firewall-configuracoes-avancadas/criar-waf-rule-set.mdx
+++ b/src/content/docs/pt-br/pages/secure-jornada/firewall-configuracoes-avancadas/criar-waf-rule-set.mdx
@@ -70,10 +70,8 @@ curl --request POST \
           { "threat": "directory_traversal",  "sensitivity": "medium" },
           { "threat": "evading_tricks",       "sensitivity": "medium" },
           { "threat": "file_upload",          "sensitivity": "medium" },
-          { "threat": "identified_attack",    "sensitivity": "medium" },
           { "threat": "remote_file_inclusion","sensitivity": "medium" },
-          { "threat": "sql_injection",        "sensitivity": "medium" },
-          { "threat": "unwanted_access",      "sensitivity": "medium" }
+          { "threat": "sql_injection",        "sensitivity": "medium" }
         ]
       }
     }


### PR DESCRIPTION
## What & why

**Related issue:** none
**Pages affected:**
- `/en/documentation/products/secure/firewall/web-application-firewall/` and `pt-br` equivalent
- `/en/documentation/products/secure/firewall/web-application-firewall/rules-set/` and `pt-br` equivalent
- `/en/documentation/products/devtools/cli/azion-cli/config/azion-config-js/` and `pt-br` equivalent
- `/en/documentation/products/guides/secure/create-waf-rule-set/` and `pt-br` equivalent

Engineering never implemented the **Unwanted Access** and **Identified Attack** WAF threat families in the product, but they were still documented in the Main Settings threat table, the CLI/SDK config schema, and a sample API request payload — in both `en` and `pt-br`. This PR removes every reference to keep the docs accurate.

## Type of change

- [ ] 🆕 New content (`feat`)
- [ ] 🩹 Fix (`fix`) — typo, broken link, wrong information
- [x] ♻️ Content update (`docs`) — rewrite, expansion, upkeep
- [ ] 🌐 Translation sync (`i18n`)
- [ ] 🏗️ Platform / structure (`refactor` / `chore`) — reviewed by UXE, no content mixed in

## Author checklist

- [x] PR title follows `type(scope): summary` (see [GOVERNANCE.md §4](GOVERNANCE.md))
- [x] Frontmatter complete: `title`, `description`, `meta_tags`, `namespace`, `permalink`, `last_reviewed`
- [x] No legacy "edge-" product names in the copy
- [ ] How-to/tutorial content includes at least one runnable, copy-paste-tested code block
- [ ] Screenshots (if any) have alt text and follow image standards
- [x] Internal links are relative and resolve locally
- [x] **If any permalink changed or page moved: redirect added in this PR** (no permalinks changed)
- [x] **i18n:** `pt-br` updated in this PR **or** follow-up `i18n` issue created
- [ ] I ran `pnpm build:local` (build + frontmatter check) without errors — attempted locally but `astro build` ran out of memory (OOM) in this environment, unrelated to the content change; no build errors were observed before the OOM