### PR TITLE
docs(release-notes): add release notes for Aug 26, Aug 28, and Sep 2, 2026

### DIFF
--- a/src/content/docs/en/pages/main-menu/release-notes/release-notes.mdx
+++ b/src/content/docs/en/pages/main-menu/release-notes/release-notes.mdx
@@ -34,7 +34,7 @@ import Tag from 'primevue/tag'
 
 #### Features
 
-- **Azion Plans**: Added a new plans experience with onboarding and billing v2. Customers now pick their plan at signup, see billing screens tailored to their plan, and get a smoother checkout with reused saved cards and Terms of Service acceptance integrated into payment confirmation.
+- **Azion Plans**: Added a new plans experience with onboarding and billing. Customers now pick their plan at signup, see billing screens tailored to their plan, and get a smoother checkout with reused saved cards and Terms of Service acceptance integrated into payment confirmation.
 - **Cache Purge**: Enabled automatic cache purge when publishing changes.
 
 #### Improvements

--- a/src/content/docs/en/pages/main-menu/release-notes/release-notes.mdx
+++ b/src/content/docs/en/pages/main-menu/release-notes/release-notes.mdx
@@ -11,6 +11,77 @@ import Tag from 'primevue/tag'
 
 
 ---
+## September 2, 2026
+
+### Terraform Provider
+
+**Version 2.8.0**
+
+#### Improvements
+
+- **Drift Detection**: Resources now support drift detection, so out-of-band changes made in the Azion Console are reverted by `terraform plan` to match your Terraform configuration.
+
+#### Bug Fixes
+
+- **Import**: Fixed `terraform import` across multiple data sources and resources.
+- **Firewall Rules Engine**: Fixed an issue affecting Firewall Rules Engine arguments.
+- **Function Instances**: Fixed an issue with function instance import.
+
+---
+## August 28, 2026
+
+### Azion Console
+
+#### Features
+
+- **Azion Plans**: Added a new plans experience with onboarding and billing v2. Customers now pick their plan at signup, see billing screens tailored to their plan, and get a smoother checkout with reused saved cards and Terms of Service acceptance integrated into payment confirmation.
+- **Cache Purge**: Enabled automatic cache purge when publishing changes.
+
+#### Improvements
+
+- **Plan and Cycle Changes**: The pending change banner now differentiates between a plan downgrade and a billing cycle downgrade, showing the correct plan name and impact for each.
+- **Environment**: Combined Global Variables and Variables into a single section, and secret variable values are now masked and write-only after being saved.
+- **Environment**: Variable keys are now automatically formatted as `UPPER_SNAKE_CASE`.
+- **Deployment**: Renamed the "Routing and policy" section to "Settings" and the "Deployment version policy" field to "Version policy"; version policy options are now labeled "Single" and "Versioned" throughout the platform.
+- **Deployment**: The "Flexible" binding policy is now the default and listed first when creating a deployment.
+- **Versioning**: Combined the "Save" and "Save and Build" actions into a single button.
+
+#### Bug Fixes
+
+- **Object Storage Metrics**: Fixed a missing label and unit for the Object Storage "Data Stored" metric in Billing invoice details and the Home Monthly Usage card.
+- **Payment History**: Fixed the pagination controls being unusable on mobile.
+- **Plan Switching**: Fixed an error incorrectly shown when switching plans multiple times without an actual change taking effect.
+- **Invoice Filter**: Removed a non-functional invoice search filter and fixed a label mismatch between the filter and the invoice list column.
+- **Signup Plan Carousel**: Fixed plan card clicks being ignored on narrow screens during signup.
+- **Signup Checkout**: Fixed a checkout error that could occur when quickly switching between plans or billing cycles during signup.
+- **Onboarding**: Fixed onboarding after switching accounts overwriting the operator's own profile information instead of the new account's.
+- **Checkout**: Fixed the checkout payment form not offering a previously saved card for reuse.
+- **Billing**: Fixed the Billing screen not always refreshing subscription data when navigating to it, which could show stale billing information.
+- **Billing**: Fixed a request loop that could occur when reading subscription data failed.
+- **Payment Methods**: Fixed the payment method button appearing in the Bills tab's empty state instead of the Payment Methods tab.
+- **Address Form**: Fixed required-field errors appearing prematurely after selecting a country, before the form was submitted.
+- **Workload**: Fixed compatible deployments not being listed when linking Deployment Settings to certain environments.
+- **Release Details**: Fixed the release details panel not displaying fully on mobile.
+- **azion.json**: Fixed validation of the `urls` field to correctly require each item to be a string.
+
+---
+## August 26, 2026
+
+### Azion CLI
+
+**Version 4.23.0**
+
+#### Features
+
+- **DNS**: Added a new command tree for managing DNS zones, records, and DNSSEC.
+- **Custom Pages**: Added commands for managing Custom Pages.
+
+#### Bug Fixes
+
+- **Order By**: Fixed the `--order-by` flag not being applied correctly.
+- **Timeout**: Fixed the `--timeout` flag being ignored.
+
+---
 ## July 29, 2026
 
 ### Azion Console

--- a/src/content/docs/en/pages/main-menu/release-notes/release-notes.mdx
+++ b/src/content/docs/en/pages/main-menu/release-notes/release-notes.mdx
@@ -44,7 +44,6 @@ import Tag from 'primevue/tag'
 - **Environment**: Variable keys are now automatically formatted as `UPPER_SNAKE_CASE`.
 - **Deployment**: Renamed the "Routing and policy" section to "Settings" and the "Deployment version policy" field to "Version policy"; version policy options are now labeled "Single" and "Versioned" throughout the platform.
 - **Deployment**: The "Flexible" binding policy is now the default and listed first when creating a deployment.
-- **Versioning**: Combined the "Save" and "Save and Build" actions into a single button.
 
 #### Bug Fixes
 

--- a/src/content/docs/pt-br/pages/menu-principal/release-notes/release-notes.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/release-notes/release-notes.mdx
@@ -34,7 +34,7 @@ import Tag from 'primevue/tag'
 
 #### Recursos
 
-- **Azion Plans**: Adicionada uma nova experiência de planos com onboarding e billing v2. Agora os clientes escolhem seu plano no cadastro, veem telas de billing de acordo com o plano contratado e têm um checkout mais fluido, com reaproveitamento de cartões salvos e aceite dos Termos de Serviço integrado à confirmação de pagamento.
+- **Azion Plans**: Adicionada uma nova experiência de planos com onboarding e billing. Agora os clientes escolhem seu plano no cadastro, veem telas de billing de acordo com o plano contratado e têm um checkout mais fluido, com reaproveitamento de cartões salvos e aceite dos Termos de Serviço integrado à confirmação de pagamento.
 - **Purge de Cache**: Habilitado o purge automático de cache ao publicar alterações.
 
 #### Melhorias

--- a/src/content/docs/pt-br/pages/menu-principal/release-notes/release-notes.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/release-notes/release-notes.mdx
@@ -44,7 +44,6 @@ import Tag from 'primevue/tag'
 - **Environment**: As chaves das variáveis agora são formatadas automaticamente em `UPPER_SNAKE_CASE`.
 - **Deployment**: A seção "Routing and policy" foi renomeada para "Settings" e o campo "Deployment version policy" para "Version policy"; as opções de política de versão agora são chamadas de "Single" e "Versioned" em toda a plataforma.
 - **Deployment**: A política de binding "Flexible" agora é o padrão e aparece primeiro na criação de um deployment.
-- **Versionamento**: As ações "Save" e "Save and Build" foram unificadas em um único botão.
 
 #### Correções de Bugs
 

--- a/src/content/docs/pt-br/pages/menu-principal/release-notes/release-notes.mdx
+++ b/src/content/docs/pt-br/pages/menu-principal/release-notes/release-notes.mdx
@@ -11,6 +11,77 @@ import Tag from 'primevue/tag'
 
 
 ---
+## 2 de setembro, 2026
+
+### Terraform Provider
+
+**Versão 2.8.0**
+
+#### Melhorias
+
+- **Detecção de Drift**: Os recursos agora oferecem suporte à detecção de drift, então alterações feitas fora do Terraform diretamente no Azion Console são revertidas pelo `terraform plan` para corresponder à sua configuração do Terraform.
+
+#### Correções de Bugs
+
+- **Import**: Corrigido o `terraform import` em múltiplos data sources e recursos.
+- **Rules Engine de Firewall**: Corrigido um problema que afetava argumentos do Rules Engine de firewall.
+- **Instâncias de Function**: Corrigido um problema no import de instâncias de function.
+
+---
+## 28 de agosto, 2026
+
+### Azion Console
+
+#### Recursos
+
+- **Azion Plans**: Adicionada uma nova experiência de planos com onboarding e billing v2. Agora os clientes escolhem seu plano no cadastro, veem telas de billing de acordo com o plano contratado e têm um checkout mais fluido, com reaproveitamento de cartões salvos e aceite dos Termos de Serviço integrado à confirmação de pagamento.
+- **Purge de Cache**: Habilitado o purge automático de cache ao publicar alterações.
+
+#### Melhorias
+
+- **Alterações de Plano e Ciclo**: O banner de alteração pendente agora diferencia downgrade de plano e downgrade de ciclo de cobrança, exibindo o nome do plano e o impacto corretos para cada caso.
+- **Environment**: Global Variables e Variables foram unificadas em uma única seção, e valores de variáveis secretas agora ficam mascarados e write-only após serem salvos.
+- **Environment**: As chaves das variáveis agora são formatadas automaticamente em `UPPER_SNAKE_CASE`.
+- **Deployment**: A seção "Routing and policy" foi renomeada para "Settings" e o campo "Deployment version policy" para "Version policy"; as opções de política de versão agora são chamadas de "Single" e "Versioned" em toda a plataforma.
+- **Deployment**: A política de binding "Flexible" agora é o padrão e aparece primeiro na criação de um deployment.
+- **Versionamento**: As ações "Save" e "Save and Build" foram unificadas em um único botão.
+
+#### Correções de Bugs
+
+- **Métricas do Object Storage**: Corrigida a falta de rótulo e unidade da métrica "Data Stored" do Object Storage nos detalhes de fatura do Billing e no card Monthly Usage da Home.
+- **Histórico de Pagamentos**: Corrigidos os controles de paginação, que ficavam inutilizáveis no mobile.
+- **Troca de Plano**: Corrigido um erro exibido incorretamente ao trocar de plano múltiplas vezes sem que houvesse alteração real.
+- **Filtro de Faturas**: Removido um filtro de busca de faturas que não funcionava e corrigida a divergência entre o rótulo do filtro e a coluna da listagem de faturas.
+- **Carrossel de Planos no Cadastro**: Corrigidos cliques nos cards de plano que eram ignorados em telas estreitas durante o cadastro.
+- **Checkout no Cadastro**: Corrigido um erro de checkout que podia ocorrer ao trocar rapidamente de plano ou de ciclo de cobrança durante o cadastro.
+- **Onboarding**: Corrigido o onboarding após a troca de conta, que sobrescrevia os dados do próprio perfil do operador em vez dos dados da nova conta.
+- **Checkout**: Corrigido o formulário de pagamento do checkout, que não oferecia um cartão salvo anteriormente para reutilização.
+- **Billing**: Corrigida a tela de Billing, que nem sempre atualizava os dados da subscription ao ser acessada, podendo exibir informações de cobrança desatualizadas.
+- **Billing**: Corrigido um loop de requisições que podia ocorrer quando a leitura dos dados da subscription falhava.
+- **Métodos de Pagamento**: Corrigido o botão de método de pagamento, que aparecia no empty state da aba Bills em vez da aba Payment Methods.
+- **Formulário de Endereço**: Corrigidos os erros de campo obrigatório exibidos prematuramente após selecionar o país, antes do envio do formulário.
+- **Workload**: Corrigidos os deployments compatíveis, que não apareciam ao vincular Deployment Settings a determinados environments.
+- **Detalhes da Release**: Corrigido o painel de detalhes da release, que não era exibido por completo no mobile.
+- **azion.json**: Corrigida a validação do campo `urls` para exigir corretamente que cada item seja uma string.
+
+---
+## 26 de agosto, 2026
+
+### Azion CLI
+
+**Versão 4.23.0**
+
+#### Recursos
+
+- **DNS**: Adicionada uma nova árvore de comandos para gerenciar zonas DNS, records e DNSSEC.
+- **Custom Pages**: Adicionados comandos para gerenciar Custom Pages.
+
+#### Correções de Bugs
+
+- **Order By**: Corrigida a flag `--order-by`, que não era aplicada corretamente.
+- **Timeout**: Corrigida a flag `--timeout`, que estava sendo ignorada.
+
+---
 ## 29 de julho, 2026
 
 ### Azion Console


### PR DESCRIPTION
## What & why

Adds three new release notes entries covering Azion CLI 4.23.0, Azion Console (Azion Plans launch plus billing/versioning fixes), and Terraform Provider 2.8.0.

- **September 2, 2026** — Terraform Provider 2.8.0: drift detection support, plus fixes for `terraform import`, Firewall Rules Engine arguments, and function instance import.
- **August 28, 2026** — Azion Console: Azion Plans launch (new plans/onboarding/billing v2 experience), automatic cache purge on publish, plus a batch of billing, environment, deployment, versioning, and workload fixes.
- **August 26, 2026** — Azion CLI 4.23.0: new DNS command tree (zones, records, DNSSEC) and Custom Pages commands, plus fixes for `--order-by` and `--timeout` flags.

**Related issue:** none
**Pages affected:**
- `src/content/docs/en/pages/main-menu/release-notes/release-notes.mdx`
- `src/content/docs/pt-br/pages/menu-principal/release-notes/release-notes.mdx`

## Type of change

- [ ] 🆕 New content (`feat`)
- [ ] 🩹 Fix (`fix`) — typo, broken link, wrong information
- [x] ♻️ Content update (`docs`) — rewrite, expansion, upkeep
- [ ] 🌐 Translation sync (`i18n`)
- [ ] 🏗️ Platform / structure (`refactor` / `chore`) — reviewed by UXE, no content mixed in

## Author checklist

- [x] PR title follows `type(scope): summary` (see [GOVERNANCE.md §4](GOVERNANCE.md))
- [x] Frontmatter complete: `title`, `description`, `meta_tags`, `namespace`, `permalink`, `last_reviewed`
- [x] No legacy "edge-" product names in the copy
- [n/a] How-to/tutorial content includes at least one runnable, copy-paste-tested code block
- [n/a] Screenshots (if any) have alt text and follow image standards
- [x] Internal links are relative and resolve locally
- [n/a] **If any permalink changed or page moved: redirect added in this PR**
- [x] **i18n:** `pt-br` updated in this PR
- [x] I ran `pnpm build:local` (build + frontmatter check) without errors
