### PR TITLE
feat(style-guide): adds style guide pages with new webkit components. 

### DIFF
--- a/src/content/docs/en/pages/style-guide/components.mdx
+++ b/src/content/docs/en/pages/style-guide/components.mdx
@@ -9,19 +9,11 @@ permalink: /documentation/style-guide/components/
 menu_namespace: styleGuideMenu
 ---
 
-Documentation pages are MDX, and this page is the whole component vocabulary. A component absent from this page is not available: an invented import fails the build, and the legacy components that do resolve are banned in the next section, with the reasons.
-
-## Do not use these components
-
-These render, but they are not part of this site's vocabulary — legacy from the Astro docs fork, unmaintained, several styled with theme variables this site no longer defines:
-
-`Card` · `Badge` · `FileTree` · `Checklist` · `Spoiler` · `Since` · `Button` · `TabBox` · `Breadcrumb`
-
-All nine compile and emit markup, so nothing fails at build when one slips in. The concrete hazards: `FileTree` injects a nested `<html><body>` block into the page; `Since` fetches the npm registry at render time and reports Astro release versions; `TabBox` carries hardcoded npm and yarn content; `Card` calls an external screenshot service; `Button` duplicates `LinkButton` without its conventions. If you need what one of these would have done, use a table, an aside, or `LinkButton`.
+Documentation pages are MDX, and this page is the whole component vocabulary: every entry is a design system component from `@aziontech/webkit`, or a thin wrapper over one. A component absent from this page is not available: an import of it fails the build.
 
 ## Asides
 
-No import needed. Asides are written as remark directives, and they are the most common construct after links.
+No import needed. Asides are written as remark directives and render the design system's `DocCallout`; they are the most common construct after links.
 
 ```mdx
 :::note
@@ -38,27 +30,31 @@ You are viewing the latest version. For accounts that are not migrated, refer to
 :::
 ```
 
-Valid types: `note`, `tip`, `caution`, `danger`.
+Valid types: `note`, `tip`, `caution`, `danger`. `caution` renders as the callout's warning kind.
 
 **`:::warning` is not valid** and does not render as intended. Use `:::caution`.
 
-The bracket text overrides the auto-translated title. In Portuguese pages, localize it: `:::note[nota]`, `:::tip[dica]`, `:::caution[Atenção]`.
+- A callout holds inline prose only: sentences, links, inline code. A list, a fence, or a table inside one breaks out of the box; put it before or after the aside.
+- The callout has no title row. The bracket text is kept as a lead-in to the copy (`Did you know? — ...`), so use it only when the first words need it. In Portuguese pages, localize it: `:::note[nota]`, `:::tip[dica]`, `:::caution[Atenção]`.
 
-## LinkButton
+## DocButton
 
-The house call to action.
+The house call to action. A wrapper around the design system's Button that keeps the button styling inside the article body.
 
 ```mdx
-import LinkButton from 'azion-webkit/linkbutton'
+import DocButton from '~/components/webkit/DocButton.vue'
 
-<LinkButton severity="secondary" label="Real-Time Purge reference" link="/en/documentation/products/build/applications/real-time-purge/" />
+<DocButton href="/en/documentation/products/build/applications/real-time-purge/" label="Real-Time Purge reference" kind="secondary" size="medium" />
 ```
 
-Props in use: `link`, `label`, `severity="secondary"`, `outlined`, `icon`, `iconPos`.
+- `href` and `label` are required. No client directive: the button is a static link.
+- `kind`: omit it for the primary action, `secondary` for a reference link. `outlined`, `text`, and `danger` also exist.
+- Always `size="medium"`.
+- `icon` takes an icon class, always placed before the label. `target="_blank"` opens an external destination in a new tab.
 
 ## Code
 
-Wrapper around expressive-code. Gives a copy button.
+Renders the design system's `CodeBlock`, with a language tab and a copy button. Fenced blocks render the same component.
 
 ```mdx
 import Code from '~/components/Code/Code.astro'
@@ -78,7 +74,7 @@ Language tags in use: `bash`, `sh`, `json`, `javascript`, `js`, `typescript`, `t
 
 ## Tabs and Fragment
 
-The multi-interface pattern: one task, one panel per interface.
+The multi-interface pattern: one task, one panel per interface. Renders the design system's `TabView`, with every panel kept in the HTML.
 
 ```mdx
 import Tabs from '~/components/tabs/Tabs'
@@ -107,7 +103,7 @@ import Code from '~/components/Code/Code.astro'
 - `client:visible` is mandatory. Without it the tabs render and do not switch.
 - Every `tab.x` needs a matching `panel.x`.
 - **Blank lines around markdown inside a Fragment are mandatory**, or the markdown renders as one literal paragraph.
-- First panel is the default; put Console first unless there is a reason not to.
+- The first tab is the default, and panels are paired to tabs by key; put Console first unless there is a reason not to.
 - Canonical keys: `tab.console`, `tab.api`, `tab.cli`, plus `tab.apiv3` / `tab.apiv4` for versioned APIs.
 - Optional `sharedStore="package-managers"` syncs selection across tab groups on a page.
 
@@ -116,12 +112,14 @@ import Code from '~/components/Code/Code.astro'
 Status badges.
 
 ```mdx
-import Tag from 'primevue/tag';
+import Tag from '~/components/webkit/Tag.vue'
 
-<Tag severity="info" client:only="vue" value="Preview" />
+<Tag severity="info">Preview</Tag>
 ```
 
-`client:only="vue"` is mandatory. Without it the badge renders and does not hydrate.
+- No client directive: the badge is static HTML.
+- `severity` is `success`, `info`, `warning`, or `danger`. `info` is the neutral label chip, used for "Preview" and product badges; the other three are status colors.
+- The label goes in the children. `value="Preview"` is also accepted.
 
 ## Video
 
@@ -136,7 +134,7 @@ No import needed. Emits the iframe plus schema.org `VideoObject` metadata.
 />
 ```
 
-`src` must be a YouTube **embed** URL. `src` and `title` are required.
+`src` must be a YouTube **embed** URL. `src` and `title` are required. For a screenshot or a clip file, use Figure.
 
 ## Mermaid diagrams
 
@@ -151,6 +149,134 @@ flowchart LR
 ````
 
 Label every node and edge in words, and never rely on color alone to carry a distinction. A diagram never stands alone: architecture and use-case pages keep the numbered dataflow beneath it.
+
+## Steps
+
+A numbered walkthrough: each step is a title with an optional body, and the numbers come from the order on the page.
+
+```mdx
+import DocSteps from '@aziontech/webkit/doc-steps'
+import DocStep from '@aziontech/webkit/doc-step'
+
+<DocSteps>
+  <DocStep title="Create the bucket">
+
+  In [Azion Console](https://console.azion.com/), go to **Object Storage** and select **+ Bucket**.
+
+  </DocStep>
+  <DocStep title="Name it">
+
+  Bucket names must be unique across all existing buckets.
+
+  </DocStep>
+</DocSteps>
+```
+
+- No client directive.
+- Never write the number: reordering the steps renumbers them.
+- A `DocStep` must sit inside a `DocSteps`; alone it throws. Blank lines around the markdown inside a step are mandatory.
+
+## Figure
+
+A framed screenshot, clip, or diagram, with an optional lead-in above and a caption below.
+
+```mdx
+import DocFrame from '@aziontech/webkit/doc-frame'
+
+<DocFrame
+  src="/assets/docs/images/uploads/real-time-metrics-overview.png"
+  alt="Overview of a Real-Time Metrics query flow"
+  caption="The query flow, from the console to the data source."
+/>
+```
+
+- `src` takes an image or a clip (`.mp4`, `.webm`). Give an image an `alt`. Without `src`, the frame wraps its children, such as a `mermaid` fence.
+- `caption` and `hint` are plain strings; the slots of the same name (`<Fragment slot="caption">`) carry a caption with a link or inline code.
+- `autoplay` plays a clip muted, inline, and looping, with no controls.
+
+## Cards
+
+A grid of navigation cards, for a page that fans out into sections.
+
+```mdx
+import DocCardGroup from '@aziontech/webkit/doc-card-group'
+import DocCard from '@aziontech/webkit/doc-card'
+
+<DocCardGroup cols={2}>
+  <DocCard title="Build" href="/en/documentation/products/build/" label="Applications, functions, and connectors." />
+  <DocCard title="Secure" href="/en/documentation/products/secure/">Firewall, WAF, and DDoS protection.</DocCard>
+</DocCardGroup>
+```
+
+- No client directive.
+- `cols` is 2, 3, or 4; the grid collapses to one column on a phone.
+- `href` makes the whole card the link. `label` is the copy; children replace it when the copy needs a link or inline code.
+- Optional: `icon` takes a PrimeIcons class (`pi pi-bolt`), `overline` a small line above the title, `link` a call-to-action text on a closing row.
+
+## Related items
+
+A framed list of rows, each a name and one sentence, for a reader choosing what to read next.
+
+```mdx
+import ItemList from '@aziontech/webkit/item-list'
+import DocItem from '@aziontech/webkit/doc-item'
+
+<ItemList>
+  <DocItem title="Cache Settings" href="/en/documentation/products/build/applications/cache-settings/">How an edge node decides what to keep and for how long.</DocItem>
+  <DocItem title="Rules Engine" href="/en/documentation/products/build/applications/rules-engine/">Conditions and behaviors on the request and response phases.</DocItem>
+</ItemList>
+```
+
+- No client directive. `ItemList` is the frame that rules between the rows.
+- `href` makes the row the link; an external URL gets the outward arrow. Optional `icon` takes a PrimeIcons class.
+
+## Changelog entry
+
+One dated entry: label and version on the left, the notes on the right, with an anchor built from the label.
+
+```mdx
+import DocUpdate from '@aziontech/webkit/doc-update'
+
+<DocUpdate label="July 10, 2026" description="Bot Manager 1.3.0" tags={['Marketplace']}>
+
+**Bot Manager** now ships nine new static rules and two new arguments.
+
+</DocUpdate>
+```
+
+- No client directive. Blank lines around the markdown inside are mandatory.
+- `label` is the anchor, slugified. Two entries with the same label need distinct `anchor` values.
+- `description` is the line under the label; `tags` is an array of short labels.
+
+## Prompt
+
+A block of literal text the reader hands to an agent, set in the mono face with a copy control. It is not a code block: no language, no highlighting.
+
+```mdx
+import DocPrompt from '@aziontech/webkit/doc-prompt'
+
+<DocPrompt client:visible title="Try it">Create an application with caching enabled and deploy it.</DocPrompt>
+```
+
+- `client:visible` is mandatory: the copy control and the expand control need it.
+- `kind="line"` makes one scrolling line instead of a paragraph capped at four lines. `title` and `icon` are optional.
+
+## Inline gloss
+
+A term in running prose that shows its definition on hover or focus, with an optional link.
+
+```mdx
+import DocTooltip from '@aziontech/webkit/doc-tooltip'
+
+The <DocTooltip client:visible headline="Cache key" tip="The identifier an edge node builds from a request." cta="Read more" href="/en/documentation/products/build/applications/cache-settings/">cache key</DocTooltip> decides what matches.
+```
+
+- `client:visible` is mandatory; without it the term renders and never opens.
+- `tip` is the definition, `headline` the bold lead-in, `cta` plus `href` the link.
+
+## Supplied by the layout
+
+`DocPageHeader` (from `title` and `description` in the frontmatter), `DocOnThisPage`, `DocPagination`, and the `DocProse` typography contract render around every page. Never author them.
 
 ---
 
@@ -168,7 +294,7 @@ Available: `apiv4Rollout`, `JourneyAPI`, `InterfaceNote`, `LetsEncryptExpiration
 
 ## SectionBasicContent
 
-Hero block, used on template showcase pages. Takes `description` and a `buttons` array, with content in a `<Fragment slot="content">`. Read an existing showcase page before using it.
+The header block of a template showcase page. Import it from `~/components/SectionBasicContent/SectionBasicContent.vue`. Takes `description` and a `buttons` array, with the rest of the page in a `<Fragment slot="content">`. Each button takes `label`, `link`, and optionally `severity: "secondary"`, `outlined: true`, `icon`, and `target`. A button without `link` renders nothing. Read an existing showcase page before using it.
 
 ## GuidesTable
 

--- a/src/content/docs/en/pages/style-guide/components.mdx
+++ b/src/content/docs/en/pages/style-guide/components.mdx
@@ -1,0 +1,234 @@
+---
+title: Components
+description: >-
+  Use the live MDX component set for documentation pages: asides, tabs, code
+  blocks, videos, diagrams, and the rules each one carries.
+meta_tags: 'style guide, components, MDX'
+namespace: documentation_style_guide_components
+permalink: /documentation/style-guide/components/
+menu_namespace: styleGuideMenu
+---
+
+Documentation pages are MDX, and this page is the whole component vocabulary. A component absent from this page is not available: an invented import fails the build, and the legacy components that do resolve are banned in the next section, with the reasons.
+
+## Do not use these components
+
+These render, but they are not part of this site's vocabulary — legacy from the Astro docs fork, unmaintained, several styled with theme variables this site no longer defines:
+
+`Card` · `Badge` · `FileTree` · `Checklist` · `Spoiler` · `Since` · `Button` · `TabBox` · `Breadcrumb`
+
+All nine compile and emit markup, so nothing fails at build when one slips in. The concrete hazards: `FileTree` injects a nested `<html><body>` block into the page; `Since` fetches the npm registry at render time and reports Astro release versions; `TabBox` carries hardcoded npm and yarn content; `Card` calls an external screenshot service; `Button` duplicates `LinkButton` without its conventions. If you need what one of these would have done, use a table, an aside, or `LinkButton`.
+
+## Asides
+
+No import needed. Asides are written as remark directives, and they are the most common construct after links.
+
+```mdx
+:::note
+Bucket names must be unique across all existing buckets.
+:::
+
+:::tip
+**Increase limits** <br></br>
+Contact [technical support](/en/documentation/services/support/) to request a higher limit for your plan.
+:::
+
+:::caution[important]
+You are viewing the latest version. For accounts that are not migrated, refer to the [legacy reference](/en/documentation/products/build/edge-application/v3/).
+:::
+```
+
+Valid types: `note`, `tip`, `caution`, `danger`.
+
+**`:::warning` is not valid** and does not render as intended. Use `:::caution`.
+
+The bracket text overrides the auto-translated title. In Portuguese pages, localize it: `:::note[nota]`, `:::tip[dica]`, `:::caution[Atenção]`.
+
+## LinkButton
+
+The house call to action.
+
+```mdx
+import LinkButton from 'azion-webkit/linkbutton'
+
+<LinkButton severity="secondary" label="Real-Time Purge reference" link="/en/documentation/products/build/applications/real-time-purge/" />
+```
+
+Props in use: `link`, `label`, `severity="secondary"`, `outlined`, `icon`, `iconPos`.
+
+## Code
+
+Wrapper around expressive-code. Gives a copy button.
+
+```mdx
+import Code from '~/components/Code/Code.astro'
+
+<Code lang="bash" code={`azion deploy --local`} />
+```
+
+Accepts only `code` and `lang`.
+
+**The value is a JavaScript template literal.** Backticks and `${` inside it must be escaped, and a line continuation needs a doubled backslash. When a snippet contains either, that is a reason to use `<Code>` rather than a fence, because you control the escaping.
+
+Fenced blocks are also house style. Use a fence for output the reader reads, and `<Code>` for input the reader copies.
+
+Language tags in use: `bash`, `sh`, `json`, `javascript`, `js`, `typescript`, `ts`, `hcl`, `graphql`, `shell`, `text`, `plaintext`. Terraform is `hcl`, not `terraform`.
+
+---
+
+## Tabs and Fragment
+
+The multi-interface pattern: one task, one panel per interface.
+
+```mdx
+import Tabs from '~/components/tabs/Tabs'
+import Code from '~/components/Code/Code.astro'
+
+<Tabs client:visible>
+    <Fragment slot="tab.console">Console</Fragment>
+    <Fragment slot="tab.api">API</Fragment>
+
+<Fragment slot="panel.console">
+
+1. Access [Azion Console](https://console.azion.com/) > **Object Storage**.
+2. Select **+ Bucket**.
+
+</Fragment>
+
+<Fragment slot="panel.api">
+
+<Code lang="bash" code={`curl ...`} />
+
+</Fragment>
+
+</Tabs>
+```
+
+- `client:visible` is mandatory. Without it the tabs render and do not switch.
+- Every `tab.x` needs a matching `panel.x`.
+- **Blank lines around markdown inside a Fragment are mandatory**, or the markdown renders as one literal paragraph.
+- First panel is the default; put Console first unless there is a reason not to.
+- Canonical keys: `tab.console`, `tab.api`, `tab.cli`, plus `tab.apiv3` / `tab.apiv4` for versioned APIs.
+- Optional `sharedStore="package-managers"` syncs selection across tab groups on a page.
+
+## Tag
+
+Status badges.
+
+```mdx
+import Tag from 'primevue/tag';
+
+<Tag severity="info" client:only="vue" value="Preview" />
+```
+
+`client:only="vue"` is mandatory. Without it the badge renders and does not hydrate.
+
+## Video
+
+No import needed. Emits the iframe plus schema.org `VideoObject` metadata.
+
+```mdx
+<Video
+  src="https://www.youtube.com/embed/BV4jRPpADw8"
+  title="Local development with Azion CLI"
+  description="How the CLI supports local debugging and faster workflows."
+  uploadDate="2023-10-17"
+/>
+```
+
+`src` must be a YouTube **embed** URL. `src` and `title` are required.
+
+## Mermaid diagrams
+
+A diagram is a `mermaid` code fence, not an image. The text reaches an agent fetching the markdown twin; an image reference does not.
+
+````md
+```mermaid
+flowchart LR
+  Client --> Edge[Edge node]
+  Edge --> Origin[Origin server]
+```
+````
+
+Label every node and edge in words, and never rely on color alone to carry a distinction. A diagram never stands alone: architecture and use-case pages keep the numbered dataflow beneath it.
+
+---
+
+## Shared snippets
+
+Reusable blocks under `~/includes/snippets/`, each with an `en/` and a `pt/` variant. Note the Portuguese folder is `pt/`, not `pt-br/`.
+
+```mdx
+import Apiv4Rollout from '~/includes/snippets/apiv4Rollout/en/snippet.mdx'
+
+<Apiv4Rollout />
+```
+
+Available: `apiv4Rollout`, `JourneyAPI`, `InterfaceNote`, `LetsEncryptExpiration`, `RulesEngineExecution`.
+
+## SectionBasicContent
+
+Hero block, used on template showcase pages. Takes `description` and a `buttons` array, with content in a `<Fragment slot="content">`. Read an existing showcase page before using it.
+
+## GuidesTable
+
+Renders the Guides and tutorials hub as a table of name, last updated, and difficulty. Used on the hub page of a product section, and nowhere else.
+
+```mdx
+import GuidesTable from '~/components/GuidesTable.astro'
+
+<GuidesTable
+  lang="en"
+  prefixes={['/documentation/build/cache/guides/', '/documentation/build/cache/tutorials/']}
+  exclude={['/documentation/build/cache/guides/']}
+/>
+```
+
+- `prefixes` — permalink prefixes whose pages fill the table. `exclude` drops the hub page itself.
+- The date comes from the file's last git commit, read at build time. Never write it by hand. An uncommitted or shallow-cloned file shows a dash.
+- Difficulty comes from the optional `difficulty` frontmatter field: `Beginner`, `Intermediate`, or `Advanced`. The value stays English on both language pages; the component localizes the label.
+- Rows sort newest first, then by title.
+- The same prefixes go in the menu row's `covers` field, so the pages pass the sidebar ownership check.
+
+---
+
+## GlossaryFilter
+
+Client-side filter over a glossary table. Used on a product's Glossary page, and nowhere else.
+
+```mdx
+import GlossaryFilter from '~/components/GlossaryFilter.astro'
+
+<GlossaryFilter lang="en">
+
+| Term | Definition |
+| --- | --- |
+| cache key | The identifier an edge node builds from a request to decide whether two requests match the same cached object. |
+
+</GlossaryFilter>
+```
+
+- The child is one GFM pipe table, `| Term | Definition |`. Blank lines around it are mandatory.
+- `lang` localizes the filter placeholder and the empty-state message: `en` or `pt-br`.
+- Each body row gets an anchor id from its term, ASCII-folded (`ação múltipla` → `#acao-multipla`), so a definition is deep-linkable. Ids are set at render time, so anchors work without JavaScript.
+- Filtering is a progressive enhancement: without JavaScript the full table renders. Matching is case- and accent-insensitive, against the whole row.
+
+## Tables and line breaks
+
+Tables are plain GFM pipe tables. Horizontal scrolling is added automatically; do not wrap them yourself.
+
+`<br />` or `<br></br>`. **Bare `<br>` breaks the build** — MDX requires every tag closed.
+
+## MDX rules that break builds
+
+- Bare `<` and `{` in prose are parsed as JSX. Escape them or use backticks.
+- Every tag must be closed or self-closing.
+- No H1 in the body; `title` renders it.
+- `---` between major sections is house style, roughly three per page. Never immediately after the frontmatter block.
+- Imports go directly after the frontmatter block, before any prose.
+
+## Related resources
+
+- [Code](/en/documentation/style-guide/formatting/code/) - when a fence carries output and a `<Code>` block carries input.
+- [Text formatting](/en/documentation/style-guide/formatting/text/) - links, bold, italics, and monospace around the components.
+- [Choose a content type](/en/documentation/style-guide/content/choose-a-content-type/) - the page kinds these components serve.

--- a/src/content/docs/en/pages/style-guide/components.mdx
+++ b/src/content/docs/en/pages/style-guide/components.mdx
@@ -8,6 +8,9 @@ namespace: documentation_style_guide_components
 permalink: /documentation/style-guide/components/
 menu_namespace: styleGuideMenu
 ---
+import FrameBox from '@aziontech/webkit/frame-box'
+import ItemList from '@aziontech/webkit/item-list'
+import DocItem from '@aziontech/webkit/doc-item'
 
 Documentation pages are MDX, and this page is the whole component vocabulary: every entry is a design system component from `@aziontech/webkit`, or a thin wrapper over one. A component absent from this page is not available: an import of it fails the build.
 
@@ -196,7 +199,7 @@ import DocFrame from '@aziontech/webkit/doc-frame'
 
 ## Cards
 
-A grid of navigation cards, for a page that fans out into sections.
+A grid of navigation cards, for a page that fans out into sections. It is the closing `## Next steps` section of a page: one card per destination, with the reason as the copy.
 
 ```mdx
 import DocCardGroup from '@aziontech/webkit/doc-card-group'
@@ -215,20 +218,24 @@ import DocCard from '@aziontech/webkit/doc-card'
 
 ## Related items
 
-A framed list of rows, each a name and one sentence, for a reader choosing what to read next.
+A framed list of rows, each a name and one sentence, for a reader choosing what to read next. It is the closing `## Related` section of a page.
 
 ```mdx
+import FrameBox from '@aziontech/webkit/frame-box'
 import ItemList from '@aziontech/webkit/item-list'
 import DocItem from '@aziontech/webkit/doc-item'
 
+<FrameBox>
 <ItemList>
   <DocItem title="Cache Settings" href="/en/documentation/products/build/applications/cache-settings/">How an edge node decides what to keep and for how long.</DocItem>
   <DocItem title="Rules Engine" href="/en/documentation/products/build/applications/rules-engine/">Conditions and behaviors on the request and response phases.</DocItem>
 </ItemList>
+</FrameBox>
 ```
 
-- No client directive. `ItemList` is the frame that rules between the rows.
+- No client directive. `FrameBox` draws the perimeter; `ItemList` rules between the rows.
 - `href` makes the row the link; an external URL gets the outward arrow. Optional `icon` takes a PrimeIcons class.
+- The copy is one sentence: what the thing is, or why the reader would go there. Inline code and links are allowed; blocks are not.
 
 ## Changelog entry
 
@@ -355,6 +362,10 @@ Tables are plain GFM pipe tables. Horizontal scrolling is added automatically; d
 
 ## Related resources
 
-- [Code](/en/documentation/style-guide/formatting/code/) - when a fence carries output and a `<Code>` block carries input.
-- [Text formatting](/en/documentation/style-guide/formatting/text/) - links, bold, italics, and monospace around the components.
-- [Choose a content type](/en/documentation/style-guide/content/choose-a-content-type/) - the page kinds these components serve.
+<FrameBox>
+<ItemList>
+  <DocItem title="Code" href="/en/documentation/style-guide/formatting/code/">When a fence carries output and a `<Code>` block carries input.</DocItem>
+  <DocItem title="Text formatting" href="/en/documentation/style-guide/formatting/text/">Links, bold, italics, and monospace around the components.</DocItem>
+  <DocItem title="Choose a content type" href="/en/documentation/style-guide/content/choose-a-content-type/">The page kinds these components serve.</DocItem>
+</ItemList>
+</FrameBox>

--- a/src/content/docs/en/pages/style-guide/content/architecture.mdx
+++ b/src/content/docs/en/pages/style-guide/content/architecture.mdx
@@ -1,0 +1,130 @@
+---
+title: Architecture pages
+description: >-
+  Write an architecture page: the diagram, the dataflow, the components, and
+  the links to the guides that implement the design.
+meta_tags: 'style guide, architecture, explanation'
+namespace: documentation_style_guide_architecture
+permalink: /documentation/style-guide/content/architecture/
+menu_namespace: styleGuideMenu
+---
+
+## Purpose
+
+An architecture page shows how several products combine into one design. The reader wants to understand the shape of a solution before building it.
+
+It applies the **explanation** base form, the same form as a [concept page](/en/documentation/style-guide/content/concept/). The difference is the subject: a concept page explains one thing, an architecture page explains how many things fit together.
+
+## When to use
+
+Write an architecture page when:
+
+- A solution needs more than one product, and the relationship between them is the point.
+- The reader must see the order of a request or a dataflow to understand the design.
+- A guide keeps redrawing the same system in prose.
+
+Do not write an architecture page when:
+
+- The subject is one product or one idea. Write a [concept page](/en/documentation/style-guide/content/concept/).
+- The reader wants to build the thing. Write a [multi-product guide](/en/documentation/style-guide/content/multi-product-guides/) and link it from here.
+- The design cannot be drawn. A design you cannot draw is one you do not yet understand well enough to publish.
+
+## Register
+
+Descriptive: 25 words per sentence, active voice, passive only when the actor is unknown. Tone: explanatory, plain, systematic. [Sentence structure](/en/documentation/style-guide/writing/sentence-structure/) holds the rules.
+
+## Structure
+
+The title names the design as a noun phrase: `Content delivery on a distributed network`. The opening paragraph states what problem the design solves and for whom.
+
+**Required sections, in order**
+
+- **`## Architecture diagram`**: the diagram as a `mermaid` code fence, then a paragraph that reads it.
+- **`### Dataflow`**: a numbered walkthrough of what moves where, with six items at most.
+- **`## Components`**: what each part does and why it is there.
+- **`## Implementation`**: links to the how-tos, and only links.
+- **`## Related resources`**: the closing section, as bulleted links, each with its reason.
+
+## Template
+
+````md
+<What problem this design solves, and for whom.>
+
+## Architecture diagram
+
+```mermaid
+flowchart LR
+  <the design, as text an agent can read>
+```
+
+<A paragraph that reads the diagram: what to look at first, and what depends on what.>
+
+### Dataflow
+
+1. <What moves first, and where it goes.>
+2. <What the platform does with it.>
+3. <Where the flow ends.>
+
+## Components
+
+- **<Component name>**: <what it does and why it is there>.
+- **<Component name>**: <what it does and why it is there>.
+
+## Implementation
+
+- [<How-to that implements this design>](<guide URL>) - <why the reader follows it>.
+
+## Related resources
+
+- [<Related page>](<page URL>) - <what the reader gets there>.
+````
+
+## Rules
+
+- **Draw the diagram in `mermaid`.** The diagram is text, so an agent fetching the markdown twin reads the design itself instead of an image reference. Do not use an image for an architecture diagram.
+- **The diagram never stands alone.** The numbered dataflow carries the meaning, and it stays even when the diagram renders.
+- **Label every node and edge in words**, and never rely on color alone to carry a distinction.
+- **Name every component and say why it is there.** A list of product names is a parts list.
+- **Link the implementation, do not inline it.** Steps belong in a [multi-product guide](/en/documentation/style-guide/content/multi-product-guides/).
+- **Write only the sections you can confirm.** A required section whose content you cannot confirm with the team that owns the product is left out until you can, never filled with a guess.
+
+## Examples
+
+- [Deploy Jamstack websites on a distributed network](/en/documentation/architectures/jamstack/deploy-jamstack-applications/): a diagram, a numbered dataflow, the components involved, and links out to the implementation.
+
+This trimmed excerpt shows the opening, the diagram section, and the dataflow:
+
+````mdx
+This design delivers a site's content from locations close to users. It reduces latency and the load on the origin infrastructure. Use it when your team delivers static-heavy sites and applications.
+
+## Architecture diagram
+
+```mermaid
+flowchart LR
+  Client -->|HTTP request| Node[Azion node]
+  Node --> Rules[Rules Engine]
+  Rules --> Cache[Cache layer]
+  Cache -->|Cache hit| Client
+  Cache -->|Cache miss| Origin[Origin server]
+  Origin --> Cache
+```
+
+The diagram shows the path of a request and its response through an application on Azion's distributed network. A client request reaches a node on Azion's distributed network, where Rules Engine and the cache layer process it. Content that is not in the cache comes from the origin server, and the response returns to the client through the same node.
+
+### Dataflow
+
+A request moves through the design in this order:
+
+1. A client sends an HTTP or HTTPS request to a domain associated with an application.
+2. At the Azion node, Rules Engine processes the request. It applies cache policies and image optimization behaviors in the request phase.
+3. The cache layer evaluates the request. On a cache-key match, the node delivers the object from the cache.
+4. On a cache miss, the node forwards the request to the origin server. The origin responds, and the node caches the content.
+5. Before the response returns to the client, Rules Engine processes the response-phase policies. The node then delivers the content to the user.
+````
+
+## Related
+
+- [Concept pages](/en/documentation/style-guide/content/concept/): the same base form, for one idea rather than a system.
+- [Multi-product guides](/en/documentation/style-guide/content/multi-product-guides/): the page that builds what this one describes.
+- [Images](/en/documentation/style-guide/formatting/images/): alt text and asset paths.
+- [Choose a content type](/en/documentation/style-guide/content/choose-a-content-type/): the full catalogue of page kinds.

--- a/src/content/docs/en/pages/style-guide/content/architecture.mdx
+++ b/src/content/docs/en/pages/style-guide/content/architecture.mdx
@@ -8,6 +8,9 @@ namespace: documentation_style_guide_architecture
 permalink: /documentation/style-guide/content/architecture/
 menu_namespace: styleGuideMenu
 ---
+import FrameBox from '@aziontech/webkit/frame-box'
+import ItemList from '@aziontech/webkit/item-list'
+import DocItem from '@aziontech/webkit/doc-item'
 
 ## Purpose
 
@@ -43,11 +46,15 @@ The title names the design as a noun phrase: `Content delivery on a distributed 
 - **`### Dataflow`**: a numbered walkthrough of what moves where, with six items at most.
 - **`## Components`**: what each part does and why it is there.
 - **`## Implementation`**: links to the how-tos, and only links.
-- **`## Related resources`**: the closing section, as bulleted links, each with its reason.
+- **`## Related resources`**: the closing section, a `DocItem` list, each row with its reason.
 
 ## Template
 
-````md
+````mdx
+import FrameBox from '@aziontech/webkit/frame-box'
+import ItemList from '@aziontech/webkit/item-list'
+import DocItem from '@aziontech/webkit/doc-item'
+
 <What problem this design solves, and for whom.>
 
 ## Architecture diagram
@@ -76,7 +83,11 @@ flowchart LR
 
 ## Related resources
 
-- [<Related page>](<page URL>) - <what the reader gets there>.
+<FrameBox>
+<ItemList>
+  <DocItem title="<Related page>" href="<page URL>"><what the reader gets there>.</DocItem>
+</ItemList>
+</FrameBox>
 ````
 
 ## Rules
@@ -124,7 +135,11 @@ A request moves through the design in this order:
 
 ## Related
 
-- [Concept pages](/en/documentation/style-guide/content/concept/): the same base form, for one idea rather than a system.
-- [Multi-product guides](/en/documentation/style-guide/content/multi-product-guides/): the page that builds what this one describes.
-- [Images](/en/documentation/style-guide/formatting/images/): alt text and asset paths.
-- [Choose a content type](/en/documentation/style-guide/content/choose-a-content-type/): the full catalogue of page kinds.
+<FrameBox>
+<ItemList>
+  <DocItem title="Concept pages" href="/en/documentation/style-guide/content/concept/">The same base form, for one idea rather than a system.</DocItem>
+  <DocItem title="Multi-product guides" href="/en/documentation/style-guide/content/multi-product-guides/">The page that builds what this one describes.</DocItem>
+  <DocItem title="Images" href="/en/documentation/style-guide/formatting/images/">Alt text and asset paths.</DocItem>
+  <DocItem title="Choose a content type" href="/en/documentation/style-guide/content/choose-a-content-type/">The full catalogue of page kinds.</DocItem>
+</ItemList>
+</FrameBox>

--- a/src/content/docs/en/pages/style-guide/content/changelog.mdx
+++ b/src/content/docs/en/pages/style-guide/content/changelog.mdx
@@ -8,6 +8,9 @@ namespace: documentation_style_guide_changelog
 permalink: /documentation/style-guide/content/changelog/
 menu_namespace: styleGuideMenu
 ---
+import FrameBox from '@aziontech/webkit/frame-box'
+import ItemList from '@aziontech/webkit/item-list'
+import DocItem from '@aziontech/webkit/doc-item'
 
 ## Purpose
 
@@ -97,5 +100,9 @@ For more information, refer to [Azion Bot Manager Lite](/en/documentation/produc
 
 ## Related
 
-- [Documentation terminology](/en/documentation/style-guide/writing/terminology/): the historical-name exemption that applies here.
-- [Choose a content type](/en/documentation/style-guide/content/choose-a-content-type/): the full catalogue of page kinds.
+<FrameBox>
+<ItemList>
+  <DocItem title="Documentation terminology" href="/en/documentation/style-guide/writing/terminology/">The historical-name exemption that applies here.</DocItem>
+  <DocItem title="Choose a content type" href="/en/documentation/style-guide/content/choose-a-content-type/">The full catalogue of page kinds.</DocItem>
+</ItemList>
+</FrameBox>

--- a/src/content/docs/en/pages/style-guide/content/changelog.mdx
+++ b/src/content/docs/en/pages/style-guide/content/changelog.mdx
@@ -1,0 +1,101 @@
+---
+title: Changelog pages
+description: >-
+  Write a changelog entry: an append-only record that keeps the product names
+  of its period and states what changed for the reader.
+meta_tags: 'style guide, changelog, release notes'
+namespace: documentation_style_guide_changelog
+permalink: /documentation/style-guide/content/changelog/
+menu_namespace: styleGuideMenu
+---
+
+## Purpose
+
+A changelog records notable changes to the platform, newest first. It is a **record**, not one of the four Diátaxis forms: it does not teach, instruct, or explain, and a reader consults it to answer one question, which is what changed and when.
+
+## When to use
+
+- Add an entry when a change alters what a reader can do, see, or configure.
+- Add it when a default changes, a limit moves, or a feature is removed.
+
+Do not add an entry when:
+
+- Nothing changed for the reader. An internal refactor is not a changelog entry.
+- The change needs instructions. Write the [how-to guide](/en/documentation/style-guide/content/how-to-guides/) and link it from the entry.
+- The change deserves reasoning. Write the [concept page](/en/documentation/style-guide/content/concept/) and link it.
+
+## Register
+
+Descriptive: 25 words per sentence, active voice, passive only when the actor is unknown. Tone: factual, plain, impersonal. [Sentence structure](/en/documentation/style-guide/writing/sentence-structure/) holds the rules.
+
+## Structure
+
+An entry sits under a date heading and runs three to six short paragraphs, with no headings of its own. When a release groups entries by area, the product heading nests one level deeper under the area heading.
+
+**Required components**
+
+- **A date heading**: `## <Month> <day>, <year>`, newest first. Dates are allowed in changelogs and only in changelogs.
+- **The opening sentence**: `**<Product>** now <verb>s <capability>.`, plus the concrete detail: the flag, the field, or the default.
+- **What it means concretely**: what works without configuration now, or what behaves differently.
+- **Who is not affected**: existing configurations, earlier versions, accounts that did not opt in.
+- **The closing link**: `For more information, refer to [<the documenting page>](/en/documentation/.../).`
+
+**Optional components**
+
+- **A product heading**: `### <Product> <version>`, under the date heading, when the release names a product or a version.
+- **Migration or opt-in steps**: with a code sample, when an API, CLI, or configuration changed.
+
+## Template
+
+```md
+## <Month> <day>, <year>
+
+### <Product> <version, when there is one>
+
+**<Product>** now <verb>s <capability>, <the concrete detail: the flag, field, or default>.
+
+<What this means in practice: what works without configuration now, or what behaves differently.>
+
+<Who is not affected: existing configurations, earlier versions, accounts that did not opt in — and how they can opt in.>
+
+<When an API, CLI, or configuration changed: the migration or opt-in, with a code sample.>
+
+For more information, refer to [<the documenting page>](/en/documentation/.../).
+```
+
+## Rules
+
+- **Open with the product as the subject.** `**<Product>** now <verb>s <capability>.` Present tense, never `we`, never `Azion is excited to`.
+- **State who is not affected.** A reader's first question about any change is whether it breaks them; answer it before they ask.
+- **Show migration or opt-in steps when the surface changed.** An API, CLI, or configuration change gets a code sample; two lines is enough.
+- **Close every entry with the documentation link.** An entry that documents the feature in full is a page filed in the wrong place.
+- **Never rewrite an entry.** Correct it with a new dated entry; the log is append-only.
+- **Keep the product names of the period.** A dated record keeps the names it was written with; only new entries use current names.
+- **End the page with its oldest entry.** A changelog has no closing section: no Next steps and no Related resources.
+
+## Examples
+
+- [Changelog archive](/en/documentation/changelog/archive/): entries grouped by year, each naming the product and the change.
+
+This trimmed entry shows the date heading, the area heading, and the entry shape:
+
+```mdx
+## July 10, 2026
+
+### Marketplace
+
+#### Bot Manager 1.3.0 and Bot Manager Lite 0.2.0
+
+**Bot Manager** now has new versions for both plans: Bot Manager Lite 0.2.0 and Bot Manager 1.3.0 for the standard plan. The standard plan was formerly named Advanced.
+
+The release adds nine new static rules and two new arguments. The `good_fingerprint_list` argument allows listed fingerprints to bypass Bot Manager validation. The `block_ai_bots` argument blocks known AI user agents automatically.
+
+This release does not upgrade existing installations. To get the new Lite version, launch [Bot Manager Lite](https://console.azion.com/marketplace/solution/azion/bot-manager-lite) through Azion Marketplace. The standard version of [Azion Bot Manager](/en/documentation/products/secure/firewall/bot-manager/) remains available on demand, upon request to the Service Delivery team.
+
+For more information, refer to [Azion Bot Manager Lite](/en/documentation/products/secure/firewall/bot-manager-lite/).
+```
+
+## Related
+
+- [Documentation terminology](/en/documentation/style-guide/writing/terminology/): the historical-name exemption that applies here.
+- [Choose a content type](/en/documentation/style-guide/content/choose-a-content-type/): the full catalogue of page kinds.

--- a/src/content/docs/en/pages/style-guide/content/choose-a-content-type.mdx
+++ b/src/content/docs/en/pages/style-guide/content/choose-a-content-type.mdx
@@ -1,0 +1,123 @@
+---
+title: Choose a content type
+description: >-
+  Pick a content type: the four base forms, the full catalog of page kinds
+  built from them, and the tests that separate them.
+meta_tags: 'style guide, content types, diataxis'
+namespace: documentation_style_guide_choose_content_type
+permalink: /documentation/style-guide/content/choose-a-content-type/
+menu_namespace: styleGuideMenu
+---
+
+## Pick the form by the reader's goal
+
+Every documentation page is written in one of four base forms, from Diátaxis. The form decides the structure of the page and its [sentence rules](/en/documentation/style-guide/writing/sentence-structure/). Pick the form by what the reader wants to do, not by what you want to write about.
+
+| The reader wants to | The form is |
+| --- | --- |
+| Learn the product by doing something that works | [Tutorial](/en/documentation/style-guide/content/tutorials/) |
+| Accomplish a specific task they already have in mind | [How-to guide](/en/documentation/style-guide/content/how-to-guides/) |
+| Look up a fact: a limit, a field, a flag, a response code | [Reference](/en/documentation/style-guide/content/reference/) |
+| Understand why something works the way it does | Explanation, as a [concept](/en/documentation/style-guide/content/concept/) or [architecture](/en/documentation/style-guide/content/architecture/) page |
+
+The forms answer "how do I write this page". The page-kinds catalog answers "which page do I build".
+
+## The page kinds
+
+A page kind is a base form plus a place in the [information architecture](/en/documentation/style-guide/content/information-architecture/) and a template. This is the complete catalog. Every page in the documentation is one of these kinds.
+
+| Kind | Base form | Required per product | Purpose |
+| --- | --- | --- | --- |
+| [Overview](/en/documentation/style-guide/content/overview/) | Reference | Yes | The product root: what the product is, what it does, when to use it |
+| [Quickstart](/en/documentation/style-guide/content/quickstart/) | Tutorial | Yes | From not using the product to the smallest working result |
+| [Tutorial](/en/documentation/style-guide/content/tutorials/) | Tutorial | No | Teach the product by building a goal the author chose |
+| [How-to guide](/en/documentation/style-guide/content/how-to-guides/) | How-to | No | Complete one task the reader arrived with |
+| [Multi-product guide](/en/documentation/style-guide/content/multi-product-guides/) | How-to | No | Reach a goal that crosses products, on one recommended path |
+| [Use case](/en/documentation/style-guide/content/use-cases/) | How-to | No | Implement a business scenario end to end, as a spec an agent can follow |
+| [Troubleshooting](/en/documentation/style-guide/content/troubleshooting/) | How-to | No | From a symptom the reader sees to a fix |
+| [Reference](/en/documentation/style-guide/content/reference/) | Reference | No | Look up fields, values, defaults, and limits |
+| [Concept](/en/documentation/style-guide/content/concept/) | Explanation | No | Understand how something works and why it is built that way |
+| [Architecture](/en/documentation/style-guide/content/architecture/) | Explanation | No | How products combine into a design |
+| [Changelog](/en/documentation/style-guide/content/changelog/) | Record | No | Log notable changes, append-only |
+| [Glossary](/en/documentation/style-guide/content/glossary/) | Reference | Yes | Define the terms the product's documentation uses, in a filterable table |
+| [Navigation hub](/en/documentation/style-guide/content/navigation-hubs/) | None | No | Direct readers deeper. Links plus one sentence of orientation |
+
+## Slots are not kinds
+
+A slot is a position in a product section; a kind is the shape of a page. The [information architecture](/en/documentation/style-guide/content/information-architecture/) lists thirteen slots, and this catalog holds thirteen kinds. Equal length is a coincidence: the two lists do not map onto each other.
+
+Several slots share one kind. Limits, Examples, and Features and capabilities all hold reference pages, placed in different slots because readers reach them at different moments. Best practices and How it works both hold concept pages. One slot can also hold several kinds: Guides and tutorials holds a navigation hub, the how-to guides, and the tutorials. Adding a slot never adds a kind, and a page that fits no kind is a page whose content type is still undecided.
+
+## Kinds Azion does not use
+
+Some kinds common in other documentation sets are deliberately absent, because each dissolves into the catalog:
+
+- **FAQ**: a list of questions is a list of pages in disguise. Route each answer to its kind, and the question becomes a heading a search can find.
+- **Configuration**: examples of settings and values are reference content. The kind adds a second name for the same page.
+- **Design, implementation, and solution guides**: three names for content the catalog already holds. A goal that crosses products is a [multi-product guide](/en/documentation/style-guide/content/multi-product-guides/). A business scenario built end to end is a [use case](/en/documentation/style-guide/content/use-cases/). The reasoning behind a design is a [concept](/en/documentation/style-guide/content/concept/) or an [architecture](/en/documentation/style-guide/content/architecture/) page.
+- **Third-party integration guide**: a how-to guide that crosses a vendor's interface. The [third-party rules](/en/documentation/style-guide/content/how-to-guides/) cover it.
+- **API guidelines** are not covered by this guide yet.
+
+## Separate tutorials from how-to guides
+
+Tutorials and how-to guides both contain steps. They serve opposite readers, and this is the distinction that matters most.
+
+A tutorial reader does not yet know what they want. They learn, and you teach. You choose the goal, you guarantee the result, and you keep decisions away from the reader. "Deploy your first application" is a tutorial: the reader has no application in mind, and any application will do.
+
+A how-to reader already knows what they want. They arrived with a problem. You remove obstacles; you do not teach. "Configure cache policies" is a how-to: the reader has a cache problem and wants it gone.
+
+Two tests separate the forms in practice. If you write "you can also" or "depending on your setup", the page is a how-to, because tutorials do not branch. If you interrupt the steps to explain what a bucket is, the page is a tutorial or a concept page, not a how-to.
+
+## Separate reference from concept
+
+Reference and explanation both describe; neither form instructs. They differ in use: one is a map the reader consults, the other is a discussion the reader reads.
+
+Reference is the map. It is complete, consistent, and deliberately plain. Nobody reads a reference from top to bottom. If a reader who scans for a limit value skips a sentence, that sentence does not belong on the page.
+
+Explanation is the discussion. It provides context, alternatives, and reasons. It is the only form where "why" and "instead of" belong. A design decision, a comparison between approaches, or the background of a feature lives in a [concept](/en/documentation/style-guide/content/concept/) or [architecture](/en/documentation/style-guide/content/architecture/) page and nowhere else.
+
+## Separate multi-product guides from use cases
+
+Both take the how-to base form and both cross products, so the split is worth stating.
+
+A multi-product guide starts from a technical goal. The reader knows what they want to build and needs the route across products. It ends when the task is done.
+
+A use case starts from a business scenario. The reader arrives with a situation, not a task. The page names the products the scenario needs, shows the architecture, configures it, and proves it works. It is written as a specification an agent can execute. That is why it carries a requirements table and a measurable outcome, which the multi-product guide does not.
+
+The test: if you can state the goal without naming an industry or a business situation, it is a multi-product guide.
+
+## Keep one form per page
+
+A page that mixes forms is the most common structural defect in documentation. A reference page that stops to walk the reader through the Console is two pages in one file. So is a how-to that pauses to explain architecture, or a tutorial that turns into a parameter table halfway down.
+
+The test is cheap: read the page once as each of the four base-form readers. If two of them each want a different half, it is two pages. Split it.
+
+## Link the forms to each other
+
+One form per page works because links connect the pages. Each form links out in a predictable direction.
+
+| A page of this form | Links to | When |
+| --- | --- | --- |
+| Tutorial | The how-to guides of its product | In a final "Next steps" section |
+| How-to guide | Reference | For every setting the steps touch |
+| Reference | The how-to guide that changes a setting | Sparingly: one link per setting at most |
+| Concept or architecture | The reference and the guides that implement the design | Where the design meets practice |
+
+Links are bidirectional. When page A links to page B for a task, page B links back to page A where the reader returns.
+
+---
+
+## Read every content-type page the same way
+
+Each page in this section describes one content type or pattern, and all of them use the same sections in the same order. Once you know where a rule lives on one page, you know where it lives on all of them.
+
+| Section | Answers |
+| --- | --- |
+| Purpose | What this kind of page does, and what it is not |
+| When to use | When to write one, and when to write something else |
+| Register | Procedural or descriptive: the sentence cap, and the tone in a few adjectives |
+| Structure | The required and optional components |
+| Template | The skeleton to copy |
+| Rules | The rules specific to this kind of page |
+| Examples | Pages that follow it |
+| Related | The neighbouring pages in this guide |

--- a/src/content/docs/en/pages/style-guide/content/concept.mdx
+++ b/src/content/docs/en/pages/style-guide/content/concept.mdx
@@ -8,6 +8,9 @@ namespace: documentation_style_guide_concept
 permalink: /documentation/style-guide/content/concept/
 menu_namespace: styleGuideMenu
 ---
+import FrameBox from '@aziontech/webkit/frame-box'
+import ItemList from '@aziontech/webkit/item-list'
+import DocItem from '@aziontech/webkit/doc-item'
 
 ## Purpose
 
@@ -45,7 +48,7 @@ The title is `How <X> works`, `About <X>`, or a short noun phrase: `How Tiered C
 - **Roadmap sentence**: the intro closes with one sentence naming the mechanisms the `##` sections cover, in order.
 - **Mechanism sections**: one noun-phrase `##` per mechanism, mirroring the roadmap sentence.
 - **The problem, the mechanism, and the tradeoff**: each section covers all three. An explanation that presents only upsides is marketing.
-- **Related resources**: a closing `## Related resources` section linking the reference page and the how-tos that apply the concept.
+- **Related resources**: a closing `## Related resources` section, a `DocItem` list linking the reference page and the how-tos that apply the concept, each row with its reason.
 
 **Optional components**
 
@@ -57,7 +60,11 @@ The title is `How <X> works`, `About <X>`, or a short noun phrase: `How Tiered C
 
 Copy the template and replace each `<placeholder>`:
 
-```md
+```mdx
+import FrameBox from '@aziontech/webkit/frame-box'
+import ItemList from '@aziontech/webkit/item-list'
+import DocItem from '@aziontech/webkit/doc-item'
+
 <A declarative statement of how the system behaves.>
 <A roadmap sentence naming the mechanisms the sections
 cover, in order.>
@@ -73,8 +80,12 @@ behaves, and what it costs.>
 
 ## Related resources
 
-- [<The reference page>](/path/) - <what the reader gets there>
-- [<The how-to that applies the concept>](/path/) - <why the reader would follow it>
+<FrameBox>
+<ItemList>
+  <DocItem title="<The reference page>" href="/path/"><what the reader gets there></DocItem>
+  <DocItem title="<The how-to that applies the concept>" href="/path/"><why the reader would follow it></DocItem>
+</ItemList>
+</FrameBox>
 ```
 
 ## Rules
@@ -107,7 +118,11 @@ End users send requests to Azion's distributed network, where content is cached.
 
 ## Related
 
-- [Architecture pages](/en/documentation/style-guide/content/architecture/): the same base form, for a design that spans products.
-- [Reference](/en/documentation/style-guide/content/reference/): where the settings and the limits belong.
-- [How-to guides](/en/documentation/style-guide/content/how-to-guides/): where the steps belong.
-- [Choose a content type](/en/documentation/style-guide/content/choose-a-content-type/): the full catalogue of page kinds.
+<FrameBox>
+<ItemList>
+  <DocItem title="Architecture pages" href="/en/documentation/style-guide/content/architecture/">The same base form, for a design that spans products.</DocItem>
+  <DocItem title="Reference" href="/en/documentation/style-guide/content/reference/">Where the settings and the limits belong.</DocItem>
+  <DocItem title="How-to guides" href="/en/documentation/style-guide/content/how-to-guides/">Where the steps belong.</DocItem>
+  <DocItem title="Choose a content type" href="/en/documentation/style-guide/content/choose-a-content-type/">The full catalogue of page kinds.</DocItem>
+</ItemList>
+</FrameBox>

--- a/src/content/docs/en/pages/style-guide/content/concept.mdx
+++ b/src/content/docs/en/pages/style-guide/content/concept.mdx
@@ -1,0 +1,113 @@
+---
+title: Concept pages
+description: >-
+  Write a concept page: explain why something works the way it does, name the
+  alternatives, and state the tradeoff.
+meta_tags: 'style guide, concept, explanation'
+namespace: documentation_style_guide_concept
+permalink: /documentation/style-guide/content/concept/
+menu_namespace: styleGuideMenu
+---
+
+## Purpose
+
+A concept page builds understanding. The reader is not in the middle of a task; they want to understand how something works and why it is built that way, usually before deciding to use it.
+
+It applies the **explanation** base form, one of the four Diátaxis forms. When a design combines several products, write an [architecture page](/en/documentation/style-guide/content/architecture/) instead: it is the same base form with a diagram and a dataflow.
+
+## When to use
+
+Write a concept page when:
+
+- The reader wants the reason the product works this way, not the steps.
+- A how-to guide grows a long preamble, or a reference page stops to justify a design.
+- The page must compare alternatives and name a tradeoff.
+
+Do not write a concept page when:
+
+- The reader needs to look up a value, a field, or a limit. Write a [reference page](/en/documentation/style-guide/content/reference/).
+- The reader needs steps for a task. Write a [how-to guide](/en/documentation/style-guide/content/how-to-guides/) or a [tutorial](/en/documentation/style-guide/content/tutorials/).
+- The subject is how several products combine into a design. Write an [architecture page](/en/documentation/style-guide/content/architecture/).
+
+This is the page kind most often missing. When another kind starts to explain, write the concept page and keep that kind clean.
+
+## Register
+
+Descriptive: 25 words per sentence, active voice, passive only where the actor is genuinely unknown or is the platform itself. Tone: explanatory, descriptive, even-handed, patient. [Sentence structure](/en/documentation/style-guide/writing/sentence-structure/) holds the rules.
+
+## Structure
+
+The title is `How <X> works`, `About <X>`, or a short noun phrase: `How Tiered Cache works`.
+
+**Required components**
+
+- **Opening move**: a declarative statement of how the system behaves, in the reader's terms before any Azion object is named. Never `This page explains`.
+- **Roadmap sentence**: the intro closes with one sentence naming the mechanisms the `##` sections cover, in order.
+- **Mechanism sections**: one noun-phrase `##` per mechanism, mirroring the roadmap sentence.
+- **The problem, the mechanism, and the tradeoff**: each section covers all three. An explanation that presents only upsides is marketing.
+- **Related resources**: a closing `## Related resources` section linking the reference page and the how-tos that apply the concept.
+
+**Optional components**
+
+- **Key terms**: the vocabulary the reader needs, defined once each.
+- **Alternatives**: the other ways to solve the problem, and what each trades away.
+- **A diagram**: when the relationship is easier to draw than to describe. Draw it as a `mermaid` code fence, and label every node in words.
+
+## Template
+
+Copy the template and replace each `<placeholder>`:
+
+```md
+<A declarative statement of how the system behaves.>
+<A roadmap sentence naming the mechanisms the sections
+cover, in order.>
+
+## <Noun phrase naming the first mechanism>
+
+<The problem this mechanism works against, how it
+behaves, and what it costs.>
+
+## <Noun phrase naming the next mechanism>
+
+<...>
+
+## Related resources
+
+- [<The reference page>](/path/) - <what the reader gets there>
+- [<The how-to that applies the concept>](/path/) - <why the reader would follow it>
+```
+
+## Rules
+
+- **Open with behavior, not framing.** State how the system behaves; never `This page explains`.
+- **Explain the thing before the Azion object.** `Cache stores a copy of a response on the edge node that fetched it. The edge node answers later requests for the same object from that copy, without reaching the origin.` Only then the objects that realize it. An opening whose every subject is an Azion product or object is an inventory, not an explanation.
+- **Mirror the roadmap.** One noun-phrase `##` per mechanism, in the order the roadmap sentence names them. A section cut from the page is cut from the roadmap in the same edit.
+- **State the tradeoff.** Every design choice costs something, so say what. An explanation that presents only upsides is marketing.
+- **No procedures.** Link the [how-to guide](/en/documentation/style-guide/content/how-to-guides/) that applies the concept.
+- **Keep alternatives here.** Alternatives and "instead of" live on concept pages and nowhere else.
+- **Use passive voice narrowly.** Only where the actor is genuinely unknown or is the platform itself.
+- **Make diagrams carry load, and draw them in `mermaid`.** A text diagram reaches an agent reading the markdown twin; an image does not. Say in prose what the diagram shows, and never rely on color alone.
+- **Discuss, do not enumerate.** A page that becomes a table of fields wants to be [reference](/en/documentation/style-guide/content/reference/).
+- **Define each term once**, where the reader first meets it, then link to it.
+- **Avoid claims that expire.** `Currently` and `will soon` age badly and nobody returns.
+
+## Examples
+
+This excerpt of a concept page for Tiered Cache shows the opening move, the roadmap sentence, and the first mechanism section:
+
+```mdx
+**Tiered Cache** is a Cache module that creates an additional cache layer between Azion's distributed network and the origin servers. With the module active, content stays cached for longer periods and the origin receives fewer requests. Tiered Cache is designed for objects that can remain in cache for a long period of time. The module is available on request: activation goes through the Sales team.
+
+Its behavior depends on five mechanisms: the cache layers, the second-layer region, the TTL requirements, the Bypass Cache limitation, and the purge order.
+
+## Cache layers
+
+End users send requests to Azion's distributed network, where content is cached. Without Tiered Cache, a request that misses the first cache layer goes to the origin. Tiered Cache adds a second cache layer between that first layer and the origin servers. The tiered layer can answer a request that misses the first layer, so the request does not reach the origin. Content stays cached for longer periods, and the origin receives fewer requests.
+```
+
+## Related
+
+- [Architecture pages](/en/documentation/style-guide/content/architecture/): the same base form, for a design that spans products.
+- [Reference](/en/documentation/style-guide/content/reference/): where the settings and the limits belong.
+- [How-to guides](/en/documentation/style-guide/content/how-to-guides/): where the steps belong.
+- [Choose a content type](/en/documentation/style-guide/content/choose-a-content-type/): the full catalogue of page kinds.

--- a/src/content/docs/en/pages/style-guide/content/glossary.mdx
+++ b/src/content/docs/en/pages/style-guide/content/glossary.mdx
@@ -1,0 +1,71 @@
+---
+title: Glossary pages
+description: >-
+  Write a product glossary of Azion-specific terms: a filterable, alphabetical
+  table whose definitions link the pages where each term is used.
+meta_tags: 'style guide, glossary, terms, definitions'
+namespace: documentation_style_guide_glossary
+permalink: /documentation/style-guide/content/glossary/
+menu_namespace: styleGuideMenu
+---
+
+## Purpose
+
+A glossary defines the terms one product's documentation uses. It is look-up material: the reader arrives with a word, finds its definition, and follows a link when the definition is not enough.
+
+A glossary holds Azion-specific vocabulary: products, modules, platform objects, and the terms Azion uses in its own way. A generic industry term, such as CDN, serverless, or virtual machine, belongs to the [Learning Center](https://www.azion.com/en/learning/), not to a documentation glossary. A term the industry also uses, but Azion uses differently, keeps its entry here and links the Learning Center for the generic sense.
+
+It is not a naming-rules page. Product naming belongs to [Documentation terminology](/en/documentation/style-guide/writing/terminology/); the glossary defines what terms mean for the reader.
+
+## When to use
+
+Every product section carries a glossary, a required slot of the [product section skeleton](/en/documentation/style-guide/content/information-architecture/). Write it when the section is built, and extend it when a page introduces a term the reader must hold to follow the prose.
+
+Do not write an entry for a term no page uses. Do not write an entry for a generic industry term: link the [Learning Center](https://www.azion.com/en/learning/) article from the page that needs it. Do not use the glossary to explain at length. A term that needs more than three sentences needs a [concept page](/en/documentation/style-guide/content/concept/), and its definition links to it.
+
+## Register
+
+Descriptive: 25 words per sentence. The tone is neutral and lexicographic: a definition states what the term is, without selling and without history.
+
+## Structure
+
+- One sentence of orientation naming the product whose terms the page defines.
+- One `<GlossaryFilter>` component wrapping one GFM table, `| Term | Definition |`. The component adds the filter box and gives each row a deep-linkable anchor built from its term (`#cache-key`). Mechanics in [Components](/en/documentation/style-guide/components/).
+- No closing section. The table is the page.
+
+## Template
+
+```mdx
+import GlossaryFilter from '~/components/GlossaryFilter.astro'
+
+Definitions for the terms the **<Product>** documentation uses.
+
+<GlossaryFilter lang="en">
+
+| Term | Definition |
+| --- | --- |
+| <term> | <What the term is, in one to three sentences, linking its canonical page inline.> |
+
+</GlossaryFilter>
+```
+
+## Rules
+
+- **Rows sort alphabetically by term, per language.** The Portuguese page alphabetizes by the Portuguese term; terms from the stay-in-English list keep their English form and sort by it.
+- **A term is lowercase** unless it is a product name or another proper noun.
+- **A definition is one to three sentences**, and the first says what the term is. Link the canonical page inline from the phrase it explains.
+- **Every definition matches a page in the documentation.** The glossary records how the documentation uses a term; it never introduces one.
+- **The glossary is a crosslinked structure.** Each definition links its canonical page inline and the pages where the reader meets the term. Every entry keeps a path back into the documentation.
+- **Moving an entry never breaks a crosslink.** When an entry migrates to the Learning Center, every page that linked the entry gets the new destination in the same change.
+- **Blank lines around the table inside the component are mandatory**, or the table renders as one literal paragraph.
+
+## Examples
+
+The first product glossary is the [Cache glossary](/en/documentation/build/cache/glossary/): twelve terms, each definition linking its canonical page.
+
+## Related
+
+- [Information architecture](/en/documentation/style-guide/content/information-architecture/) - the slot the glossary fills in every product section.
+- [Documentation terminology](/en/documentation/style-guide/writing/terminology/) - the naming rules the glossary never restates.
+- [Components](/en/documentation/style-guide/components/) - the GlossaryFilter mechanics.
+- [Concept pages](/en/documentation/style-guide/content/concept/) - where a term goes when three sentences are not enough.

--- a/src/content/docs/en/pages/style-guide/content/glossary.mdx
+++ b/src/content/docs/en/pages/style-guide/content/glossary.mdx
@@ -8,6 +8,9 @@ namespace: documentation_style_guide_glossary
 permalink: /documentation/style-guide/content/glossary/
 menu_namespace: styleGuideMenu
 ---
+import FrameBox from '@aziontech/webkit/frame-box'
+import ItemList from '@aziontech/webkit/item-list'
+import DocItem from '@aziontech/webkit/doc-item'
 
 ## Purpose
 
@@ -65,7 +68,11 @@ The first product glossary is the [Cache glossary](/en/documentation/build/cache
 
 ## Related
 
-- [Information architecture](/en/documentation/style-guide/content/information-architecture/) - the slot the glossary fills in every product section.
-- [Documentation terminology](/en/documentation/style-guide/writing/terminology/) - the naming rules the glossary never restates.
-- [Components](/en/documentation/style-guide/components/) - the GlossaryFilter mechanics.
-- [Concept pages](/en/documentation/style-guide/content/concept/) - where a term goes when three sentences are not enough.
+<FrameBox>
+<ItemList>
+  <DocItem title="Information architecture" href="/en/documentation/style-guide/content/information-architecture/">The slot the glossary fills in every product section.</DocItem>
+  <DocItem title="Documentation terminology" href="/en/documentation/style-guide/writing/terminology/">The naming rules the glossary never restates.</DocItem>
+  <DocItem title="Components" href="/en/documentation/style-guide/components/">The GlossaryFilter mechanics.</DocItem>
+  <DocItem title="Concept pages" href="/en/documentation/style-guide/content/concept/">Where a term goes when three sentences are not enough.</DocItem>
+</ItemList>
+</FrameBox>

--- a/src/content/docs/en/pages/style-guide/content/how-to-guides.mdx
+++ b/src/content/docs/en/pages/style-guide/content/how-to-guides.mdx
@@ -8,6 +8,9 @@ namespace: documentation_style_guide_how_to_guides
 permalink: /documentation/style-guide/content/how-to-guides/
 menu_namespace: styleGuideMenu
 ---
+import FrameBox from '@aziontech/webkit/frame-box'
+import ItemList from '@aziontech/webkit/item-list'
+import DocItem from '@aziontech/webkit/doc-item'
 
 ## Purpose
 
@@ -33,7 +36,7 @@ Procedural: 20 words per sentence, one instruction per step, imperative and acti
 - **Task sections**: one `##` per task, each an imperative verb phrase.
 - **Lead-in**: directly before each procedure, one sentence ending in a colon, such as `To create the bucket:`.
 - **Outcome sentence**: every procedure ends by stating what the reader now has or sees.
-- **Next steps**: a closing `## Next steps` section with one or two bulleted links, each shaped `[Title](/path/) - reason`.
+- **Next steps**: a closing `## Next steps` section, a `DocCardGroup` with one or two cards: the title, the link, and the reason as the card copy.
 
 **Optional components**
 
@@ -44,7 +47,10 @@ Procedural: 20 words per sentence, one instruction per step, imperative and acti
 
 Copy the template and replace each `<placeholder>`.
 
-```md
+```mdx
+import DocCardGroup from '@aziontech/webkit/doc-card-group'
+import DocCard from '@aziontech/webkit/doc-card'
+
 [One scope sentence: what the page lets the reader
 do, and from where.]
 
@@ -71,7 +77,9 @@ To <reach the result of the task>:
 
 ## Next steps
 
-- [<Title>](/path/) - <why the reader would follow it>
+<DocCardGroup cols={2}>
+  <DocCard title="<Title>" href="/path/" label="<why the reader would follow it>" />
+</DocCardGroup>
 ```
 
 Separate the major sections of the page with a `---` rule, and never place one directly after the frontmatter.
@@ -132,6 +140,10 @@ The bucket appears in the bucket list.
 
 ## Related
 
-- [Tutorials](/en/documentation/style-guide/content/tutorials/): the page for the reader who is learning.
-- [Troubleshooting pages](/en/documentation/style-guide/content/troubleshooting/): the how-to whose task is a fix.
-- [Reference](/en/documentation/style-guide/content/reference/): where every setting a guide touches is documented.
+<FrameBox>
+<ItemList>
+  <DocItem title="Tutorials" href="/en/documentation/style-guide/content/tutorials/">The page for the reader who is learning.</DocItem>
+  <DocItem title="Troubleshooting pages" href="/en/documentation/style-guide/content/troubleshooting/">The how-to whose task is a fix.</DocItem>
+  <DocItem title="Reference" href="/en/documentation/style-guide/content/reference/">Where every setting a guide touches is documented.</DocItem>
+</ItemList>
+</FrameBox>

--- a/src/content/docs/en/pages/style-guide/content/how-to-guides.mdx
+++ b/src/content/docs/en/pages/style-guide/content/how-to-guides.mdx
@@ -1,0 +1,137 @@
+---
+title: How-to guides
+description: >-
+  Write a how-to guide: start with the outcome, remove obstacles instead of
+  teaching, and keep each step to one imperative instruction.
+meta_tags: 'style guide, how-to'
+namespace: documentation_style_guide_how_to_guides
+permalink: /documentation/style-guide/content/how-to-guides/
+menu_namespace: styleGuideMenu
+---
+
+## Purpose
+
+A how-to guide takes a reader who has a problem to a solved problem. The reader already knows what they want. The page removes the obstacles between them and the result; it does not teach.
+
+## When to use
+
+- The reader arrived with a specific task and a real situation.
+- Do not use a how-to for a reader who is learning the product: that page is a [tutorial](/en/documentation/style-guide/content/tutorials/).
+- A how-to whose task is a fix is a [troubleshooting page](/en/documentation/style-guide/content/troubleshooting/).
+- When in doubt, [Choose a content type](/en/documentation/style-guide/content/choose-a-content-type/) has the router.
+
+## Register
+
+Procedural: 20 words per sentence, one instruction per step, imperative and active. Tone: directive, plain, efficient. [Sentence structure](/en/documentation/style-guide/writing/sentence-structure/) holds the rules.
+
+## Structure
+
+**Required components**
+
+- **Scope sentence**: the opening states, in one sentence, what the page lets the reader do and from where. Never `In this guide`.
+- **Prerequisites**: a `## Prerequisites` section when the page has any, bulleted; each item is a link or a one-line command. A single prerequisite is a sentence, not a list.
+- **Task sections**: one `##` per task, each an imperative verb phrase.
+- **Lead-in**: directly before each procedure, one sentence ending in a colon, such as `To create the bucket:`.
+- **Outcome sentence**: every procedure ends by stating what the reader now has or sees.
+- **Next steps**: a closing `## Next steps` section with one or two bulleted links, each shaped `[Title](/path/) - reason`.
+
+**Optional components**
+
+- **Tabs by interface**: one `<Tabs>` block when a task runs through more than one interface, Console panel first, one complete procedure per panel.
+- **One aside** holding the alternative path, when the task genuinely branches.
+
+## Template
+
+Copy the template and replace each `<placeholder>`.
+
+```md
+[One scope sentence: what the page lets the reader
+do, and from where.]
+
+## Prerequisites
+
+- <A link or a one-line command per item>
+
+---
+
+## <Imperative verb phrase that names the task>
+
+To <reach the result of the task>:
+
+1. <One imperative instruction.>
+2. <One imperative instruction.>
+
+<The outcome: what the reader now has or sees.>
+
+---
+
+## <Next task, if the page covers a sequence>
+
+---
+
+## Next steps
+
+- [<Title>](/path/) - <why the reader would follow it>
+```
+
+Separate the major sections of the page with a `---` rule, and never place one directly after the frontmatter.
+
+## Rules
+
+- **Name the task in the title.** A short imperative verb phrase: `Create a bucket`, `Bypass origin cache`. Not a gerund, not a question, not a `How to ...` prefix — the verb carries it. The prefix is retired on new and rewritten pages.
+- **Open with one scope sentence.** State what the page lets the reader do and from where: `You can create a bucket from Azion Console, the Azion CLI, or the API.`
+- **One task per heading.** A heading covering two tasks is two headings.
+- **Add information after every heading.** A task section's first sentence must add information its heading does not; the lead-in carries the section.
+- **Follow the step rules.** Steps follow [Procedures](/en/documentation/style-guide/writing/procedures/), and every procedure ends with its outcome sentence.
+- **Show the output after every command.** The reader sees what success looks like before the next step depends on it. The rule is in [Procedures](/en/documentation/style-guide/writing/procedures/).
+- **Branch where the task branches.** Multi-interface tasks use one `<Tabs>` block, Console panel first — never sequential sections per interface.
+- **Do not teach.** A sentence of context, then the steps. A paragraph of background belongs to a concept page; link it.
+- **Use one verb per action**, on every mention across the page.
+- **Link the neighbors.** Sibling how-tos and the product's reference page, from the body or from `## Next steps`.
+- **Send a goal that crosses products** to a [multi-product guide](/en/documentation/style-guide/content/multi-product-guides/).
+- **Link out for third-party products.** Name the vendor's step; do not document their interface.
+
+## Examples
+
+This excerpt shows the scope sentence, the prerequisites, and the Console panel of the first task:
+
+```mdx
+You can create an [Object Storage](/en/documentation/products/store/object-storage/) bucket and change its permissions from Azion Console, the Azion CLI, or the API.
+
+## Prerequisites
+
+To use the CLI procedures, you need the Azion CLI installed and a configured personal token.
+
+---
+
+## Create a bucket
+
+<Tabs client:visible>
+    <Fragment slot="tab.console">Console</Fragment>
+    <Fragment slot="tab.cli">CLI</Fragment>
+    <Fragment slot="tab.api">API</Fragment>
+
+<Fragment slot="panel.console">
+
+To create the bucket from Azion Console:
+
+1. Access [Azion Console](https://console.azion.com/) > **Object Storage**.
+2. Select **+ Bucket**.
+3. Enter a **Bucket Name** between 6 and 63 characters.
+4. Set **Workloads Access** to _Read Only_, _Read-Write_, or _Restricted_.
+5. Select **Save**.
+
+The bucket appears in the bucket list.
+
+</Fragment>
+
+</Tabs>
+```
+
+- [Create request and response rules](/en/documentation/build/applications/guides/rules-engine/): two tasks on one page, each a named procedure with numbered imperative steps.
+
+## Related
+
+- [Tutorials](/en/documentation/style-guide/content/tutorials/): the page for the reader who is learning.
+- [Troubleshooting pages](/en/documentation/style-guide/content/troubleshooting/): the how-to whose task is a fix.
+- [Reference](/en/documentation/style-guide/content/reference/): where every setting a guide touches is documented.

--- a/src/content/docs/en/pages/style-guide/content/information-architecture.mdx
+++ b/src/content/docs/en/pages/style-guide/content/information-architecture.mdx
@@ -1,0 +1,86 @@
+---
+title: Information architecture
+description: >-
+  Follow the target structure for Azion documentation: the product section
+  skeleton, the order of the reader's journey, and where a new page goes.
+meta_tags: 'style guide, information architecture, navigation, sidebar'
+namespace: documentation_style_guide_information_architecture
+permalink: /documentation/style-guide/content/information-architecture/
+menu_namespace: styleGuideMenu
+---
+
+This page defines the target structure for the Azion documentation. New sections follow it, and existing sections converge on it as they are revised. Do not copy the structure of an existing section: this pattern wins.
+
+Two principles organize everything. Sections follow the order of the reader's journey with the product. Each section holds one [content type](/en/documentation/style-guide/content/choose-a-content-type/), so the journey decides where a section sits and the type decides what its pages look like.
+
+## The product section skeleton
+
+Every product section follows this order. The table shows what each slot holds and when it exists.
+
+| Order | Slot | Required | Holds |
+| --- | --- | --- | --- |
+| 1 | Overview | Yes | The product root page: what the product is, what it does, when to use it |
+| 2 | Quickstart | Yes | [Quickstart pages](/en/documentation/style-guide/content/quickstart/): from not using the product to the smallest working result |
+| 3 | How it works | When the product needs explaining | [Concept pages](/en/documentation/style-guide/content/concept/): the mechanism, the tradeoff, how to choose between options |
+| 4 | Features and capabilities | When the product has feature surfaces | The product's own sub-surfaces, such as a rules engine, a cache, or a runtime API |
+| 5 | Guides and tutorials | When the product has tasks | One [navigation hub](/en/documentation/style-guide/content/navigation-hubs/) listing the [how-to guides](/en/documentation/style-guide/content/how-to-guides/) and the [tutorials](/en/documentation/style-guide/content/tutorials/) |
+| 6 | Examples | Optional | Working code the reader copies, grouped by language or by task |
+| 7 | Reference | When the product has settings | [Reference pages](/en/documentation/style-guide/content/reference/): fields, values, defaults |
+| 8 | Limits | When the product has limits | The limits table, dimensioned by plan |
+| 9 | Best practices | Optional | How to run the product well, and the reasoning behind each recommendation |
+| 10 | Troubleshooting | When the product has known symptoms | [Troubleshooting pages](/en/documentation/style-guide/content/troubleshooting/): symptom, cause, fix |
+| 11 | Glossary | Yes | [Glossary pages](/en/documentation/style-guide/content/glossary/): the terms the product's documentation uses, defined in a filterable table |
+| 12 | Pricing | Yes | A link to the product's section of the pricing page |
+| 13 | Changelog | Yes | A link to the product's changelog entries |
+
+Two slots have a fixed sidebar shape.
+
+**Guides and tutorials is one row that opens a page.** The row points at a hub whose body is a single table: name, last updated, and difficulty, one row per guide and per tutorial. The sidebar never expands it, and the reader opens a guide from the table. A section with forty guides stays one sidebar row, so the sidebar keeps showing the whole product.
+
+The table is generated, not written. The date comes from the file's last commit and the difficulty from a `difficulty` frontmatter field, so the hub cannot drift from the pages it lists.
+
+**Reference is a fixed group.** The sidebar shows a **Reference** parent holding one row per reference page. The group name is the same in every product section, so the reader finds the fields in the same place everywhere.
+
+Other rows may group the same way. A group is a menu parent, not a page, and it stays one level deep. Two modes exist:
+
+- **Fixed groups** hold one slot's pages under the slot's standard name. Reference is the canonical case, and the Quickstart interface variants group the same way.
+- **Same-type groups** hold related closing pages under one thematic parent. **Management** holds Limits, Pricing, and Changelog: the pages the reader consults about running the product.
+
+Do not group rows that read fine flat. A parent costs the reader one click on every visit, so a group must pay for itself.
+
+A product with modules repeats the pattern one level down. A module with its own surface gets a subsection with the same skeleton, reduced to the parts it needs.
+
+Quickstart is the one slot that splits by interface. A product whose first run differs across Azion Console, the Azion CLI, the API, or an AI agent gives each interface its own page. The pages group under Quickstart, with Console first. The group is a sidebar parent, not a page, and each page documents one interface end to end. One page remains the floor: split when an interface has its own first-run audience and its own steps, not to complete the set.
+
+The platform onboarding section at `/documentation/get-started/` is a different thing with a similar name. Quickstart is the per-product slot. Get started is the platform entry point, and it belongs to no product.
+
+## Order, and what earns a slot
+
+- **The order mirrors adoption.** A slot never moves ahead of its stage.
+- **Pricing and Changelog close the section.** The reader consults them rather than passing through them.
+- **The Required column decides what ships.** Every other slot exists only when real content fills it.
+- **Never add a slot to complete the pattern**, and never keep an empty one as a placeholder.
+- **Grow by splitting a slot the section already has:** Guides and tutorials into named task groups on the hub page, Quickstart by interface, Features and capabilities by surface.
+- **The thirteen never grow in number.**
+
+## Pricing and limits
+
+- **Pricing is a link, never a page.** Slot 11 points at `/documentation/platform/pricing/#<product>`. Confirm the anchor resolves before you ship it.
+- **Never restate a price, a quota, or a billing metric** in a product page. A duplicated price is wrong the day it changes.
+- **Name the plan when availability is part of behavior**, and link pricing for the numbers.
+- **Limits are dimensioned by plan.** A single number hides the difference from every reader on another plan.
+- **The limits table contract lives in [Reference](/en/documentation/style-guide/content/reference/):** units, defaults, and raisable limits.
+- **Limits take slot 8 when the set is worth consulting alone.** A `## Limits` section in the reference page covers a short set.
+
+## Place a new page
+
+Content that no single product owns lives beside the products, not inside one of them. Decide by the reader the page serves:
+
+- The page documents one product: place it in that product's section, in the slot its content type indicates.
+- The page explains the platform, accounts, or billing: it goes in Fundamentals.
+- The page diagnoses platform problems or reaches the support team: it goes in Support.
+- The page solves a business scenario end to end: it is a [use case](/en/documentation/style-guide/content/use-cases/), and it goes in Guides.
+- The page shows how products combine into a design: it goes in Architectures.
+- The page collects links for an area: it is a [navigation hub](/en/documentation/style-guide/content/navigation-hubs/), and it needs a real audience before it exists.
+
+When no section fits, open an issue before you create one. A new section changes navigation for every reader.

--- a/src/content/docs/en/pages/style-guide/content/multi-product-guides.mdx
+++ b/src/content/docs/en/pages/style-guide/content/multi-product-guides.mdx
@@ -8,6 +8,9 @@ namespace: documentation_style_guide_multi_product_guides
 permalink: /documentation/style-guide/content/multi-product-guides/
 menu_namespace: styleGuideMenu
 ---
+import FrameBox from '@aziontech/webkit/frame-box'
+import ItemList from '@aziontech/webkit/item-list'
+import DocItem from '@aziontech/webkit/doc-item'
 
 ## Purpose
 
@@ -41,7 +44,7 @@ Procedural: 20 words per sentence, one instruction per step, imperative and acti
 - **Prerequisites**: a `## Prerequisites` section, bulleted; each item is a link or a one-line command. A single prerequisite is a sentence, not a list.
 - **Stages**: one `##` per workflow stage, never per product, each an imperative heading naming the stage. Each stage names its product on entry, holds an ordinary procedure, and stands alone.
 - **Outcome sentence**: every procedure ends by stating what the reader now has or sees.
-- **Next steps**: a closing `## Next steps` section with bulleted links, each shaped `[Title](/path/) - reason`.
+- **Next steps**: a closing `## Next steps` section, a `DocCardGroup` with one card per destination: the title, the link, and the reason as the card copy.
 
 **Optional components**
 
@@ -52,7 +55,10 @@ Procedural: 20 words per sentence, one instruction per step, imperative and acti
 
 Copy the template and replace each `<placeholder>`.
 
-```md
+```mdx
+import DocCardGroup from '@aziontech/webkit/doc-card-group'
+import DocCard from '@aziontech/webkit/doc-card'
+
 [One or two sentences: the problem first, then the
 products, by role.]
 
@@ -81,7 +87,9 @@ To <reach the result of the stage>:
 
 ## Next steps
 
-- [<Title>](/path/) - <why the reader would follow it>
+<DocCardGroup cols={2}>
+  <DocCard title="<Title>" href="/path/" label="<why the reader would follow it>" />
+</DocCardGroup>
 ```
 
 Separate the major sections of the page with a `---` rule, and never place one directly after the frontmatter.
@@ -127,7 +135,11 @@ The Application Accelerator module is enabled for the application.
 
 ## Related
 
-- [How-to guides](/en/documentation/style-guide/content/how-to-guides/): the base form this kind applies.
-- [Architecture pages](/en/documentation/style-guide/content/architecture/): the page that describes the design this guide builds.
-- [Information architecture](/en/documentation/style-guide/content/information-architecture/): where a guide that belongs to no product section lives.
-- [Choose a content type](/en/documentation/style-guide/content/choose-a-content-type/): the full catalogue of page kinds.
+<FrameBox>
+<ItemList>
+  <DocItem title="How-to guides" href="/en/documentation/style-guide/content/how-to-guides/">The base form this kind applies.</DocItem>
+  <DocItem title="Architecture pages" href="/en/documentation/style-guide/content/architecture/">The page that describes the design this guide builds.</DocItem>
+  <DocItem title="Information architecture" href="/en/documentation/style-guide/content/information-architecture/">Where a guide that belongs to no product section lives.</DocItem>
+  <DocItem title="Choose a content type" href="/en/documentation/style-guide/content/choose-a-content-type/">The full catalogue of page kinds.</DocItem>
+</ItemList>
+</FrameBox>

--- a/src/content/docs/en/pages/style-guide/content/multi-product-guides.mdx
+++ b/src/content/docs/en/pages/style-guide/content/multi-product-guides.mdx
@@ -1,0 +1,133 @@
+---
+title: Multi-product guides
+description: >-
+  Write a guide for a goal that crosses products: one recommended path,
+  organized by workflow stage rather than by product.
+meta_tags: 'style guide, multi-product guide, solution guide'
+namespace: documentation_style_guide_multi_product_guides
+permalink: /documentation/style-guide/content/multi-product-guides/
+menu_namespace: styleGuideMenu
+---
+
+## Purpose
+
+A multi-product guide takes the reader to a goal that no single product reaches. It applies the [how-to](/en/documentation/style-guide/content/how-to-guides/) base form.
+
+Other documentation sets split this kind into solution guides, design guides, and implementation guides. This documentation uses one name and one set of rules, because the three describe the same page.
+
+## When to use
+
+Write a multi-product guide when:
+
+- The goal needs two or more products, and no product section owns it.
+- The reader thinks in outcomes, such as protecting a checkout, rather than in product names.
+- A single-product guide keeps sending the reader to another product mid-task.
+
+Do not write a multi-product guide when:
+
+- One product reaches the goal. Write a [how-to guide](/en/documentation/style-guide/content/how-to-guides/) in that product's section.
+- The reader wants to understand the design rather than build it. Write an [architecture page](/en/documentation/style-guide/content/architecture/).
+- The goal is a commercial scenario with a business frame. That is a use case, and it takes the same base form with an added scenario and a requirements table.
+
+## Register
+
+Procedural: 20 words per sentence, one instruction per step, imperative and active. Tone: directive, plain, decisive. [Sentence structure](/en/documentation/style-guide/writing/sentence-structure/) holds the rules.
+
+## Structure
+
+**Required components**
+
+- **Problem opening**: one or two sentences stating the problem, before any product name. The products enter after the problem, by role: "You configure caching with **Applications** and request filtering with **Firewall**."
+- **Prerequisites**: a `## Prerequisites` section, bulleted; each item is a link or a one-line command. A single prerequisite is a sentence, not a list.
+- **Stages**: one `##` per workflow stage, never per product, each an imperative heading naming the stage. Each stage names its product on entry, holds an ordinary procedure, and stands alone.
+- **Outcome sentence**: every procedure ends by stating what the reader now has or sees.
+- **Next steps**: a closing `## Next steps` section with bulleted links, each shaped `[Title](/path/) - reason`.
+
+**Optional components**
+
+- **A products table**: what each product contributes, when more than three are involved.
+- **A diagram**: when the order of the pieces is hard to hold in prose. Link the [architecture page](/en/documentation/style-guide/content/architecture/) instead when one exists.
+
+## Template
+
+Copy the template and replace each `<placeholder>`.
+
+```md
+[One or two sentences: the problem first, then the
+products, by role.]
+
+## Prerequisites
+
+- <A link or a one-line command per item>
+
+---
+
+## <Imperative heading naming the first workflow stage>
+
+<One sentence naming the product this stage runs in.>
+
+To <reach the result of the stage>:
+
+1. <One imperative instruction.>
+2. <One imperative instruction.>
+
+<The outcome: what the reader now has or sees.>
+
+---
+
+## <Imperative heading naming the next stage>
+
+---
+
+## Next steps
+
+- [<Title>](/path/) - <why the reader would follow it>
+```
+
+Separate the major sections of the page with a `---` rule, and never place one directly after the frontmatter.
+
+## Rules
+
+- **Title the goal, not the products.** The title states the goal in plain language, with no product names: `Serve a site with cached content and a protected checkout`. The reader searches for the outcome.
+- **State the problem first.** One or two sentences, then the products by role: "You configure caching with **Applications** and request filtering with **Firewall**."
+- **Order by the workflow, never by the product catalog.** A page organized product-by-product is a bundle of how-tos wearing one title.
+- **Name the product at each stage.** An unqualified interface name is ambiguous once the page crosses products.
+- **Stay a how-to.** The products are the route, not the subject. A paragraph of product background belongs to a concept page; link it.
+- **Follow the step rules.** Steps follow [Procedures](/en/documentation/style-guide/writing/procedures/), and every procedure ends with its outcome sentence.
+- **Show the output after every command.** The reader sees what success looks like before the next step depends on it. The rule is in [Procedures](/en/documentation/style-guide/writing/procedures/).
+- **Commit to one recommended path.** Alternatives go in one aside, never as forks in the steps.
+- **Verify the whole path.** These guides fail in the seams, so check the outcome and not the last step.
+- **Link the neighbors.** Each product's how-tos and reference page, from the body or from `## Next steps`.
+
+## Examples
+
+This excerpt shows the problem opening, the prerequisites, and the first workflow stage:
+
+```mdx
+Each route of a storefront needs a different rule. The catalogue can answer from cache, the cart must not, and the checkout needs a rate limit. You configure caching with **Applications** and request filtering with **Firewall**.
+
+## Prerequisites
+
+- An application that serves the store
+- A firewall
+
+## Turn on Application Accelerator
+
+The **Bypass Cache** behavior requires the **Application Accelerator** module of **Applications**.
+
+To turn on the module:
+
+1. Access [Azion Console](https://console.azion.com/) > **Applications** > **your application**.
+2. In the **Main Settings** tab, go to the **Modules** section.
+3. Turn on the **Application Accelerator** switch.
+4. Select **Save**.
+
+The Application Accelerator module is enabled for the application.
+```
+
+## Related
+
+- [How-to guides](/en/documentation/style-guide/content/how-to-guides/): the base form this kind applies.
+- [Architecture pages](/en/documentation/style-guide/content/architecture/): the page that describes the design this guide builds.
+- [Information architecture](/en/documentation/style-guide/content/information-architecture/): where a guide that belongs to no product section lives.
+- [Choose a content type](/en/documentation/style-guide/content/choose-a-content-type/): the full catalogue of page kinds.

--- a/src/content/docs/en/pages/style-guide/content/navigation-hubs.mdx
+++ b/src/content/docs/en/pages/style-guide/content/navigation-hubs.mdx
@@ -8,6 +8,9 @@ namespace: documentation_style_guide_navigation_hubs
 permalink: /documentation/style-guide/content/navigation-hubs/
 menu_namespace: styleGuideMenu
 ---
+import FrameBox from '@aziontech/webkit/frame-box'
+import ItemList from '@aziontech/webkit/item-list'
+import DocItem from '@aziontech/webkit/doc-item'
 
 ## Purpose
 
@@ -120,8 +123,13 @@ This section holds the guides to manage Object Storage buckets and objects, and 
 
 ## Related
 
-- [Overview pages](/en/documentation/style-guide/content/overview/) - The product root, which orients and links but also describes.
-- [Information architecture](/en/documentation/style-guide/content/information-architecture/) - Where hubs sit and which sections need one.
-- [Frontmatter](/en/documentation/style-guide/conventions/frontmatter/) - The `type: homepage` field a card-grid hub sets.
-- [Choose a content type](/en/documentation/style-guide/content/choose-a-content-type/) - The full catalogue of page kinds.
-- [How-to guides](/en/documentation/style-guide/content/how-to-guides/) and [Tutorials](/en/documentation/style-guide/content/tutorials/) - The two kinds a table hub lists.
+<FrameBox>
+<ItemList>
+  <DocItem title="Overview pages" href="/en/documentation/style-guide/content/overview/">The product root, which orients and links but also describes.</DocItem>
+  <DocItem title="Information architecture" href="/en/documentation/style-guide/content/information-architecture/">Where hubs sit and which sections need one.</DocItem>
+  <DocItem title="Frontmatter" href="/en/documentation/style-guide/conventions/frontmatter/">The `type: homepage` field a card-grid hub sets.</DocItem>
+  <DocItem title="Choose a content type" href="/en/documentation/style-guide/content/choose-a-content-type/">The full catalogue of page kinds.</DocItem>
+  <DocItem title="How-to guides" href="/en/documentation/style-guide/content/how-to-guides/">The two kinds a table hub lists.</DocItem>
+  <DocItem title="Tutorials" href="/en/documentation/style-guide/content/tutorials/">The two kinds a table hub lists.</DocItem>
+</ItemList>
+</FrameBox>

--- a/src/content/docs/en/pages/style-guide/content/navigation-hubs.mdx
+++ b/src/content/docs/en/pages/style-guide/content/navigation-hubs.mdx
@@ -1,0 +1,127 @@
+---
+title: Navigation hubs
+description: >-
+  Write a navigation hub in one of its two shapes: grouped links for mixed
+  destinations, or a generated table for one set the reader compares.
+meta_tags: 'style guide, navigation, hub, landing page'
+namespace: documentation_style_guide_navigation_hubs
+permalink: /documentation/style-guide/content/navigation-hubs/
+menu_namespace: styleGuideMenu
+---
+
+## Purpose
+
+A navigation hub sends the reader deeper into the documentation. It carries links and one sentence of orientation, and nothing else.
+
+It applies **no** Diátaxis base form. A hub does not teach, instruct, describe, or explain: it routes. That is why it has no sentence budget for prose it should not be carrying.
+
+## When to use
+
+- Write a hub when a section holds more pages than a sidebar makes legible.
+- Write one for a section that gathers pages from several products, such as a solutions or architectures index.
+- Write one for the Guides and tutorials slot of a product section, which is a single sidebar row pointing at a hub rather than a dropdown. [Information architecture](/en/documentation/style-guide/content/information-architecture/) holds that rule.
+
+Do not write a hub when:
+
+- The section is a product. A product opens with an [Overview](/en/documentation/style-guide/content/overview/), which orients and links.
+- The page would explain what the section is about at length. That is a [concept page](/en/documentation/style-guide/content/concept/).
+- The sidebar already makes the pages findable. A hub that duplicates the sidebar is a second thing to maintain and a second thing to go stale.
+
+## Register
+
+Descriptive: 25 words per sentence, active voice, passive only when the actor is unknown. Tone: brief, plain, orienting. [Sentence structure](/en/documentation/style-guide/writing/sentence-structure/) holds the rules.
+
+## Structure
+
+Both shapes open the same way and close the same way. Only the body differs.
+
+- **Opening move**: one orientation sentence saying what the section holds.
+- **Closing**: none. The last link or the last table row ends the page.
+
+### Shape 1: grouped links
+
+The default. Use it when the destinations differ from each other and the reader needs a sentence to tell them apart.
+
+- **Body**: link groups under noun-phrase `##` headings.
+- **Link shape**: `[Title](/path/) - one sentence on what the reader gets there.`
+
+### Shape 2: a table
+
+Use it when the hub lists one homogeneous set and the reader chooses by effort and freshness rather than by description. The Guides and tutorials slot is this shape, because every row is a how-to or a tutorial for the same product and a per-row sentence would repeat the page title.
+
+- **Body**: one `<GuidesTable>`, no `##` headings and no groups.
+- **Columns**: name, last updated, difficulty.
+- **The table is generated, never typed.** The date comes from the file's last commit and the difficulty from each page's `difficulty` frontmatter field, so the hub cannot fall out of step with the pages it lists.
+- **Every listed page sets `difficulty`**: `Beginner`, `Intermediate`, or `Advanced`. A page without it shows a dash, which reads as an oversight.
+
+## Template
+
+Copy the template for the shape you need and replace each `<placeholder>`.
+
+Grouped links:
+
+```md
+<One sentence: what the section holds.>
+
+## <Group name>
+
+- [<Page title>](<url>) - <what the reader gets there, in one sentence>.
+- [<Page title>](<url>) - <what the reader gets there, in one sentence>.
+
+## <Next group name>
+
+- [<Page title>](<url>) - <what the reader gets there, in one sentence>.
+```
+
+A table:
+
+```mdx
+import GuidesTable from '~/components/GuidesTable.astro'
+
+<One sentence: what the section holds.>
+
+<GuidesTable
+  lang="en"
+  prefixes={['<path prefix of the guides>', '<path prefix of the tutorials>']}
+  exclude={['<this hub page>']}
+/>
+```
+
+## Rules
+
+- **No closing section and no other prose.** One sentence of orientation; explanation belongs in a [concept page](/en/documentation/style-guide/content/concept/).
+- **Make every link earn its place.** A hub is judged by what it leaves out; one that lists everything ranks nothing.
+- **Write descriptions that differentiate.** Say what this page gives that its neighbours do not.
+- **Group when the list passes seven**, by what the reader is trying to do. A table does not group: it sorts, newest first.
+- **Pick the shape by what the reader compares.** Mixed destinations need a sentence each, so they take grouped links. One kind of page, compared on effort and freshness, takes the table.
+- **Never hand-write a table row.** A typed date is wrong the first time somebody forgets it, which is why this is the one place the guide allows a date outside a changelog.
+- **Register the covered paths in the sidebar.** The menu row that opens a table hub carries `covers`, listing the path prefixes whose pages the hub owns. Without it those pages fail the sidebar ownership check.
+- **Keep it in step with the section.** Update the hub in the same change that adds a page.
+- **Set `type: homepage` only on a card-grid hub.** Every other page omits the field. For more information, refer to [Frontmatter](/en/documentation/style-guide/conventions/frontmatter/).
+
+## Examples
+
+- [Architectures](/en/documentation/architectures/) - One line of orientation, then the designs grouped by the problem they solve.
+- [Cache guides and tutorials](/en/documentation/build/cache/guides/) - The table shape: one sentence, then every guide and tutorial with its date and difficulty.
+
+An Object Storage hub, trimmed to its orientation sentence and first group:
+
+```mdx
+This section holds the guides to manage Object Storage buckets and objects, and the product reference.
+
+## Buckets
+
+- [Create an Object Storage bucket](/en/documentation/products/store/storage/create-bucket/) - Create a bucket to store your objects.
+- [Update an Object Storage bucket](/en/documentation/products/store/storage/update-buckets/) - Update a bucket after you create it.
+- [Delete an Object Storage bucket](/en/documentation/products/store/storage/delete-buckets/) - Delete a bucket that you no longer need.
+- [List Object Storage buckets](/en/documentation/products/store/storage/list-buckets/) - List all of your buckets.
+- [Use a bucket as origin](/en/documentation/products/store/storage/use-bucket-as-origin/) - Use a bucket as the origin for your content.
+```
+
+## Related
+
+- [Overview pages](/en/documentation/style-guide/content/overview/) - The product root, which orients and links but also describes.
+- [Information architecture](/en/documentation/style-guide/content/information-architecture/) - Where hubs sit and which sections need one.
+- [Frontmatter](/en/documentation/style-guide/conventions/frontmatter/) - The `type: homepage` field a card-grid hub sets.
+- [Choose a content type](/en/documentation/style-guide/content/choose-a-content-type/) - The full catalogue of page kinds.
+- [How-to guides](/en/documentation/style-guide/content/how-to-guides/) and [Tutorials](/en/documentation/style-guide/content/tutorials/) - The two kinds a table hub lists.

--- a/src/content/docs/en/pages/style-guide/content/overview.mdx
+++ b/src/content/docs/en/pages/style-guide/content/overview.mdx
@@ -8,6 +8,9 @@ namespace: documentation_style_guide_overview_pages
 permalink: /documentation/style-guide/content/overview/
 menu_namespace: styleGuideMenu
 ---
+import FrameBox from '@aziontech/webkit/frame-box'
+import ItemList from '@aziontech/webkit/item-list'
+import DocItem from '@aziontech/webkit/doc-item'
 
 ## Purpose
 
@@ -40,7 +43,7 @@ Descriptive: 25 words per sentence, active voice, passive only when the actor is
 - **The mechanism**: where a request, an event, or a job crosses more than two objects before the product runs, that chain as a `mermaid` diagram, then a numbered walk of at most six items. Open with what the reader would otherwise assume wrong.
 - **The boundaries**: one compressed bulleted block with bolded lead-ins — languages, APIs, frameworks, integrations, and the headline limits. One block, not one section per feature.
 - **Capability sections**: only for a capability that changes what the reader would build, three at most. A capability that is one sentence and a link belongs in the boundaries block or the router.
-- **Closing**: `## Next steps`, a two-column table indexed by what the reader wants to do: `| If you want to | Go to |`.
+- **Closing**: `## Next steps`, a `DocCardGroup` indexed by what the reader wants to do: each card names the destination, and its copy is the intent (`Run your first one now.`).
 
 The sections keep this order.
 
@@ -50,6 +53,8 @@ Copy the template and replace each `<placeholder>`:
 
 ```mdx
 import DocButton from '~/components/webkit/DocButton.vue'
+import DocCardGroup from '@aziontech/webkit/doc-card-group'
+import DocCard from '@aziontech/webkit/doc-card'
 
 <What the class of thing is, for a reader who has never used one. One or two sentences; define any industry term in place.>
 
@@ -87,10 +92,10 @@ import DocButton from '~/components/webkit/DocButton.vue'
 
 ## Next steps
 
-| If you want to | Go to |
-| --- | --- |
-| <Run your first one now> | [Quickstart](<url>) |
-| <Look up a field, a limit, or a default> | [Reference](<url>) |
+<DocCardGroup cols={2}>
+  <DocCard title="Quickstart" href="<url>" label="<Run your first one now>." />
+  <DocCard title="Reference" href="<url>" label="<Look up a field, a limit, or a default>." />
+</DocCardGroup>
 ```
 
 ## Rules
@@ -137,19 +142,26 @@ If you know the Web `Request` and `Response` objects, you know the code model.
 The same page closes with the router, indexed by what the reader wants to do rather than by page title:
 
 ```mdx
+import DocCardGroup from '@aziontech/webkit/doc-card-group'
+import DocCard from '@aziontech/webkit/doc-card'
+
 ## Next steps
 
-| If you want to | Go to |
-| --- | --- |
-| Run your first function now | [Quickstart](/en/documentation/build/functions/quickstart/) |
-| Understand what invokes a function | [How Functions works](/en/documentation/build/functions/how-it-works/) |
-| Look up a handler, a parameter, or a limit | [Handlers](/en/documentation/build/functions/reference/handlers/) |
-| Look up a term | [Glossary](/en/documentation/build/functions/glossary/) |
+<DocCardGroup cols={2}>
+  <DocCard title="Quickstart" href="/en/documentation/build/functions/quickstart/" label="Run your first function now." />
+  <DocCard title="How Functions works" href="/en/documentation/build/functions/how-it-works/" label="Understand what invokes a function." />
+  <DocCard title="Handlers" href="/en/documentation/build/functions/reference/handlers/" label="Look up a handler, a parameter, or a limit." />
+  <DocCard title="Glossary" href="/en/documentation/build/functions/glossary/" label="Look up a term." />
+</DocCardGroup>
 ```
 
 ## Related
 
-- [Reference](/en/documentation/style-guide/content/reference/): the base form an Overview applies.
-- [Quickstart pages](/en/documentation/style-guide/content/quickstart/): the page an Overview sends the reader to.
-- [Information architecture](/en/documentation/style-guide/content/information-architecture/): where the Overview sits in a product section.
-- [Choose a content type](/en/documentation/style-guide/content/choose-a-content-type/): the full catalogue of page kinds.
+<FrameBox>
+<ItemList>
+  <DocItem title="Reference" href="/en/documentation/style-guide/content/reference/">The base form an Overview applies.</DocItem>
+  <DocItem title="Quickstart pages" href="/en/documentation/style-guide/content/quickstart/">The page an Overview sends the reader to.</DocItem>
+  <DocItem title="Information architecture" href="/en/documentation/style-guide/content/information-architecture/">Where the Overview sits in a product section.</DocItem>
+  <DocItem title="Choose a content type" href="/en/documentation/style-guide/content/choose-a-content-type/">The full catalogue of page kinds.</DocItem>
+</ItemList>
+</FrameBox>

--- a/src/content/docs/en/pages/style-guide/content/overview.mdx
+++ b/src/content/docs/en/pages/style-guide/content/overview.mdx
@@ -1,0 +1,155 @@
+---
+title: Overview pages
+description: >-
+  Write a product Overview: the product root that says what the product is,
+  what it does, and when to use it.
+meta_tags: 'style guide, overview'
+namespace: documentation_style_guide_overview_pages
+permalink: /documentation/style-guide/content/overview/
+menu_namespace: styleGuideMenu
+---
+
+## Purpose
+
+An Overview page is the root of a product section. It states what the product is, what it does, and when a reader would use it. It applies the [reference](/en/documentation/style-guide/content/reference/) base form.
+
+Every product has one. It is the page a reader lands on from search, from the sidebar, and from another product that links to this one.
+
+## When to use
+
+- Write one Overview for every product, as the first page of its section.
+- Write it before any other page in that section. The Overview decides what the section is about.
+
+Do not write an Overview when:
+
+- The subject is a module or a feature. That belongs in a [reference page](/en/documentation/style-guide/content/reference/) inside the product section.
+- The page would walk the reader through a task. That is a [how-to guide](/en/documentation/style-guide/content/how-to-guides/), linked from here.
+- The page would only list links. That is a [navigation hub](/en/documentation/style-guide/content/navigation-hubs/).
+
+## Register
+
+Descriptive: 25 words per sentence, active voice, passive only when the actor is unknown. Tone: inviting, factual, direct. [Sentence structure](/en/documentation/style-guide/writing/sentence-structure/) holds the rules.
+
+## Structure
+
+**Required components**
+
+- **Definition block**, in two layers. First the concept: one or two sentences saying what the class of thing is, for a reader who has never used one, with any industry term defined in place. Then the product: `**<Product>** <verb>s <the concept> <where and how on Azion>.` Then one sentence naming the concrete jobs people use it for, in the reader's vocabulary: `Use <Product> to handle A, run B, or serve C.` A bulleted benefit list is the weaker form of that sentence: it reads as a brochure and costs a screen.
+- **CTAs**: a primary `LinkButton` labeled **Quickstart** and a secondary one labeled `<Product> reference`.
+- **The specimen**: where the product has a code artifact, a configuration object, or a request, one complete, minimal example of it, in full, within the first screen. Two to four bullets name its parts, and one sentence says what prior knowledge transfers. A product with no such artifact skips this section rather than inventing one.
+- **The mechanism**: where a request, an event, or a job crosses more than two objects before the product runs, that chain as a `mermaid` diagram, then a numbered walk of at most six items. Open with what the reader would otherwise assume wrong.
+- **The boundaries**: one compressed bulleted block with bolded lead-ins — languages, APIs, frameworks, integrations, and the headline limits. One block, not one section per feature.
+- **Capability sections**: only for a capability that changes what the reader would build, three at most. A capability that is one sentence and a link belongs in the boundaries block or the router.
+- **Closing**: `## Next steps`, a two-column table indexed by what the reader wants to do: `| If you want to | Go to |`.
+
+The sections keep this order.
+
+## Template
+
+Copy the template and replace each `<placeholder>`:
+
+```mdx
+import LinkButton from 'azion-webkit/linkbutton'
+
+<What the class of thing is, for a reader who has never used one. One or two sentences; define any industry term in place.>
+
+**<Product>** <verb>s <the concept> <where and how on Azion>. Use <Product> to <job A>, <job B>, or <job C>.
+
+<LinkButton label="Quickstart" link="<quickstart URL>" />
+<LinkButton severity="secondary" label="<Product> reference" link="<reference URL>" />
+
+## <The artifact, as a noun phrase>
+
+<One complete, minimal example of the artifact.>
+
+- **<Part>**: <what it is>.
+- **<Part>**: <what it is>.
+
+<One sentence on what prior knowledge transfers.>
+
+---
+
+## <The chain, as a noun phrase>
+
+<What the reader would otherwise assume wrong.>
+
+<A mermaid fence drawing the chain from the request to the response.>
+
+1. <What happens first.>
+2. <...>
+
+## <The boundaries, as a noun phrase>
+
+- **<Dimension>**: <what it supports, and where it stops>.
+- **<Dimension>**: <...>.
+
+---
+
+## Next steps
+
+| If you want to | Go to |
+| --- | --- |
+| <Run your first one now> | [Quickstart](<url>) |
+| <Look up a field, a limit, or a default> | [Reference](<url>) |
+```
+
+## Rules
+
+- **Never instruct.** No numbered steps, no procedures, no click-throughs. The specimen is not a walkthrough: it is shown once, complete, with nothing for the reader to do. An overview that instructs is a [quickstart page](/en/documentation/style-guide/content/quickstart/) filed wrong.
+- **No quality adjectives.** Say what the product does and where it stops.
+- **The title is the product name, a noun.** Not "documentation", not a gerund.
+- **Explain the thing before the product.** The first sentence says what the class of thing is; the product sentence follows it. Cover the product name: what remains must be true of any vendor's version of the thing.
+- **Name the product by the second sentence at the latest, and never open on the problem space.** A concept sentence explains a mechanism. A sentence about how important the problem is explains nothing.
+- **Organize by the reader's questions, not by your feature list.** The sections answer, in order: what is this and what does Azion's version do, what am I writing, how does it get called, what can it do and where does it stop, where do I go now. An outline that reproduces the product's module list is a catalog: it answers "what do we sell" instead of "what am I deciding".
+- **The questions shape the sections; they never become the headings.** A heading is a short noun phrase, never a question: `Function structure`, not `What a function looks like`.
+- **Draw the diagram from the documented sequence.** A diagram of a sequence the documentation already states in prose is a change of notation, not a new fact. Every node and every arrow matches a step the product performs, and the numbered walk carries the meaning if the figure does not render.
+- **Send the reader to the [Quickstart](/en/documentation/style-guide/content/quickstart/)**, in the CTAs and again in the router.
+- **Never thin the specimen or drop the diagram to make the page shorter.** They are the two things the reader came for. A page that runs long has grown capability sections; compress those into the boundaries block.
+
+## Examples
+
+This excerpt of the **Functions** overview shows the definition block in two layers, then the specimen. The first paragraph explains what a function is to a reader who has never used one; the second names the product and what it does on Azion; the specimen shows the artifact instead of describing it:
+
+```mdx
+A function is code that runs when a request arrives, on infrastructure Azion operates. You write a handler that receives the request and returns a response. The platform starts the handler on demand and stops it when the response is sent, so there is no server to provision or scale. That model is called [serverless](https://www.azion.com/en/learning/serverless/what-is-serverless/).
+
+**Functions** runs that code in JavaScript on Azion's distributed network, inside the request path of an application or a firewall. Use Functions to build APIs, manipulate request and response headers, apply logic from request metadata, or block traffic before it reaches your application.
+
+## Function structure
+
+A function exports one default object whose keys are handlers. The `fetch` handler answers an HTTP request:
+
+<Code lang="javascript" code={`
+export default {
+  fetch: async (request, env, ctx) => {
+    return new Response('Hello World');
+  }
+};
+`} />
+
+- **`export default`** exposes the object Azion Runtime reads. Each key names a handler for one event.
+- **`fetch(request, env, ctx)`** runs on an HTTP request.
+- **The returned `Response`** answers the request.
+
+If you know the Web `Request` and `Response` objects, you know the code model.
+```
+
+The same page closes with the router, indexed by what the reader wants to do rather than by page title:
+
+```mdx
+## Next steps
+
+| If you want to | Go to |
+| --- | --- |
+| Run your first function now | [Quickstart](/en/documentation/build/functions/quickstart/) |
+| Understand what invokes a function | [How Functions works](/en/documentation/build/functions/how-it-works/) |
+| Look up a handler, a parameter, or a limit | [Handlers](/en/documentation/build/functions/reference/handlers/) |
+| Look up a term | [Glossary](/en/documentation/build/functions/glossary/) |
+```
+
+## Related
+
+- [Reference](/en/documentation/style-guide/content/reference/): the base form an Overview applies.
+- [Quickstart pages](/en/documentation/style-guide/content/quickstart/): the page an Overview sends the reader to.
+- [Information architecture](/en/documentation/style-guide/content/information-architecture/): where the Overview sits in a product section.
+- [Choose a content type](/en/documentation/style-guide/content/choose-a-content-type/): the full catalogue of page kinds.

--- a/src/content/docs/en/pages/style-guide/content/overview.mdx
+++ b/src/content/docs/en/pages/style-guide/content/overview.mdx
@@ -35,7 +35,7 @@ Descriptive: 25 words per sentence, active voice, passive only when the actor is
 **Required components**
 
 - **Definition block**, in two layers. First the concept: one or two sentences saying what the class of thing is, for a reader who has never used one, with any industry term defined in place. Then the product: `**<Product>** <verb>s <the concept> <where and how on Azion>.` Then one sentence naming the concrete jobs people use it for, in the reader's vocabulary: `Use <Product> to handle A, run B, or serve C.` A bulleted benefit list is the weaker form of that sentence: it reads as a brochure and costs a screen.
-- **CTAs**: a primary `LinkButton` labeled **Quickstart** and a secondary one labeled `<Product> reference`.
+- **CTAs**: a primary `DocButton` labeled **Quickstart** and a secondary one labeled `<Product> reference`.
 - **The specimen**: where the product has a code artifact, a configuration object, or a request, one complete, minimal example of it, in full, within the first screen. Two to four bullets name its parts, and one sentence says what prior knowledge transfers. A product with no such artifact skips this section rather than inventing one.
 - **The mechanism**: where a request, an event, or a job crosses more than two objects before the product runs, that chain as a `mermaid` diagram, then a numbered walk of at most six items. Open with what the reader would otherwise assume wrong.
 - **The boundaries**: one compressed bulleted block with bolded lead-ins — languages, APIs, frameworks, integrations, and the headline limits. One block, not one section per feature.
@@ -49,14 +49,14 @@ The sections keep this order.
 Copy the template and replace each `<placeholder>`:
 
 ```mdx
-import LinkButton from 'azion-webkit/linkbutton'
+import DocButton from '~/components/webkit/DocButton.vue'
 
 <What the class of thing is, for a reader who has never used one. One or two sentences; define any industry term in place.>
 
 **<Product>** <verb>s <the concept> <where and how on Azion>. Use <Product> to <job A>, <job B>, or <job C>.
 
-<LinkButton label="Quickstart" link="<quickstart URL>" />
-<LinkButton severity="secondary" label="<Product> reference" link="<reference URL>" />
+<DocButton href="<quickstart URL>" label="Quickstart" size="medium" />
+<DocButton href="<reference URL>" label="<Product> reference" kind="secondary" size="medium" />
 
 ## <The artifact, as a noun phrase>
 

--- a/src/content/docs/en/pages/style-guide/content/quickstart.mdx
+++ b/src/content/docs/en/pages/style-guide/content/quickstart.mdx
@@ -1,0 +1,136 @@
+---
+title: Quickstart pages
+description: >-
+  Write a Quickstart page: a tutorial whose goal is the first activation of
+  one product, with one path and minimal prerequisites.
+meta_tags: 'style guide, quickstart, get started'
+namespace: documentation_style_guide_quickstart
+permalink: /documentation/style-guide/content/quickstart/
+menu_namespace: styleGuideMenu
+---
+
+## Purpose
+
+A Quickstart page is a tutorial whose goal is the first activation of one product: from not using it to the smallest working result. It follows the [tutorial](/en/documentation/style-guide/content/tutorials/) base form.
+
+Quickstart is the per-product slot. The platform onboarding section at `/documentation/get-started/` carries a similar name and is a different thing: it belongs to no product.
+
+## When to use
+
+- Write a Quickstart page when a product needs a documented path to its first working result.
+- Write at least one Quickstart page per product, as the entry point directly after the product Overview.
+- Write a per-interface variant when an interface has its own first-run audience and its own steps.
+- Do not write a Quickstart page for a task the reader already has in mind. That task needs a [how-to guide](/en/documentation/style-guide/content/how-to-guides/).
+- Do not present options or compare interfaces inside a page. Each page documents one interface, end to end.
+- Do not write a separate Quickstart page for a module or a feature. The pattern covers one whole product.
+
+## Register
+
+Procedural: 20 words per sentence, one instruction per step, imperative and active. Tone: directive, plain, brisk, certain. [Sentence structure](/en/documentation/style-guide/writing/sentence-structure/) holds the rules.
+
+## Structure
+
+A Quickstart page follows the tutorial skeleton. [Tutorials](/en/documentation/style-guide/content/tutorials/) argues each part, and this list names what the pattern requires. A single page takes the title `<Product> quickstart`. An interface variant takes `<Product> quickstart using <interface>`: `using Azion Console`, `using the Azion CLI`, `using the API`, or `using an AI agent`.
+
+**Required components**
+
+- **Opening move**: `This guide instructs you through <outcome>.` followed by a short bullet list of what the reader will have done. Frame the outcome as a first: "your first bucket", "your first deployment".
+- **Object chain**: after the opening move, name every object the reader creates and what each one must be linked to, in order. One short list, before the prerequisites.
+- **Prerequisites**: a `## Prerequisites` section with bulleted items. Each item is a link, a one-line command, or a noun phrase naming the requirement. A single prerequisite is a sentence, not a list.
+- **Stages**: numbered stage headings, `## 1. <Imperative verb phrase>` through `## N.`, ending in a stage that activates or verifies. Each stage holds one procedure and ends with its outcome sentence.
+- **Next steps**: a `## Next steps` closing with bulleted links shaped `[Title](/path/) - one sentence on why the reader would follow it.`
+
+**Optional components**
+
+- **Screenshots**: for a step whose visible result is a screen, not command output.
+- **Asides**: rare. A tutorial full of note blocks tries to be reference material.
+
+## Template
+
+Copy the template and replace each `<placeholder>`:
+
+```md
+This guide instructs you through <outcome, framed as a first:
+your first bucket, your first deployment>.
+
+- <What the reader will have done, as a short bullet list>
+- <...>
+
+To <reach the outcome>, you create and connect these objects:
+
+1. <The first object, and what creates it.>
+2. <The next object, and what it must be linked to.>
+3. <The last link, and what it makes reachable.>
+
+## Prerequisites
+
+- <A link or a one-line command where one exists, otherwise a noun phrase>
+
+## 1. <Imperative verb phrase>
+
+<A procedure, numbered when it has two or more actions.>
+
+<The outcome sentence: what the reader now has or sees.>
+
+## 2. <Imperative verb phrase>
+
+<...>
+
+## N. <Imperative verb phrase that activates or verifies>
+
+<...>
+
+## Next steps
+
+- [Title](/path/) - one sentence on why the reader would follow it.
+- [Title](/path/) - one sentence on why the reader would follow it.
+```
+
+## Rules
+
+- **State the object chain before the first step.** Name every object the reader creates and what it must be linked to, in order. A quickstart that lists clicks without the composition model leaves the reader unable to repeat the result with different objects.
+- **Document one linear path per page.** Inside a page, pick one interface and stay on it. No `<Tabs>`, and no comparison of interfaces or options.
+- **Split by interface when the interface changes the path.** One page is the floor. Add a variant when an interface has its own first-run audience and its own steps: Azion Console, the Azion CLI, the API, or an AI agent connected through the [Azion MCP server](/en/documentation/agent-setup/). The variants sit under one Quickstart group in the sidebar, Console first. The group is a menu parent, not a page.
+- **Name the sibling paths in one line**, under the opening move: `Prefer the CLI? Refer to [<Product> quickstart using the Azion CLI](/path/).` The reader who lands on the wrong path leaves it in one step.
+- **Delete a variant you cannot keep true.** Every variant multiplies the commands that run before a release. A stale first-run page fails the reader at first contact.
+- **Write each stage as a procedure.** Steps follow [Procedures](/en/documentation/style-guide/writing/procedures/), and every stage ends with its outcome sentence.
+- **Keep prerequisites to the minimum real set.** Every item is a reason to abandon the page.
+- **End in a stage that activates or verifies.** The reader leaves with proof of the working result.
+- **Link tutorials and the main how-tos in `## Next steps`.** Give each link its reason.
+- **Test every command before the page ships.** One instruction per step, and a visible result at each one.
+- **Show the output after every command.** The reader sees what success looks like before the next step depends on it. The rule is in [Procedures](/en/documentation/style-guide/writing/procedures/).
+- **Place it directly after the product Overview.**
+
+## Examples
+
+This excerpt of a Quickstart page for **Functions** shows the opening move, the object chain, and the prerequisites:
+
+```mdx
+This guide instructs you through running your first function on the Azion Web Platform.
+
+- Create a function and write its code.
+- Connect the function to an application and a workload.
+- Verify that the function answers a request.
+
+To run a function, you create and connect these objects:
+
+1. A **function**, which holds the code.
+2. A **function instance**, which binds the function to an application.
+3. A **rule** in the Rules Engine, which decides the requests that trigger the instance.
+4. A **workload**, which the application is linked to and which receives the traffic.
+
+---
+
+## Prerequisites
+
+- An [Azion account](https://console.azion.com/).
+```
+
+The chain tells the reader why four objects exist before a single request reaches their code. Without it, the steps read as unexplained clicks.
+
+## Related
+
+- [Tutorials](/en/documentation/style-guide/content/tutorials/): the base form this pattern applies.
+- [How-to guides](/en/documentation/style-guide/content/how-to-guides/): where the options and the alternatives go.
+- [Information architecture](/en/documentation/style-guide/content/information-architecture/): where the page sits in a product section.
+- [Choose a content type](/en/documentation/style-guide/content/choose-a-content-type/): the full catalogue of page kinds.

--- a/src/content/docs/en/pages/style-guide/content/quickstart.mdx
+++ b/src/content/docs/en/pages/style-guide/content/quickstart.mdx
@@ -8,6 +8,9 @@ namespace: documentation_style_guide_quickstart
 permalink: /documentation/style-guide/content/quickstart/
 menu_namespace: styleGuideMenu
 ---
+import FrameBox from '@aziontech/webkit/frame-box'
+import ItemList from '@aziontech/webkit/item-list'
+import DocItem from '@aziontech/webkit/doc-item'
 
 ## Purpose
 
@@ -38,7 +41,7 @@ A Quickstart page follows the tutorial skeleton. [Tutorials](/en/documentation/s
 - **Object chain**: after the opening move, name every object the reader creates and what each one must be linked to, in order. One short list, before the prerequisites.
 - **Prerequisites**: a `## Prerequisites` section with bulleted items. Each item is a link, a one-line command, or a noun phrase naming the requirement. A single prerequisite is a sentence, not a list.
 - **Stages**: numbered stage headings, `## 1. <Imperative verb phrase>` through `## N.`, ending in a stage that activates or verifies. Each stage holds one procedure and ends with its outcome sentence.
-- **Next steps**: a `## Next steps` closing with bulleted links shaped `[Title](/path/) - one sentence on why the reader would follow it.`
+- **Next steps**: a `## Next steps` closing, a `DocCardGroup` with one card per destination: the title, the link, and one sentence on why the reader would follow it.
 
 **Optional components**
 
@@ -49,7 +52,10 @@ A Quickstart page follows the tutorial skeleton. [Tutorials](/en/documentation/s
 
 Copy the template and replace each `<placeholder>`:
 
-```md
+```mdx
+import DocCardGroup from '@aziontech/webkit/doc-card-group'
+import DocCard from '@aziontech/webkit/doc-card'
+
 This guide instructs you through <outcome, framed as a first:
 your first bucket, your first deployment>.
 
@@ -82,8 +88,10 @@ To <reach the outcome>, you create and connect these objects:
 
 ## Next steps
 
-- [Title](/path/) - one sentence on why the reader would follow it.
-- [Title](/path/) - one sentence on why the reader would follow it.
+<DocCardGroup cols={2}>
+  <DocCard title="Title" href="/path/" label="one sentence on why the reader would follow it." />
+  <DocCard title="Title" href="/path/" label="one sentence on why the reader would follow it." />
+</DocCardGroup>
 ```
 
 ## Rules
@@ -96,7 +104,7 @@ To <reach the outcome>, you create and connect these objects:
 - **Write each stage as a procedure.** Steps follow [Procedures](/en/documentation/style-guide/writing/procedures/), and every stage ends with its outcome sentence.
 - **Keep prerequisites to the minimum real set.** Every item is a reason to abandon the page.
 - **End in a stage that activates or verifies.** The reader leaves with proof of the working result.
-- **Link tutorials and the main how-tos in `## Next steps`.** Give each link its reason.
+- **Link tutorials and the main how-tos in `## Next steps`.** Give each card its reason.
 - **Test every command before the page ships.** One instruction per step, and a visible result at each one.
 - **Show the output after every command.** The reader sees what success looks like before the next step depends on it. The rule is in [Procedures](/en/documentation/style-guide/writing/procedures/).
 - **Place it directly after the product Overview.**
@@ -130,7 +138,11 @@ The chain tells the reader why four objects exist before a single request reache
 
 ## Related
 
-- [Tutorials](/en/documentation/style-guide/content/tutorials/): the base form this pattern applies.
-- [How-to guides](/en/documentation/style-guide/content/how-to-guides/): where the options and the alternatives go.
-- [Information architecture](/en/documentation/style-guide/content/information-architecture/): where the page sits in a product section.
-- [Choose a content type](/en/documentation/style-guide/content/choose-a-content-type/): the full catalogue of page kinds.
+<FrameBox>
+<ItemList>
+  <DocItem title="Tutorials" href="/en/documentation/style-guide/content/tutorials/">The base form this pattern applies.</DocItem>
+  <DocItem title="How-to guides" href="/en/documentation/style-guide/content/how-to-guides/">Where the options and the alternatives go.</DocItem>
+  <DocItem title="Information architecture" href="/en/documentation/style-guide/content/information-architecture/">Where the page sits in a product section.</DocItem>
+  <DocItem title="Choose a content type" href="/en/documentation/style-guide/content/choose-a-content-type/">The full catalogue of page kinds.</DocItem>
+</ItemList>
+</FrameBox>

--- a/src/content/docs/en/pages/style-guide/content/reference.mdx
+++ b/src/content/docs/en/pages/style-guide/content/reference.mdx
@@ -1,0 +1,153 @@
+---
+title: Reference
+description: >-
+  Write a reference page: what a reference describes, the standard section
+  order, tables with units and defaults, and the sentence budget.
+meta_tags: 'style guide, reference pages'
+namespace: documentation_style_guide_reference
+permalink: /documentation/style-guide/content/reference/
+menu_namespace: styleGuideMenu
+---
+
+## Purpose
+
+A reference page is look-up material. The reader consults it to find one value, one field, or one limit, and then leaves.
+
+## When to use
+
+Write a reference page when:
+
+- The reader needs to look up a field, a setting, a limit, or a flag.
+- The information is enumerable and fits in a table.
+
+Do not write a reference page when:
+
+- The reader needs steps for a task. Write a [how-to guide](/en/documentation/style-guide/content/how-to-guides/).
+- The reader needs the reasoning behind a design. Write a [concept](/en/documentation/style-guide/content/concept/).
+
+## Register
+
+Descriptive: 25 words per sentence, active voice, passive only when the actor is unknown. Tone: plain, neutral, exhaustive. [Sentence structure](/en/documentation/style-guide/writing/sentence-structure/) holds the rules.
+
+## Structure
+
+**Required components**
+
+- **Title**: a noun phrase naming the thing: `Object Storage`, `Cache settings`, `azion create bucket`.
+- **Opening move**: one to three definitional sentences about the artifact, then straight to the data. No procedure framing.
+- **Sections**: noun-phrase `##`s naming the actual object, field group, or level. Tables carry the information — fields, values, defaults, limits — with consistent phrasing down every column and units on every number. Prose between tables is one or two sentences of orientation.
+- **Limits**: a `## Limits` section when the product has them, **dimensioned by plan**. Use `| Scope | Plan | Limit |` when a scope repeats across plans, or one column per plan when the set is short enough to read across. Every row carries its unit and says whether the limit is hard or raisable.
+- **Closing**: `## Related resources`, with links shaped `[Title](/path/) - reason`, covering the concept page and the main how-tos.
+
+**Optional components**
+
+- **Asides**: a tip above the limits table when support can raise the limits, and a caution for a version or migration warning. Use no other aside.
+
+The sections keep this order.
+
+When the limits set grows large enough to consult on its own, it moves into its own Limits slot in the product section. These rules do not change: only the location does. [Information architecture](/en/documentation/style-guide/content/information-architecture/) holds the slot list.
+
+## Template
+
+Copy the template and replace each `<placeholder>`:
+
+```md
+**<Product or resource>** is <one to three definitional sentences about the artifact>.
+
+## <Object, field group, or level, as a noun phrase>
+
+<One or two sentences of orientation.>
+
+| Field | Description |
+| --- | --- |
+| <Field name> | <What it holds, with the default value> |
+
+## <Object, field group, or level, as a noun phrase>
+
+<...>
+
+---
+
+## Limits
+
+:::tip
+Support can raise the limits marked raisable. Contact <support link>.
+:::
+
+| Scope | Plan | Limit | Raisable |
+| --- | --- | --- | --- |
+| <Scope> | <Plan name> | <Value with the unit> | Yes / No |
+
+---
+
+## Related resources
+
+- [<The concept page>](<url>) - <why the reader would follow it>
+- [<A main how-to>](<url>) - <why the reader would follow it>
+```
+
+## Rules
+
+- **Never a numbered click-through.** The moment one appears, the page is a [how-to guide](/en/documentation/style-guide/content/how-to-guides/) filed wrong. Link the how-to instead.
+- **Be complete before you are interesting.** A reference missing three of twelve fields is broken; one with dull descriptions of all twelve is doing its job.
+- **Put enumerable information in tables.** Fields, limits, flags, defaults, status codes.
+- **Keep phrasing consistent down a column.** Readers scan; varied phrasing forces them to read.
+- **State the units and the defaults.** A limit without a unit is not a fact.
+- **Dimension every limit by plan.** A limit that differs across plans is not one fact. A number published without the plan it belongs to is wrong for every reader on a different plan.
+- **Distinguish a limit from a default.** A default is a field value and belongs in the field table. A limit is a ceiling and belongs under `## Limits`.
+- **Say whether each limit is hard or raisable.** The reader's next action depends on it: a raisable limit is a support request, a hard limit is a design constraint.
+- **Never invent a limit or a plan name.** Take both from the pricing page, the plans agreement, or the product team. A value you cannot confirm is not published: narrow the table to the dimensions you can confirm.
+- **Never restate a price.** Amounts, quotas sold by the unit, and billing metrics live on the pricing page alone. Link it; do not copy it.
+- **No marketing.** Say what it does and where it stops.
+- **A CLI command page has its own shape.** A one-line summary, then `## Usage` with the command, then `## Optional flags` with one entry per flag.
+
+## Examples
+
+This excerpt of a reference page for **Object Storage** shows the definitional opening, one object section with its table, and the closing:
+
+```mdx
+**Object Storage** is a Store product that stores objects in buckets. A bucket is the container; an object is the stored item plus its metadata. Azion stores all buckets in the _us-east_ cloud region and bills storage per GB/hour, with no minimum retention.
+
+## Buckets
+
+Bucket names follow these rules:
+
+| Rule | Value |
+| --- | --- |
+| Length | 6 to 63 characters |
+| Characters | Alphanumeric characters and hyphen |
+| Reserved prefix | Must not start with `azion` |
+| Uniqueness | Exclusive across all Azion accounts |
+
+You cannot rename a bucket. You can delete a bucket only when it is empty, 24 hours after the removal of the final object.
+
+## Related resources
+
+- [Create an Object Storage bucket](/en/documentation/products/store/storage/create-bucket/) - create a bucket and set its `workloads_access` permission.
+- [Use a bucket as origin](/en/documentation/products/store/storage/use-bucket-as-origin/) - serve content from a bucket through Connectors.
+```
+
+This excerpt shows a limits table where the breakdown by plan was not confirmed. The table carries the columns that were confirmed and no more:
+
+```mdx
+## Limits
+
+:::tip
+Support can raise the limits marked raisable. Contact the [technical support team](/en/documentation/services/support/).
+:::
+
+| Scope | Limit | Raisable |
+| --- | --- | --- |
+| Buckets | 100 per account | Yes |
+| S3 credential access keys | 100,000 per account | Yes |
+```
+
+The missing column is the point. The breakdown by plan for these numbers was not confirmed, so the table has no plan column rather than an invented one.
+
+## Related
+
+- [Choose a content type](/en/documentation/style-guide/content/choose-a-content-type/): the full catalogue of page kinds.
+- [Tutorials](/en/documentation/style-guide/content/tutorials/): the content type that teaches through a first project.
+- [How-to guides](/en/documentation/style-guide/content/how-to-guides/): the content type that holds the steps.
+- [Concept](/en/documentation/style-guide/content/concept/): the page kind that holds the reasoning.
+- [Documentation voice](/en/documentation/style-guide/writing/voice/): the one register every page uses.

--- a/src/content/docs/en/pages/style-guide/content/reference.mdx
+++ b/src/content/docs/en/pages/style-guide/content/reference.mdx
@@ -8,6 +8,9 @@ namespace: documentation_style_guide_reference
 permalink: /documentation/style-guide/content/reference/
 menu_namespace: styleGuideMenu
 ---
+import FrameBox from '@aziontech/webkit/frame-box'
+import ItemList from '@aziontech/webkit/item-list'
+import DocItem from '@aziontech/webkit/doc-item'
 
 ## Purpose
 
@@ -37,7 +40,7 @@ Descriptive: 25 words per sentence, active voice, passive only when the actor is
 - **Opening move**: one to three definitional sentences about the artifact, then straight to the data. No procedure framing.
 - **Sections**: noun-phrase `##`s naming the actual object, field group, or level. Tables carry the information — fields, values, defaults, limits — with consistent phrasing down every column and units on every number. Prose between tables is one or two sentences of orientation.
 - **Limits**: a `## Limits` section when the product has them, **dimensioned by plan**. Use `| Scope | Plan | Limit |` when a scope repeats across plans, or one column per plan when the set is short enough to read across. Every row carries its unit and says whether the limit is hard or raisable.
-- **Closing**: `## Related resources`, with links shaped `[Title](/path/) - reason`, covering the concept page and the main how-tos.
+- **Closing**: `## Related resources`, a `DocItem` list covering the concept page and the main how-tos, each row with its reason.
 
 **Optional components**
 
@@ -51,7 +54,11 @@ When the limits set grows large enough to consult on its own, it moves into its 
 
 Copy the template and replace each `<placeholder>`:
 
-```md
+```mdx
+import FrameBox from '@aziontech/webkit/frame-box'
+import ItemList from '@aziontech/webkit/item-list'
+import DocItem from '@aziontech/webkit/doc-item'
+
 **<Product or resource>** is <one to three definitional sentences about the artifact>.
 
 ## <Object, field group, or level, as a noun phrase>
@@ -82,8 +89,12 @@ Support can raise the limits marked raisable. Contact <support link>.
 
 ## Related resources
 
-- [<The concept page>](<url>) - <why the reader would follow it>
-- [<A main how-to>](<url>) - <why the reader would follow it>
+<FrameBox>
+<ItemList>
+  <DocItem title="<The concept page>" href="<url>"><why the reader would follow it></DocItem>
+  <DocItem title="<A main how-to>" href="<url>"><why the reader would follow it></DocItem>
+</ItemList>
+</FrameBox>
 ```
 
 ## Rules
@@ -106,6 +117,10 @@ Support can raise the limits marked raisable. Contact <support link>.
 This excerpt of a reference page for **Object Storage** shows the definitional opening, one object section with its table, and the closing:
 
 ```mdx
+import FrameBox from '@aziontech/webkit/frame-box'
+import ItemList from '@aziontech/webkit/item-list'
+import DocItem from '@aziontech/webkit/doc-item'
+
 **Object Storage** is a Store product that stores objects in buckets. A bucket is the container; an object is the stored item plus its metadata. Azion stores all buckets in the _us-east_ cloud region and bills storage per GB/hour, with no minimum retention.
 
 ## Buckets
@@ -123,8 +138,12 @@ You cannot rename a bucket. You can delete a bucket only when it is empty, 24 ho
 
 ## Related resources
 
-- [Create an Object Storage bucket](/en/documentation/products/store/storage/create-bucket/) - create a bucket and set its `workloads_access` permission.
-- [Use a bucket as origin](/en/documentation/products/store/storage/use-bucket-as-origin/) - serve content from a bucket through Connectors.
+<FrameBox>
+<ItemList>
+  <DocItem title="Create an Object Storage bucket" href="/en/documentation/products/store/storage/create-bucket/">create a bucket and set its `workloads_access` permission.</DocItem>
+  <DocItem title="Use a bucket as origin" href="/en/documentation/products/store/storage/use-bucket-as-origin/">serve content from a bucket through Connectors.</DocItem>
+</ItemList>
+</FrameBox>
 ```
 
 This excerpt shows a limits table where the breakdown by plan was not confirmed. The table carries the columns that were confirmed and no more:
@@ -146,8 +165,12 @@ The missing column is the point. The breakdown by plan for these numbers was not
 
 ## Related
 
-- [Choose a content type](/en/documentation/style-guide/content/choose-a-content-type/): the full catalogue of page kinds.
-- [Tutorials](/en/documentation/style-guide/content/tutorials/): the content type that teaches through a first project.
-- [How-to guides](/en/documentation/style-guide/content/how-to-guides/): the content type that holds the steps.
-- [Concept](/en/documentation/style-guide/content/concept/): the page kind that holds the reasoning.
-- [Documentation voice](/en/documentation/style-guide/writing/voice/): the one register every page uses.
+<FrameBox>
+<ItemList>
+  <DocItem title="Choose a content type" href="/en/documentation/style-guide/content/choose-a-content-type/">The full catalogue of page kinds.</DocItem>
+  <DocItem title="Tutorials" href="/en/documentation/style-guide/content/tutorials/">The content type that teaches through a first project.</DocItem>
+  <DocItem title="How-to guides" href="/en/documentation/style-guide/content/how-to-guides/">The content type that holds the steps.</DocItem>
+  <DocItem title="Concept" href="/en/documentation/style-guide/content/concept/">The page kind that holds the reasoning.</DocItem>
+  <DocItem title="Documentation voice" href="/en/documentation/style-guide/writing/voice/">The one register every page uses.</DocItem>
+</ItemList>
+</FrameBox>

--- a/src/content/docs/en/pages/style-guide/content/troubleshooting.mdx
+++ b/src/content/docs/en/pages/style-guide/content/troubleshooting.mdx
@@ -1,0 +1,144 @@
+---
+title: Troubleshooting pages
+description: >-
+  Write a troubleshooting page: name the symptom the reader sees, order the
+  causes by frequency, and put the fix before the ticket.
+meta_tags: 'style guide, troubleshooting'
+namespace: documentation_style_guide_troubleshooting
+permalink: /documentation/style-guide/content/troubleshooting/
+menu_namespace: styleGuideMenu
+---
+
+## Purpose
+
+A troubleshooting page fixes a symptom the reader is looking at right now. It applies the [how-to](/en/documentation/style-guide/content/how-to-guides/) base form: the task is a fix.
+
+## When to use
+
+- Write a troubleshooting page when a known failure has a fix the reader can apply alone.
+- Write one page for a group of related symptoms, with one section per symptom.
+- Do not write a troubleshooting page for a task the reader plans. A planned task needs a [how-to guide](/en/documentation/style-guide/content/how-to-guides/).
+- Do not write one when the product works as designed. The reasons behind a design belong in a [concept](/en/documentation/style-guide/content/concept/) page.
+- Do not write one when the only fix is a support ticket. A page whose only step is "open a ticket" is a link, not a page.
+
+## Register
+
+Procedural: 20 words per sentence, one instruction per step, imperative and active. Tone: calm, plain, directive, remedial. [Sentence structure](/en/documentation/style-guide/writing/sentence-structure/) holds the rules.
+
+## Structure
+
+The title is shaped `Troubleshoot <feature or symptom class>`: `Troubleshoot WAF blocking legitimate requests`.
+
+**Required components**
+
+- **Opening move**: one scope sentence naming the product and the class of symptoms the page covers.
+- **Symptom sections**: one `##` per symptom, each fully self-contained and readable in any order.
+- **Symptom headings**: a noun phrase stating the observable behavior, quoting error strings verbatim in monospace: `` ## `403 Forbidden` on legitimate requests ``.
+- **The symptom**: what the reader sees, in one or two sentences, first in every section.
+- **The cause**: what produces the symptom.
+- **The fix**: a numbered procedure, or remedy bullets shaped `**<Remedy name>**: what it does and its link`.
+- **The outcome**: what the reader should now see, closing every section.
+- **Related resources**: a closing `## Related resources` section linking the how-to and reference pages the fixes lean on.
+
+**Optional components**
+
+- **Error output**: the message or the screen that confirms the reader has this symptom.
+- **Support escalation**: one aside linking the support path, placed after every fix.
+
+## Template
+
+Copy the template and replace each `<placeholder>`:
+
+```md
+[One scope sentence: the product and the class of
+symptoms the page covers.]
+
+---
+
+## <Observable behavior, with the error string in monospace>
+
+<The symptom: what the reader sees, in one or two sentences.>
+
+<The cause.>
+
+To <fix the symptom>:
+
+1. <One imperative instruction.>
+2. <One imperative instruction.>
+
+<The outcome the reader should now see.>
+
+---
+
+## <Next symptom, readable alone>
+
+<The symptom.>
+
+<The cause.>
+
+- **<Remedy name>**: <what it does and its link>.
+
+<The outcome.>
+
+---
+
+## Related resources
+
+- [<Title>](/path/) - <the how-to or reference page the fixes lean on>
+```
+
+Separate the symptom sections with a `---` rule, and never place one directly after the frontmatter.
+
+## Rules
+
+- **Name the page after the symptom class.** The title is shaped `Troubleshoot <feature or symptom class>`.
+- **Open with one scope sentence** naming the product and the class of symptoms the page covers.
+- **Name the symptom, not the cause.** The reader searches with what they see; quote error strings verbatim in monospace.
+- **Make each symptom section stand alone.** The reader arrives at any section first; name the subject in each one.
+- **Keep the order inside each section**: the symptom, the cause, the fix, the outcome.
+- **Order causes by frequency.** When a symptom has more than one cause, the reader tries fixes top-down.
+- **Write fixes as numbered imperative steps** per [Procedures](/en/documentation/style-guide/writing/procedures/), or as remedy bullets shaped `**<Remedy name>**: what it does and its link`.
+- **Link long procedures instead of restating them.** The fix section holds what is specific to the symptom; the generic path is a link.
+- **Close with `## Related resources`**: the how-to and reference pages the fixes lean on. A support-escalation aside may come before it.
+- **Place by scope.** Platform-wide problems in Support, product problems in that product's guides.
+
+## Examples
+
+This excerpt of a troubleshooting page for WAF false positives shows the opening move and the first symptom section:
+
+```mdx
+**Web Application Firewall (WAF)** can block legitimate requests when an internal rule matches them. This page covers these false positives and the allowed rules that fix them.
+
+---
+
+## `403 Forbidden` on legitimate requests
+
+After you turn on the WAF in blocking mode, legitimate requests receive a `403 Forbidden` response.
+
+The cause is a WAF internal rule that matches the request. Common examples include:
+
+| Rule ID | Matches |
+| --- | --- |
+| `1000` | SQL keywords |
+| `1013` | Apostrophe (`'`) |
+| `1302` | HTML open tag (`<`) |
+
+To find the rule and allow the legitimate requests with WAF Tuning:
+
+1. Access [Azion Console](https://console.azion.com/) > **WAF Rules** > **your rule set**.
+2. Go to the **Tuning** tab.
+3. Set a **Time Range**, for example _Last 12 hours_. WAF Tuning queries cover up to 3 days.
+4. In the **Workloads** dropdown, select the domains to analyze. Results only appear with at least one domain selected.
+5. Select **Apply**. The **Possible Attacks** list shows **Rule ID**, **Description**, **Hits**, **Paths**, **IPs**, and **Countries**.
+6. (Optional) To see more details for a record, select **More Details**.
+7. Use the **Field** checkbox to select the legitimate records.
+8. Select **Allow Rules**.
+
+The new allowed rule appears in the **Allowed Rules** tab of the **WAF Rules** page. The WAF no longer blocks the requests that match the allowed rule.
+```
+
+## Related
+
+- [How-to guides](/en/documentation/style-guide/content/how-to-guides/): the base form this pattern applies.
+- [Information architecture](/en/documentation/style-guide/content/information-architecture/): where platform-wide and product-specific troubleshooting live.
+- [Choose a content type](/en/documentation/style-guide/content/choose-a-content-type/): the full catalogue of page kinds.

--- a/src/content/docs/en/pages/style-guide/content/troubleshooting.mdx
+++ b/src/content/docs/en/pages/style-guide/content/troubleshooting.mdx
@@ -8,6 +8,9 @@ namespace: documentation_style_guide_troubleshooting
 permalink: /documentation/style-guide/content/troubleshooting/
 menu_namespace: styleGuideMenu
 ---
+import FrameBox from '@aziontech/webkit/frame-box'
+import ItemList from '@aziontech/webkit/item-list'
+import DocItem from '@aziontech/webkit/doc-item'
 
 ## Purpose
 
@@ -38,7 +41,7 @@ The title is shaped `Troubleshoot <feature or symptom class>`: `Troubleshoot WAF
 - **The cause**: what produces the symptom.
 - **The fix**: a numbered procedure, or remedy bullets shaped `**<Remedy name>**: what it does and its link`.
 - **The outcome**: what the reader should now see, closing every section.
-- **Related resources**: a closing `## Related resources` section linking the how-to and reference pages the fixes lean on.
+- **Related resources**: a closing `## Related resources` section, a `DocItem` list of the how-to and reference pages the fixes lean on.
 
 **Optional components**
 
@@ -49,7 +52,11 @@ The title is shaped `Troubleshoot <feature or symptom class>`: `Troubleshoot WAF
 
 Copy the template and replace each `<placeholder>`:
 
-```md
+```mdx
+import FrameBox from '@aziontech/webkit/frame-box'
+import ItemList from '@aziontech/webkit/item-list'
+import DocItem from '@aziontech/webkit/doc-item'
+
 [One scope sentence: the product and the class of
 symptoms the page covers.]
 
@@ -84,7 +91,11 @@ To <fix the symptom>:
 
 ## Related resources
 
-- [<Title>](/path/) - <the how-to or reference page the fixes lean on>
+<FrameBox>
+<ItemList>
+  <DocItem title="<Title>" href="/path/"><the how-to or reference page the fixes lean on></DocItem>
+</ItemList>
+</FrameBox>
 ```
 
 Separate the symptom sections with a `---` rule, and never place one directly after the frontmatter.
@@ -99,7 +110,7 @@ Separate the symptom sections with a `---` rule, and never place one directly af
 - **Order causes by frequency.** When a symptom has more than one cause, the reader tries fixes top-down.
 - **Write fixes as numbered imperative steps** per [Procedures](/en/documentation/style-guide/writing/procedures/), or as remedy bullets shaped `**<Remedy name>**: what it does and its link`.
 - **Link long procedures instead of restating them.** The fix section holds what is specific to the symptom; the generic path is a link.
-- **Close with `## Related resources`**: the how-to and reference pages the fixes lean on. A support-escalation aside may come before it.
+- **Close with `## Related resources`**: a `DocItem` list of the how-to and reference pages the fixes lean on. A support-escalation aside may come before it.
 - **Place by scope.** Platform-wide problems in Support, product problems in that product's guides.
 
 ## Examples
@@ -139,6 +150,10 @@ The new allowed rule appears in the **Allowed Rules** tab of the **WAF Rules** p
 
 ## Related
 
-- [How-to guides](/en/documentation/style-guide/content/how-to-guides/): the base form this pattern applies.
-- [Information architecture](/en/documentation/style-guide/content/information-architecture/): where platform-wide and product-specific troubleshooting live.
-- [Choose a content type](/en/documentation/style-guide/content/choose-a-content-type/): the full catalogue of page kinds.
+<FrameBox>
+<ItemList>
+  <DocItem title="How-to guides" href="/en/documentation/style-guide/content/how-to-guides/">The base form this pattern applies.</DocItem>
+  <DocItem title="Information architecture" href="/en/documentation/style-guide/content/information-architecture/">Where platform-wide and product-specific troubleshooting live.</DocItem>
+  <DocItem title="Choose a content type" href="/en/documentation/style-guide/content/choose-a-content-type/">The full catalogue of page kinds.</DocItem>
+</ItemList>
+</FrameBox>

--- a/src/content/docs/en/pages/style-guide/content/tutorials.mdx
+++ b/src/content/docs/en/pages/style-guide/content/tutorials.mdx
@@ -8,6 +8,9 @@ namespace: documentation_style_guide_tutorials
 permalink: /documentation/style-guide/content/tutorials/
 menu_namespace: styleGuideMenu
 ---
+import FrameBox from '@aziontech/webkit/frame-box'
+import ItemList from '@aziontech/webkit/item-list'
+import DocItem from '@aziontech/webkit/doc-item'
 
 ## Purpose
 
@@ -52,7 +55,7 @@ The title is an imperative verb phrase naming the artifact: `Build a comments AP
 - **Opening move**: `In this tutorial, you will <verb> <the artifact and its goal>.` Then one sentence enumerating the sub-goals: "You will create ..., configure ..., and deploy ...".
 - **Prerequisites**: a `## Prerequisites` section, always first, each item a link or a one-line command where one exists, otherwise a noun phrase.
 - **Stages**: numbered stage headings, `## 1. <Imperative verb phrase>`, in build order. `(Optional)` may follow the number: `## 8. (Optional) Add a custom domain`. The final stage deploys or verifies.
-- **Next steps**: a `## Next steps` closing with bulleted links shaped `[Title](/path/) - one sentence on why the reader would follow it.`
+- **Next steps**: a `## Next steps` closing, a `DocCardGroup` with one card per destination: the title, the link, and one sentence on why the reader would follow it.
 
 **Optional components**
 
@@ -63,7 +66,10 @@ The title is an imperative verb phrase naming the artifact: `Build a comments AP
 
 Copy the template and replace each `<placeholder>`:
 
-```md
+```mdx
+import DocCardGroup from '@aziontech/webkit/doc-card-group'
+import DocCard from '@aziontech/webkit/doc-card'
+
 In this tutorial, you will <verb> <the artifact and its goal>.
 You will create <...>, configure <...>, and deploy <...>.
 
@@ -91,8 +97,10 @@ You will create <...>, configure <...>, and deploy <...>.
 
 ## Next steps
 
-- [Title](/path/) - one sentence on why the reader would follow it.
-- [Title](/path/) - one sentence on why the reader would follow it.
+<DocCardGroup cols={2}>
+  <DocCard title="Title" href="/path/" label="one sentence on why the reader would follow it." />
+  <DocCard title="Title" href="/path/" label="one sentence on why the reader would follow it." />
+</DocCardGroup>
 ```
 
 ## Rules
@@ -105,7 +113,7 @@ You will create <...>, configure <...>, and deploy <...>.
 - **Give every code block a colon lead-in.** "Install the CLI:" then the command. Use `<Code>` for anything the reader copies.
 - **Show the output after every command.** The reader sees what success looks like before the next step depends on it. The rule is in [Procedures](/en/documentation/style-guide/writing/procedures/).
 - **Keep tutorials scarce.** One per product area. Tutorials are expensive to keep working.
-- **Link the how-tos and concepts the tutorial touched in `## Next steps`.** Give each link its reason.
+- **Link the how-tos and concepts the tutorial touched in `## Next steps`.** Give each card its reason.
 
 ## Examples
 
@@ -142,6 +150,10 @@ The database is ready when `status` is `created`.
 
 ## Related
 
-- [Quickstart pages](/en/documentation/style-guide/content/quickstart/): the tutorial whose goal is first activation.
-- [How-to guides](/en/documentation/style-guide/content/how-to-guides/): the page for the reader who arrived with a task.
-- [Choose a content type](/en/documentation/style-guide/content/choose-a-content-type/): the router.
+<FrameBox>
+<ItemList>
+  <DocItem title="Quickstart pages" href="/en/documentation/style-guide/content/quickstart/">The tutorial whose goal is first activation.</DocItem>
+  <DocItem title="How-to guides" href="/en/documentation/style-guide/content/how-to-guides/">The page for the reader who arrived with a task.</DocItem>
+  <DocItem title="Choose a content type" href="/en/documentation/style-guide/content/choose-a-content-type/">The router.</DocItem>
+</ItemList>
+</FrameBox>

--- a/src/content/docs/en/pages/style-guide/content/tutorials.mdx
+++ b/src/content/docs/en/pages/style-guide/content/tutorials.mdx
@@ -1,0 +1,147 @@
+---
+title: Tutorials
+description: >-
+  Write a tutorial: the author picks the goal, guarantees the result, and
+  keeps every decision away from the reader.
+meta_tags: 'style guide, tutorials'
+namespace: documentation_style_guide_tutorials
+permalink: /documentation/style-guide/content/tutorials/
+menu_namespace: styleGuideMenu
+---
+
+## Purpose
+
+A tutorial teaches the product by having the reader build something that works. The author chooses the goal, guarantees the result, and keeps every decision away from the reader.
+
+## When to use
+
+**Recognize a tutorial by:**
+
+- A reader who has chosen the product and has not yet built anything with it.
+- One artifact that works when the last stage ends.
+- A single path the author chose and guarantees, from the first command to a verified result.
+- Learning that arrives as a side effect of building, never as a lecture.
+
+**It is still a tutorial when:**
+
+- It uses more than one product, because the artifact needs them. The author chose the goal, and that is what decides the kind.
+- It builds against a third-party service that belongs to the artifact. Name the vendor's step and link out; never document their interface.
+- It runs entirely in Azion Console, because that is the honest path to the result.
+- It leaves out a capability the artifact does not need. Completeness belongs to [reference](/en/documentation/style-guide/content/reference/).
+
+**Write something else when:**
+
+- The reader arrived with the task already in mind. That is a [how-to guide](/en/documentation/style-guide/content/how-to-guides/).
+- The page activates a product for the first time. That is a [quickstart](/en/documentation/style-guide/content/quickstart/).
+- The page implements a business scenario end to end. That is a [use case](/en/documentation/style-guide/content/use-cases/).
+- The subject is fields, values, and defaults. That is [reference](/en/documentation/style-guide/content/reference/).
+- Nothing is finished at the end. Steps that end nowhere teach nothing, so find the artifact or drop the page.
+
+When two kinds still look possible, [Choose a content type](/en/documentation/style-guide/content/choose-a-content-type/) has the router.
+
+## Register
+
+Procedural: 20 words per sentence, one instruction per step, imperative and active. Tone: directive, plain, instructive, certain. [Sentence structure](/en/documentation/style-guide/writing/sentence-structure/) holds the rules.
+
+## Structure
+
+The title is an imperative verb phrase naming the artifact: `Build a comments API`, `Deploy a static site with Functions`.
+
+**Required components**
+
+- **Opening move**: `In this tutorial, you will <verb> <the artifact and its goal>.` Then one sentence enumerating the sub-goals: "You will create ..., configure ..., and deploy ...".
+- **Prerequisites**: a `## Prerequisites` section, always first, each item a link or a one-line command where one exists, otherwise a noun phrase.
+- **Stages**: numbered stage headings, `## 1. <Imperative verb phrase>`, in build order. `(Optional)` may follow the number: `## 8. (Optional) Add a custom domain`. The final stage deploys or verifies.
+- **Next steps**: a `## Next steps` closing with bulleted links shaped `[Title](/path/) - one sentence on why the reader would follow it.`
+
+**Optional components**
+
+- **One concept sentence** with a link to a [concept](/en/documentation/style-guide/content/concept/) page, when a concept is genuinely required.
+- **An image** as the visible result of a step, when words alone cannot show it.
+
+## Template
+
+Copy the template and replace each `<placeholder>`:
+
+```md
+In this tutorial, you will <verb> <the artifact and its goal>.
+You will create <...>, configure <...>, and deploy <...>.
+
+## Prerequisites
+
+- <A link or a one-line command where one exists, otherwise a noun phrase>
+
+## 1. <Imperative verb phrase>
+
+<A procedure. Every step shows a visible result.>
+
+<The outcome sentence: what the reader now has or sees.>
+
+## 2. <Imperative verb phrase>
+
+<...>
+
+## 3. (Optional) <Imperative verb phrase>
+
+<An optional stage. `(Optional)` follows the number.>
+
+## 4. <Imperative verb phrase that deploys or verifies>
+
+<...>
+
+## Next steps
+
+- [Title](/path/) - one sentence on why the reader would follow it.
+- [Title](/path/) - one sentence on why the reader would follow it.
+```
+
+## Rules
+
+- **Keep the contract.** You choose every option: no branching, no "depending on your needs". Every step shows a visible result, and you have run every command.
+- **No `<Tabs>`.** Tabs are a branch, and tutorials do not branch. A task that genuinely needs three interfaces is a [how-to guide](/en/documentation/style-guide/content/how-to-guides/).
+- **Do not explain.** One sentence and a link when a concept is genuinely required. Keep asides rare.
+- **Make every screenshot earn its place.** One image for a result words cannot show, never a shot of every screen the reader passes.
+- **Link out for third-party products.** Name the vendor's step; do not document their interface.
+- **Give every code block a colon lead-in.** "Install the CLI:" then the command. Use `<Code>` for anything the reader copies.
+- **Show the output after every command.** The reader sees what success looks like before the next step depends on it. The rule is in [Procedures](/en/documentation/style-guide/writing/procedures/).
+- **Keep tutorials scarce.** One per product area. Tutorials are expensive to keep working.
+- **Link the how-tos and concepts the tutorial touched in `## Next steps`.** Give each link its reason.
+
+## Examples
+
+This excerpt builds a user list API. It shows the opening move, the prerequisites, and the first stage:
+
+```mdx
+In this tutorial, you will build a user list API with **Functions** and **SQL Database**. You will create a database, seed a `users` table, create a function, and route requests to it.
+
+## Prerequisites
+
+- An Azion account with a configured personal token
+- An application with a domain in the format `<id>.map.azionedge.net`
+
+---
+
+## 1. Create the database
+
+To create the database, send a `POST` request to the databases endpoint:
+
+<Code lang="bash" code={`curl --location 'https://api.azion.com/v4/edge_sql/databases' \\
+--header 'Authorization: Token [TOKEN VALUE]' \\
+--header 'Content-Type: application/json' \\
+--data '{"name": "mydatabase"}'`} />
+
+The response returns `"state": "pending"` and `"status": "creating"`. Database creation is asynchronous.
+
+To check the creation status, send `GET` requests to the same endpoint until `status` is `created`:
+
+<Code lang="bash" code={`curl --location 'https://api.azion.com/v4/edge_sql/databases' \\
+--header 'Authorization: Token [TOKEN VALUE]'`} />
+
+The database is ready when `status` is `created`.
+```
+
+## Related
+
+- [Quickstart pages](/en/documentation/style-guide/content/quickstart/): the tutorial whose goal is first activation.
+- [How-to guides](/en/documentation/style-guide/content/how-to-guides/): the page for the reader who arrived with a task.
+- [Choose a content type](/en/documentation/style-guide/content/choose-a-content-type/): the router.

--- a/src/content/docs/en/pages/style-guide/content/use-cases.mdx
+++ b/src/content/docs/en/pages/style-guide/content/use-cases.mdx
@@ -9,6 +9,9 @@ namespace: documentation_style_guide_use_cases
 permalink: /documentation/style-guide/content/use-cases/
 menu_namespace: styleGuideMenu
 ---
+import FrameBox from '@aziontech/webkit/frame-box'
+import ItemList from '@aziontech/webkit/item-list'
+import DocItem from '@aziontech/webkit/doc-item'
 
 ## Purpose
 
@@ -56,7 +59,7 @@ Procedural: 20 words per sentence, one instruction per step, imperative and acti
 - **Verification**: a `## Verify the setup` section with one check per requirement and its expected result.
 - **Measuring results**: a `## Measuring results` section naming the metrics that show the setup working, and where to read each one.
 - **Best practices**: a `## Best practices` section holding the recommendations and the reasoning behind each.
-- **Next steps**: a `## Next steps` closing with bulleted links shaped `[Title](/path/) - reason`.
+- **Next steps**: a `## Next steps` closing, a `DocCardGroup` with one card per destination: the title, the link, and the reason as the card copy.
 
 **Optional components**
 
@@ -74,7 +77,10 @@ The bound that keeps a use case honest is the four-section cap on `## Configure`
 
 Copy the template and replace each `<placeholder>`:
 
-````md
+````mdx
+import DocCardGroup from '@aziontech/webkit/doc-card-group'
+import DocCard from '@aziontech/webkit/doc-card'
+
 <Scenario. Three to five sentences: what the team has, what it
 needs, and what this page sets up.>
 
@@ -152,7 +158,9 @@ To <reach the result of this stage>:
 
 ## Next steps
 
-- [<Title>](/path/) - <why the reader would follow it>
+<DocCardGroup cols={2}>
+  <DocCard title="<Title>" href="/path/" label="<why the reader would follow it>" />
+</DocCardGroup>
 ````
 
 ## Rules
@@ -194,8 +202,12 @@ Each row names a business requirement, translates it into a technical need, and 
 
 ## Related
 
-- [Multi-product guides](/en/documentation/style-guide/content/multi-product-guides/): the same base form, without the business frame.
-- [Architecture pages](/en/documentation/style-guide/content/architecture/): the kind to write when there is nothing to configure.
-- [How-to guides](/en/documentation/style-guide/content/how-to-guides/): the kind to write when the setup is one task.
-- [Information architecture](/en/documentation/style-guide/content/information-architecture/): where use cases sit, and why they live outside a product.
-- [Choose a content type](/en/documentation/style-guide/content/choose-a-content-type/): the full catalogue of page kinds.
+<FrameBox>
+<ItemList>
+  <DocItem title="Multi-product guides" href="/en/documentation/style-guide/content/multi-product-guides/">The same base form, without the business frame.</DocItem>
+  <DocItem title="Architecture pages" href="/en/documentation/style-guide/content/architecture/">The kind to write when there is nothing to configure.</DocItem>
+  <DocItem title="How-to guides" href="/en/documentation/style-guide/content/how-to-guides/">The kind to write when the setup is one task.</DocItem>
+  <DocItem title="Information architecture" href="/en/documentation/style-guide/content/information-architecture/">Where use cases sit, and why they live outside a product.</DocItem>
+  <DocItem title="Choose a content type" href="/en/documentation/style-guide/content/choose-a-content-type/">The full catalogue of page kinds.</DocItem>
+</ItemList>
+</FrameBox>

--- a/src/content/docs/en/pages/style-guide/content/use-cases.mdx
+++ b/src/content/docs/en/pages/style-guide/content/use-cases.mdx
@@ -1,0 +1,201 @@
+---
+title: Use cases
+description: >-
+  Write a use-case page: a business scenario turned into an executable
+  specification, with required products, an architecture, and measurable
+  results.
+meta_tags: 'style guide, use cases, guides, spec driven documentation'
+namespace: documentation_style_guide_use_cases
+permalink: /documentation/style-guide/content/use-cases/
+menu_namespace: styleGuideMenu
+---
+
+## Purpose
+
+A use-case page turns a business scenario into a setup someone can build and verify. The reader arrives with a situation, not a task: a storefront that slows down during a sale, a live event that has to reach one more region.
+
+A use case is a specification, not an article. It carries everything an implementer needs in one page: the products the scenario requires, the architecture, the configuration, the checks, and the metrics that show it working. That implementer is often an agent, so the page is written to be executed rather than read.
+
+Use cases live in the Guides section, never inside one product.
+
+## When to use
+
+**Recognize a use case by:**
+
+- A reader who arrived with a business situation rather than a task.
+- A requirements table mapping each business need to the product that meets it.
+- An outcome that stays measurable after the setup works.
+- A specification complete enough for an agent to execute without asking a question.
+
+**It is still a use case when:**
+
+- It configures four things or fewer. More than four means it is two use cases.
+- It links the generic procedure instead of repeating it here.
+- It ships without a demo, because none exists. Never describe a demo that does not run.
+
+**Write something else when:**
+
+- There is nothing to configure. The page explains a design, so write an [architecture page](/en/documentation/style-guide/content/architecture/).
+- The setup is a single task. That is a [how-to guide](/en/documentation/style-guide/content/how-to-guides/).
+- The goal is technical and needs no business framing. That is a [multi-product guide](/en/documentation/style-guide/content/multi-product-guides/).
+- The reader has no scenario, only the product. That is a [tutorial](/en/documentation/style-guide/content/tutorials/).
+
+## Register
+
+Procedural: 20 words per sentence, one instruction per step, imperative and active. Tone: precise, plain, businesslike, sober. [Sentence structure](/en/documentation/style-guide/writing/sentence-structure/) holds the rules.
+
+## Structure
+
+**Required components**
+
+- **Scenario**: three to five sentences naming what the team has, what it needs, and what this page sets up. Followed by one line stating what the use case does not cover.
+- **Prerequisites**: a `## Prerequisites` section, each item a link or a one-line command where one exists.
+- **Required products**: the requirements table. One row per requirement, naming the technical need, the product that meets it, and the page that documents it.
+- **Reference architecture**: a `## Reference architecture` section holding a `mermaid` diagram and a numbered `### Dataflow` beneath it.
+- **Configuration**: one `## Configure <thing>` section per requirement, four at most, each holding a procedure that ends with its outcome sentence.
+- **Verification**: a `## Verify the setup` section with one check per requirement and its expected result.
+- **Measuring results**: a `## Measuring results` section naming the metrics that show the setup working, and where to read each one.
+- **Best practices**: a `## Best practices` section holding the recommendations and the reasoning behind each.
+- **Next steps**: a `## Next steps` closing with bulleted links shaped `[Title](/path/) - reason`.
+
+**Optional components**
+
+- **Demo**: a `## Demo` section linking a running example, a template, or a repository. Omit it when none exists; never describe a demo that does not run.
+
+The sections keep this order. What governs the page is proportion, not length. A use case runs longer than other kinds by design: it is a specification, and an implementer working from it cannot fill a gap by asking. The page's weight belongs in the sections an implementer executes:
+
+- **The configuration sections carry the page.** Four at most, and together they are the largest part of it. If they are not, the page is describing a scenario rather than building one.
+- **Scenario, prerequisites, demo, and next steps stay brief.** Each orients and hands off. A scenario that runs past a couple of paragraphs is selling.
+- **Reference architecture, verification, measurement, and best practices sit between the two.** Each carries real content — a diagram, a check that runs, a signal to watch — and none of them is a place to expand.
+
+The bound that keeps a use case honest is the four-section cap on `## Configure`, not a length. Compression is never the fix, because what gets compressed is the diagram, the command output, and the concrete value — the parts an implementer cannot proceed without.
+
+## Template
+
+Copy the template and replace each `<placeholder>`:
+
+````md
+<Scenario. Three to five sentences: what the team has, what it
+needs, and what this page sets up.>
+
+<One line naming what this use case does not cover.>
+
+## Prerequisites
+
+- <A link or a one-line command where one exists>
+
+---
+
+## Required products
+
+| Requirement | Technical need | Product | Documented at |
+| --- | --- | --- | --- |
+| <What the scenario requires> | <What that needs technically> | <Product> | [<Page>](/path/) |
+
+---
+
+## Reference architecture
+
+```mermaid
+flowchart LR
+  <the design, as text an agent can read>
+```
+
+### Dataflow
+
+1. <What arrives first, and where it goes.>
+2. <What the platform does with it.>
+3. <Where the flow ends.>
+
+---
+
+## Configure <the first specific thing>
+
+To <reach the result of this stage>:
+
+1. <One imperative instruction.>
+2. <One imperative instruction.>
+
+<The outcome: what the reader now has.>
+
+## Configure <the next specific thing>
+
+<...>
+
+---
+
+## Verify the setup
+
+- <One check per requirement, with the result the reader should see.>
+
+---
+
+## Demo
+
+- [<Running example or template>](/path/) - <what it demonstrates>.
+
+---
+
+## Measuring results
+
+| Metric | Where to read it | What working looks like |
+| --- | --- | --- |
+| <Metric> | <Dashboard, query, or header> | <The expected direction or range> |
+
+---
+
+## Best practices
+
+- **<Recommendation>**: <what it does, and the reason behind it>.
+
+---
+
+## Next steps
+
+- [<Title>](/path/) - <why the reader would follow it>
+````
+
+## Rules
+
+- **Write a specification, not an article.** Every value is concrete, every command runs, and no step says "depending on your setup". The reader may be an agent, and an agent cannot resolve an ambiguity by asking.
+- **Show the output after every command.** The reader sees what success looks like before the next step depends on it. The rule is in [Procedures](/en/documentation/style-guide/writing/procedures/).
+- **Narrow the scenario to one buildable setup.** State it as `A <team> that <has this> configures <this setup> so that <this checkable outcome>.` If the sentence needs an "and also", it is two use cases.
+- **Start from the requirements table.** Every row is a requirement you have confirmed against the product. A requirement you cannot confirm does not go in the table.
+- **Inline what is specific to this use case. Link what is true for every use case.** The generic path is a link; the page holds what the scenario changes.
+- **Cap the configuration at four sections.** More than four means the use case is too wide. Split it rather than raise the cap.
+- **Diagram in `mermaid`.** The diagram is text so that an agent reading the markdown twin gets the design, not an image reference. The numbered dataflow still carries the meaning: the diagram never stands alone.
+- **Separate verification from measurement.** Verification is a one-time check that the setup is correct. Measurement is the ongoing signal that it still works.
+- **Keep best practices as recommendations with reasons.** A recommendation without its reason is an instruction in the wrong section, and it belongs in the procedure.
+- **Never make a commercial claim.** No cost saving, no percentage, no competitor, no customer name, and no assertion that a configuration makes anyone compliant.
+- **Example figures are not limits.** A figure that frames the scenario stays in the scenario paragraph and appears nowhere else.
+- **Never invent a product name, a field, or a value.** Take product names from [Documentation terminology](/en/documentation/style-guide/writing/terminology/), and fields and values from the product, not from a URL or a directory path.
+
+## Examples
+
+This excerpt of a use case for an e-commerce storefront shows the scenario, the not-covered line, and the requirements table:
+
+```mdx
+A retail team runs a storefront on Azion and expects heavy traffic during a seasonal sale. The catalogue pages are identical for every visitor, the cart is personal, and the checkout accepts a limited number of requests per customer. This page configures caching for the catalogue, a cache bypass for the cart, and a rate limit on checkout.
+
+This use case does not cover payment processing or inventory synchronization.
+
+---
+
+## Required products
+
+| Requirement | Technical need | Product | Documented at |
+| --- | --- | --- | --- |
+| Catalogue pages served fast under load | Cache identical responses on Azion's distributed network | Applications | [Cache settings](/en/documentation/build/cache/reference/cache-settings/) |
+| Cart stays personal | Bypass cache for authenticated paths | Applications | [Rules Engine](/en/documentation/build/applications/reference/rules-engine/) |
+| Checkout resists abuse | Rate limit by client identity | Firewall | [Rules Engine for Firewall](/en/documentation/secure/firewall/reference/rules-engine/) |
+```
+
+Each row names a business requirement, translates it into a technical need, and points at the page that documents it. The reader can check every claim before running a single step.
+
+## Related
+
+- [Multi-product guides](/en/documentation/style-guide/content/multi-product-guides/): the same base form, without the business frame.
+- [Architecture pages](/en/documentation/style-guide/content/architecture/): the kind to write when there is nothing to configure.
+- [How-to guides](/en/documentation/style-guide/content/how-to-guides/): the kind to write when the setup is one task.
+- [Information architecture](/en/documentation/style-guide/content/information-architecture/): where use cases sit, and why they live outside a product.
+- [Choose a content type](/en/documentation/style-guide/content/choose-a-content-type/): the full catalogue of page kinds.

--- a/src/content/docs/en/pages/style-guide/conventions/bilingual.mdx
+++ b/src/content/docs/en/pages/style-guide/conventions/bilingual.mdx
@@ -1,0 +1,99 @@
+---
+title: Bilingual pages
+description: >-
+  Pair the English and Portuguese versions of a page by namespace, with
+  localized permalinks, language-prefixed links, and the translation rules.
+meta_tags: 'style guide, bilingual, translation, portuguese'
+namespace: documentation_style_guide_bilingual
+permalink: /documentation/style-guide/conventions/bilingual/
+menu_namespace: styleGuideMenu
+---
+
+## Write every page twice
+
+The documentation publishes every page in English and in Brazilian Portuguese. English is the source of truth. Write the Portuguese page on top of the finished English page, not in parallel with it. The structure of the Portuguese page follows the English page, and a change to the English page creates matching work on the Portuguese page.
+
+To write or update a Portuguese page, open the English page first. If the English page does not exist, write it first: a Portuguese page written first has no source, and the English page that follows becomes a translation of a translation.
+
+## Pair the versions by namespace
+
+The site pairs the two versions of a page by their `namespace` field, not by file path. The language switcher depends on this pairing. Both files carry the same value, character for character:
+
+```
+en:     title:     Create an Object Storage bucket
+        permalink: /documentation/products/store/storage/create-bucket/
+        namespace: docs_store_storage_create_bucket
+
+pt-br:  title:     Criar um bucket do Object Storage
+        permalink: /documentacao/produtos/store/storage/criar-bucket/
+        namespace: docs_store_storage_create_bucket
+```
+
+Each frontmatter field follows one of three rules on the Portuguese page:
+
+| Field | Portuguese page |
+| --- | --- |
+| `title` | translated |
+| `description` | translated |
+| `permalink` | translated |
+| `namespace` | identical to English |
+| `menu_namespace` | identical to English |
+| `meta_tags` | conventionally left in English |
+
+A mismatched namespace breaks the language switcher, and the build passes anyway. Nothing warns you, so check the value character for character before the page ships. The rules for each field are in [Frontmatter](/en/documentation/style-guide/conventions/frontmatter/).
+
+## Localize directories and permalinks
+
+Localize directory names and filenames; do not copy the English tree. `guides/` becomes `guias/`, and `create-bucket.mdx` becomes `criar-bucket.mdx`. Permalinks follow the same rule: `/documentation/products/...` becomes `/documentacao/produtos/...`.
+
+Permalinks stay ASCII in both languages. Fold accents instead of encoding them: `configuracao`, not `configuração`.
+
+## Link with the right language prefix
+
+Internal links are absolute, start with a language prefix, and end with a slash. The same link changes only its prefix between the two versions:
+
+```
+English page:    [Applications](/en/documentation/build/applications/)
+Portuguese page: [Applications](/pt-br/documentacao/build/applications/)
+```
+
+A Portuguese page links to an English page only when no Portuguese translation exists. Never send the reader to English when a Portuguese page exists.
+
+## Write English that survives translation
+
+The English page sets the translator's task. A short sentence translates one to one. A 45-word sentence with three subordinate clauses forces the translator to restructure it, and restructuring is where meaning drifts.
+
+The structural rules in [Sentence structure](/en/documentation/style-guide/writing/sentence-structure/) carry over to Portuguese unchanged. Sentence caps, one instruction per step, simple tenses, active voice, and short noun clusters all transfer. The vocabulary rules do not carry over; the Portuguese vocabulary lives in [Documentation terminology](/en/documentation/style-guide/writing/terminology/).
+
+## Apply the translation rules
+
+Five rules cover most of the work on a Portuguese page:
+
+- Do not translate generic technical terms: `data center`, `serverless`, `template`, `compliance`, `on-premise`. The strings `edge` and `edge computing` stay untranslated where they already appear, but new text does not introduce them.
+- Do not translate product names: **Applications**, **Functions**, **Firewall**, **Azion Platform**, **Azion Marketplace**.
+- Apply the substitutions: `aplicação`, not `aplicativo`; `rede distribuída`, not `borda`; `performance`, not `desempenho`.
+- Write titles in sentence case: capitalize the first word and proper nouns only.
+- Localize aside labels: `:::note[nota]`, `:::tip[dica]`, `:::caution[Atenção]`. An English label on a Portuguese page is a visible defect.
+
+The full stay-in-English list is in [Documentation terminology](/en/documentation/style-guide/writing/terminology/).
+
+## Use the fixed Portuguese forms
+
+Three recurring elements translate the same way on every page. Do not improvise a new form for them.
+
+Three section names have fixed Portuguese forms:
+
+- `## Prerequisites` becomes `## Pré-requisitos`.
+- `## Next steps` becomes `## Próximos passos`.
+- `## Related resources` becomes `## Recursos relacionados`.
+
+The standard link sentences have fixed forms, and the verb is `consulte`:
+
+- `Para mais informações, consulte [Título](/pt-br/.../).`
+- `Para <fazer algo>, consulte [Título](/pt-br/.../).`
+
+Console UI labels stay as the interface shows them. Do not translate button or field names the Console renders in English: **Save**, **Workloads Access**, **+ Bucket**.
+
+## Review every translation
+
+Never ship a machine translation without review. A wrong translation is harder to find and fix than a missing one, because the page looks complete. Use machine translation for a first draft only, and review the draft before it ships.

--- a/src/content/docs/en/pages/style-guide/conventions/frontmatter.mdx
+++ b/src/content/docs/en/pages/style-guide/conventions/frontmatter.mdx
@@ -1,0 +1,75 @@
+---
+title: Frontmatter
+description: >-
+  Set the five frontmatter fields on every documentation page — title,
+  description, meta_tags, namespace, and permalink — under the rules for each
+  one.
+meta_tags: 'style guide, frontmatter, namespace, permalink'
+namespace: documentation_style_guide_frontmatter
+permalink: /documentation/style-guide/conventions/frontmatter/
+menu_namespace: styleGuideMenu
+---
+
+## Start from the template
+
+Every documentation page opens with a frontmatter block. The writer sets five fields:
+
+```yaml
+---
+title: Create an Object Storage bucket
+description: >-
+  Create a read-only Object Storage bucket and grant read-write
+  permissions from the Azion API, the CLI, or Azion Console.
+meta_tags: 'Object Storage, bucket, permissions, edge storage, create bucket'
+namespace: docs_store_storage_create_bucket
+permalink: /documentation/products/store/storage/create-bucket/
+---
+```
+
+The `title` renders as the page's H1. The body therefore starts at a `##` heading, never at `#`. Write the title in sentence case, as [Documentation terminology](/en/documentation/style-guide/writing/terminology/) defines.
+
+A validator runs inside every build. It stops the build when a `namespace` or a `permalink` is absent, malformed, or appears twice in the same language. The validator does not read the other fields, so their quality depends on the writer.
+
+## Set the namespace
+
+The `namespace` identifies the page across the site. It is also the join key between languages: the English page and its Portuguese translation carry the same value, character for character. [Bilingual pages](/en/documentation/style-guide/conventions/bilingual/) describes the pairing in full.
+
+Two rules apply:
+
+- Keep the value unique within its language. A duplicate stops the build.
+- Keep the value identical across the language pair. A mismatch breaks the language switcher, and the build still passes.
+
+The second rule has no safety net. The switcher silently loses the connection between the two pages, so check the value by hand.
+
+Write the value in lowercase words joined by underscores. Build it from the product and the feature: `docs_store_storage_create_bucket`.
+
+## Set the permalink
+
+The `permalink` is the page URL without the language segment. The permalink alone sets the URL; the file path does not.
+
+- Do not add a language prefix. The directory tree provides it: a file in the English tree publishes at `/en/` plus the permalink. A permalink that starts with `/en/` publishes the page at `/en/en/...`.
+- Use lowercase ASCII letters, digits, hyphens, and slashes only, and end with a slash: `/documentation/products/store/storage/create-bucket/`.
+- Keep the permalink unique within its language. The English page and its Portuguese page have different permalinks, so the pair never collides.
+- Fold accents out of Portuguese permalinks: `configuracao`, not `configuração`.
+- Name the URL for the page's subject, never for its current sidebar position. Moving a file does not change the URL, so a permalink chosen for the subject survives every reorganization.
+- Changing a permalink changes the URL, and the old URL then needs a redirect entry in the same change.
+
+## Write the description and meta tags
+
+The `description` becomes the page's meta description. The `meta_tags` value becomes its keywords, as a comma-separated list inside quotes.
+
+No check validates either field, so an empty one ships silently. Write both on every page.
+
+Write the description as one or two self-contained sentences, 50 to 160 characters long. Start with an imperative verb and state what the reader accomplishes on the page. Do not restate the title word for word. The rules in [Sentence structure](/en/documentation/style-guide/writing/sentence-structure/) apply to the description.
+
+Four openers are banned: `This page describes...`, `This document explains...`, `Learn more about...`, and `Learn how to...`. Start with the bare verb instead. A generic opener spends the description on framing instead of information.
+
+## Place the page in a sidebar
+
+The optional `menu_namespace` field names the sidebar that lists the page. Without the field, the page uses the default menu. Set the field when the page belongs to a section with its own sidebar, and give both languages the same value.
+
+The field also settles ownership: every page belongs to exactly one section. A section can list a page that another section owns, and that row is a cross-link rather than a claim. Keep ownership with the section where the page's neighbors live.
+
+## Omit the type field
+
+The frontmatter accepts an optional `type` field that switches a page to a special layout, such as a card-grid home. Documentation pages omit it. A page without the field uses the default layout, which is the right one for documentation content.

--- a/src/content/docs/en/pages/style-guide/formatting/code.mdx
+++ b/src/content/docs/en/pages/style-guide/formatting/code.mdx
@@ -1,0 +1,60 @@
+---
+title: Code
+description: >-
+  Run every command before it ships, keep placeholders that cannot be mistaken
+  for real values, and keep credentials out of code blocks.
+meta_tags: 'style guide, code blocks, placeholders'
+namespace: documentation_style_guide_code
+permalink: /documentation/style-guide/formatting/code/
+menu_namespace: styleGuideMenu
+---
+
+## Run every command before you publish it
+
+An untested code block is a guess that looks authoritative. Prose signals uncertainty with words; a code block signals nothing, so the reader executes it with full trust. On the page, a guessed command is identical to a tested one. The difference appears when the command fails, on the reader's machine.
+
+Run every command and every snippet before the page ships. When you cannot run one, do not publish it. A page that states less, and is right about all of it, beats a page that guesses.
+
+## Compose, do not invent
+
+A code block mixes two kinds of content: the facts it carries and the syntax that expresses them. Tool syntax needed to express a sourced fact — `curl` flags, a `Content-Type` header carrying a given JSON body, shell quoting — is composition, not invention. A new product value, field, endpoint, or default is invention.
+
+For the rule that every specific traces to a source, refer to [Word choice](/en/documentation/style-guide/writing/word-choice/).
+
+## Make placeholders obvious and consistent
+
+A placeholder has one job: the reader must see at a glance that the value is theirs to replace. Two formats do that job: brackets with capitals, `[TOKEN VALUE]`, and angle brackets with lowercase words, `<your-bucket-name>`. Use one format for every placeholder on a page; three conventions on one page teach the reader none.
+
+Each kind of value has a reserved form:
+
+| Kind of value | Form |
+| --- | --- |
+| Secret or token | `[TOKEN VALUE]` |
+| Reader-supplied name or value | `<your-bucket-name>`, `<your-azion-domain>` |
+| Example domain | `example.com`, `example.org` |
+| Example IP range | `192.0.2.0/24`, `198.51.100.0/24`, `203.0.113.0/24` |
+
+The IP ranges are reserved for documentation and route nowhere.
+
+- Incorrect: `--token abc123`
+- Correct: `--token [TOKEN VALUE]`
+
+`abc123` reads as a value that might work, and a reader in a hurry pastes it unchanged. `[TOKEN VALUE]` cannot pass for a real value. The worst placeholder is a realistic fake, because it hides that there is anything to replace.
+
+## Introduce every code block
+
+One sentence before the block states what the code does. A bare code block is a snippet the reader must reverse-engineer before deciding whether to run it.
+
+## Leave the prompt out of copyable input
+
+No `$` or `>` before a command. The reader pastes the line, prompt included, and the command fails. A prompt belongs only in output shown in a fence, where it reproduces a real session.
+
+## Write comments as prose
+
+A comment inside a snippet follows the page's language and the sentence rules, and says why, not what. A comment that restates the line under it adds nothing.
+
+## Keep credentials out of code blocks
+
+No real credential appears in documentation: not a live one, not an expired one, not a revoked one. On the page, an expired credential is indistinguishable from a live one, so the ban covers them all equally. A fabricated value with a realistic shape is banned for the same reason: no reader, and no scanner, can tell it from a leak. Write the placeholder instead: `[TOKEN VALUE]`.
+
+This section shows no incorrect example. A realistic fake credential in a style guide is still a realistic fake credential in public documentation.

--- a/src/content/docs/en/pages/style-guide/formatting/headings.mdx
+++ b/src/content/docs/en/pages/style-guide/formatting/headings.mdx
@@ -1,0 +1,69 @@
+---
+title: Headings
+description: >-
+  Write headings in sentence case, with imperative verbs instead of gerunds,
+  correct levels, and phrasing that works as a search query.
+meta_tags: 'style guide, headings'
+namespace: documentation_style_guide_headings
+permalink: /documentation/style-guide/formatting/headings/
+menu_namespace: styleGuideMenu
+---
+
+## Use sentence case
+
+Capitalize the first word and proper nouns only.
+
+- Incorrect: `Configure Cache Policies`
+- Correct: `Configure cache policies`
+
+Title case forces a capitalization decision on every word, and those decisions drift across pages. Sentence case removes the decisions, so headings stay consistent in both languages.
+
+A product name keeps its capitals in any position, because it is a proper noun.
+
+## Lead with an imperative verb
+
+A heading that names a task starts with the bare verb, never with a gerund.
+
+- Incorrect: `Creating a bucket`
+- Correct: `Create a bucket`
+
+Three reasons support the rule:
+
+- Gerunds translate inconsistently as the first word of a heading. Google's developer style guide bans them for that reason, and this documentation publishes every page in two languages.
+- The heading lands in the same register as the steps under it, which [Sentence structure](/en/documentation/style-guide/writing/sentence-structure/) defines as imperative. The reader scans one voice, not two.
+
+Two `-ing` forms stay correct. A word in `-ing` that names a thing is a noun, so `Getting started` and `Billing` stay. A word in `-ing` later in the heading is also fine: `Introduction to request logging`.
+
+## Start the body at `##`
+
+The `title` field in the frontmatter renders as the page's only H1. The body starts at `##`, so a `#` heading in the body creates a second H1 and breaks the page outline.
+
+## Do not skip levels
+
+Heading levels advance one step at a time: `###` under `##`, and `####` under `###`. A jump from `##` to `####` implies a level that does not exist, and readers and tools lose the structure.
+
+## Name the thing, not the section
+
+A heading labels the content, not its position on the page. `Limits` says what the section holds. `Step 1` says only where the section sits, and it says nothing when the section appears alone.
+
+| Incorrect | Correct |
+| --- | --- |
+| `Step 1` | `Create a bucket` |
+| `Some important limits to keep in mind` | `Limits` |
+
+## Write headings that work as search queries
+
+A retrieval system returns one section of a page, not the whole page. The heading tells the system and the reader what the section answers. `Configure cache TTL` retrieves, because it matches what a person with that task types. `Configuration` matches almost anything, so it retrieves nothing in particular.
+
+- Incorrect: `Configuration`
+- Correct: `Configure cache TTL`
+
+## Use an acronym in a heading only when the page expands it
+
+A heading may carry a well-established acronym, as long as the first line below it spells the term out. `Configure WAF rule sets` is a valid heading when the paragraph under it writes `Web Application Firewall (WAF)`.
+
+[Word choice](/en/documentation/style-guide/writing/word-choice/) holds the expansion rule for the rest of the page.
+
+## Keep emojis out of titles
+
+No emojis in titles, headings, or sidebar labels. Emojis break search indexing, read poorly in screen readers, and render inconsistently across platforms.

--- a/src/content/docs/en/pages/style-guide/formatting/images.mdx
+++ b/src/content/docs/en/pages/style-guide/formatting/images.mdx
@@ -1,0 +1,38 @@
+---
+title: Images
+description: >-
+  Add a screenshot only when it earns its place, keep sensitive data out of
+  it, and give every image its alt text.
+meta_tags: 'style guide, images, screenshots, alt text'
+namespace: documentation_style_guide_images
+permalink: /documentation/style-guide/formatting/images/
+menu_namespace: styleGuideMenu
+---
+
+## Use a screenshot only when words failed
+
+Every screenshot is a maintenance cost. The interface changes without notice, the page goes stale silently, and a stale screenshot misleads with full confidence. Add one only when the words alone did not carry the instruction.
+
+The test: if the sentence names the control and the action clearly, the screenshot repeats it. Delete the screenshot, keep the sentence.
+
+## Keep sensitive information out
+
+A screenshot never shows real account data: names, e-mails, tokens, domains, or identifiers. Capture a test account, or mask the values before publishing. A leaked value in an image is as public as a leaked value in text, and harder to find later.
+
+## Crop to the relevant area
+
+Capture the part of the interface the instruction points at, not the full screen. Volatile interface chrome — menus, avatars, version banners — dates the image and distracts from the control that matters.
+
+## Write alt text for every image
+
+Alt text states what the image conveys, in one sentence. The rules are in [Accessibility](/en/documentation/style-guide/writing/accessibility/).
+
+## Format the asset path
+
+Asset paths are root-absolute with no language prefix, because one image serves both language versions:
+
+- Correct: `/assets/docs/images/uploads/diagram.png`
+
+## Historical records are exempt
+
+Screenshots in changelogs and release notes record what the interface looked like at that date. They are point-in-time records: do not update them when the interface changes.

--- a/src/content/docs/en/pages/style-guide/formatting/numbers.mdx
+++ b/src/content/docs/en/pages/style-guide/formatting/numbers.mdx
@@ -1,0 +1,73 @@
+---
+title: Numbers and units
+description: >-
+  Write numbers the same way on every page: when to spell them out,
+  separators, units of measure, dates, times, and currency.
+meta_tags: 'style guide, numbers, units, dates, measurements'
+namespace: documentation_style_guide_numbers
+permalink: /documentation/style-guide/formatting/numbers/
+menu_namespace: styleGuideMenu
+---
+
+## Spell out zero through nine
+
+Write `zero` through `nine` as words, and `10` upward as numerals.
+
+- Correct: `Create three rules.`
+- Correct: `The account allows 100 buckets.`
+
+Three cases take a numeral whatever the value: a measurement, a version, and anything the reader types or reads on screen. `Set the TTL to 5 seconds`, not `five seconds`.
+
+## Use a period for decimals and a comma for thousands
+
+| Rule | Example |
+| --- | --- |
+| Period for the decimal separator | `9.5`, `3.14159` |
+| Comma for thousands | `10,000`, `25,456,990` |
+| A leading zero below one | `0.5`, never `.5` |
+
+Portuguese reverses both separators. A translated page writes `10.000` and `9,5`, so a number copied across a pair without conversion is wrong in one of them.
+
+## Write a unit with its number
+
+- Put a space between the numeral and the unit: `20 MB`, `60 seconds`.
+- Hyphenate when the measurement modifies a noun: `a 60-second TTL`.
+- Abbreviate only next to a number, and never follow the abbreviation with a period: `20 MB`, not `20 MB.` or `twenty MB`.
+
+Every value in a table carries its unit. A cell holding `100` leaves the reader choosing between megabytes, seconds, and requests. [Reference](/en/documentation/style-guide/content/reference/) treats a limit without a unit as an incomplete fact.
+
+`MB` and `MiB` are different numbers. Write the unit the product states and never convert between decimal (`kB`, `MB`, `GB`) and binary (`KiB`, `MiB`, `GiB`) forms. The same applies to rates: `Gbps` counts bits and `MB/s` counts bytes, eight times apart, so keep the form the product uses.
+
+A limit is exact and is never rounded. Round only an illustrative figure, and mark it: `about 200 ms`.
+
+## Use an en dash for a negative number
+
+Write `–40` with an en dash, not a hyphen. The rule applies to prose: in code, commands, and any value the reader copies, keep the ASCII hyphen-minus — a pasted `–40` does not parse. [Punctuation](/en/documentation/style-guide/formatting/punctuation/) covers the other dash rules.
+
+## Write an ordinal without a suffix beyond the number
+
+Write `first` and `second` as words. In a numeral, write `1st`, never `1stly` or `firstly`.
+
+## Format a date only where a date belongs
+
+Dates appear in changelogs and nowhere else, which [Word choice](/en/documentation/style-guide/writing/word-choice/) states as a rule. A date anywhere else ages the page.
+
+Where a date is allowed, spell the month out and order it month, day, year: `July 10, 2026`.
+
+- Incorrect: `7/10/2026`
+- Incorrect: `July 10th, 2026`
+- Correct: `July 10, 2026`
+
+A numeric date reads as month-first in the United States and day-first almost everywhere else, so it means two things at once.
+
+## Write a time in the 24-hour clock or with AM and PM
+
+Capitalize `AM` and `PM` and put a space before them: `10:45 AM`. Portuguese pages use the 24-hour clock: `10:45`, `18:30`.
+
+Do not write `24/7`. Write `at all times` or name the actual availability.
+
+## Format currency only on the pricing page
+
+A price, a quota sold by the unit, and a billing metric live on the pricing page alone. [Reference](/en/documentation/style-guide/content/reference/) forbids restating one on a product page.
+
+Where an amount is allowed, the symbol precedes the number with no space: `$1,000`.

--- a/src/content/docs/en/pages/style-guide/formatting/punctuation.mdx
+++ b/src/content/docs/en/pages/style-guide/formatting/punctuation.mdx
@@ -1,0 +1,100 @@
+---
+title: Punctuation
+description: >-
+  Punctuate Azion documentation: the Oxford comma, dashes and hyphens, heading
+  and list punctuation, spacing, and the symbols to avoid.
+meta_tags: 'style guide, punctuation, commas, dashes, hyphens'
+namespace: documentation_style_guide_punctuation
+permalink: /documentation/style-guide/formatting/punctuation/
+menu_namespace: styleGuideMenu
+---
+
+## Use the Oxford comma
+
+In a list of three or more items, put a comma before the conjunction.
+
+- Incorrect: `Applications, Firewall and Edge DNS`
+- Correct: `Applications, Firewall, and Edge DNS`
+
+The last comma removes an ambiguity that the reader would otherwise have to resolve. Without it, the final two items can read as a pair.
+
+Portuguese takes the opposite convention: in a simple enumeration, no comma goes before `e`.
+
+## Prefer a period to an em dash
+
+An em dash replaces a period, a colon, or a comma, and one of those three is almost always clearer. Reach for them first.
+
+- Before: `The cache answers the request—the origin never sees it.`
+- After: `The cache answers the request. The origin never sees it.`
+
+When a dash is genuinely the right mark, write it with no space on either side.
+
+Dashes used for emphasis are the pattern to avoid, and [Word choice](/en/documentation/style-guide/writing/word-choice/) covers that family in full. This is a rule for writing, not a defect for review: nobody flags a single em dash.
+
+## Use an en dash for a range
+
+An en dash joins the ends of a range of time or quantity, with no space on either side.
+
+- Incorrect: `50 - 70%`
+- Correct: `50–70%`
+
+Write the range with words when a preposition already opened it: `from 50% to 70%`, never `from 50–70%`.
+
+## Hyphenate a compound modifier
+
+Two words that modify a noun together take a hyphen, with no spaces.
+
+| Incorrect | Correct |
+| --- | --- |
+| `real time logging` | `real-time logging` |
+| `read only bucket` | `read-only bucket` |
+
+The hyphen disappears when the words are not modifying a noun: `the bucket is read only`.
+
+Do not hyphenate a word that starts with `auto`, such as `autoscale` and `autodial`, unless the unhyphenated form is genuinely unclear.
+
+## Do not use ellipses or exclamation points
+
+An ellipsis asks the reader to supply the rest of the thought. Documentation states the thought.
+
+An exclamation point adds volume, not information. It also reads as promotional, which [Documentation voice](/en/documentation/style-guide/writing/voice/) rules out.
+
+The one exception is quoted output. When Azion Console or a command prints either mark, quote it exactly.
+
+## Leave headings and URLs unpunctuated
+
+- No end punctuation on a heading, a title, or a sidebar label.
+- No colon inside a heading. `Cache settings: an overview` becomes `Cache settings`.
+- No period at the end of a URL, because readers copy the trailing character.
+
+## Punctuate a list item by its length
+
+- An item of four words or more ends with a period.
+- An item of three words or fewer takes no end punctuation.
+- Every item in one list follows the same choice, so mixed lists get rewritten rather than mixed.
+
+A table cell follows the same rule: a cell that is a sentence ends with a period, and a cell that is a value or a fragment does not.
+
+## Use a colon to introduce, and avoid the semicolon
+
+A colon introduces a list, a procedure, or a code block. Capitalize after a colon only when a list follows; keep running text lowercase.
+
+- Correct: `You need three things: an account, a token, and a domain.`
+- Correct: `To create the bucket:`
+
+Avoid the semicolon. A semicolon joining two clauses is two sentences, and a semicolon joining a step to its result is the outcome sentence that [Procedures](/en/documentation/style-guide/writing/procedures/) already requires.
+
+## Set spacing and symbols
+
+| Rule | Example |
+| --- | --- |
+| One space after a period, a question mark, or a colon | `Save the rule. Deploy the application.` |
+| No space around a slash | `100 km/h` |
+| The percent sign attaches to its number | `100%` |
+| Write `and`, never `&` | `Rules and behaviors` |
+
+## Portuguese differs on dashes
+
+Portuguese takes a space on each side of a dash that separates a clause. Apart from this and the serial comma, this page holds in both languages.
+
+Prefer restructuring the Portuguese sentence to using a dash at all. [Bilingual pages](/en/documentation/style-guide/conventions/bilingual/) covers what else changes in a pair.

--- a/src/content/docs/en/pages/style-guide/formatting/text.mdx
+++ b/src/content/docs/en/pages/style-guide/formatting/text.mdx
@@ -1,0 +1,132 @@
+---
+title: Text formatting
+description: >-
+  Format the text of a page: when bold and italics apply, how internal links
+  and asset paths are written, and when a list is numbered.
+meta_tags: 'style guide, formatting, links, lists, tables'
+namespace: documentation_style_guide_text_formatting
+permalink: /documentation/style-guide/formatting/text/
+menu_namespace: styleGuideMenu
+---
+
+## Use bold for UI labels and product names
+
+Bold marks a label the reader must find on screen, and it marks a product name. Everything else stays plain, because bold for emphasis competes with those two jobs. A paragraph with three bold phrases has none.
+
+- Incorrect: `You **must** purge the cache **before** you deploy the **new version**.`
+- Correct: `Purge the cache before you deploy the new version.`
+
+Bold does its job when it points at the interface: `Select **Save** to apply the change.` The reader knows which word to look for.
+
+## Use italics for UI values and defined terms
+
+Italics mark a value or option the reader picks in the interface: `Set the permission to _Read Only_.` The label is bold; the value is italic.
+
+Italics also mark a term at the moment the page defines it: `A *cache key* identifies one object in the cache.` After the definition, the term appears in plain text. Italics anywhere else dilute both signals, so the documentation uses them rarely.
+
+## Use monospace for code and typed values
+
+Monospace marks code and anything the reader types: commands, paths, field names, flags, headers, status codes, and filenames.
+
+Tool names take monospace, never bold: `azion`, `npm`, `curl`. Bold names a product; monospace names the command the reader runs.
+
+The three styles divide the work: bold for the label, italics for the value, monospace for the typed text.
+
+## Never underline, and never bold a link
+
+Underlining belongs to links alone. An underlined word that is not a link reads as a broken link, and the reader clicks it.
+
+Do not bold the text inside a link either. The link already carries its own styling, and bold on top of it competes with the bold that marks UI labels.
+
+- Incorrect: `Refer to [**Cache settings**](/en/documentation/build/cache/reference/cache-settings/).`
+- Correct: `Refer to [Cache settings](/en/documentation/build/cache/reference/cache-settings/).`
+
+## Format internal links
+
+An internal link is absolute, starts with the language prefix, and ends with a trailing slash.
+
+- Incorrect: `[Applications](../build/applications)`
+- Correct: `[Applications](/en/documentation/build/applications/)`
+
+Asset paths follow a different rule. One image serves both language versions of a page, so its path is root-absolute with no language prefix.
+
+- Correct: `/assets/docs/images/uploads/diagram.png`
+
+## Write link text that names the destination
+
+The reader decides from the link text alone whether to follow the link. "Click here" names the action instead of the destination, and a bare URL buries the destination in syntax. Both force the reader to read around the link.
+
+- Incorrect: `To learn about sentence rules, [click here](/en/documentation/style-guide/writing/sentence-structure/).`
+- Correct: `The sentence caps are defined in [Sentence structure](/en/documentation/style-guide/writing/sentence-structure/).`
+
+Two standard forms cover almost every link sentence:
+
+- `For more information, refer to [Page Title](/en/documentation/.../).`
+- `To <do something>, refer to [Section Title](/en/documentation/.../).`
+
+Do not write `Learn more about...`, `To read more...`, `click here`, `this page`, or a bare URL in prose. Link text names the destination.
+
+A closing-section link carries its reason: `[Title](/path/) - one sentence on what the reader gets there.`
+
+Link text is unique on the page. Two links with the same text must go to the same place, because a reader who sees the same words expects the same destination.
+
+Links inside a paragraph point at documentation pages. External links gather at the end of the page or the section, so the reading flow never leaves the docs mid-task.
+
+## Link the first mention of another documented element
+
+When the prose names a product, a module, or a feature that has its own page, the first mention on the page links to that page: `Cache is an [Applications](/en/documentation/build/applications/) module.` Later mentions stay plain, or bold where the product-name rule asks for it.
+
+The link replaces the bold at that first mention, because the text inside a link is never bold. A reader who meets an unfamiliar name always has its page one click away.
+
+## Use asides for what the text cannot hold
+
+An aside carries information that is useful but does not fit the flow. The four variants divide the job:
+
+| Variant | Carries |
+| --- | --- |
+| `:::note` | Useful information that does not fit the flow |
+| `:::tip` | A shortcut or a recommendation |
+| `:::caution` | An action with consequences the reader must weigh |
+| `:::danger` | An action that breaks something or exposes data |
+
+Three limits keep asides readable. Use at most one aside of a kind per section. Keep an aside to three short paragraphs. Never put a heading inside an aside.
+
+An aside never carries the primary answer. The reader who skips every aside must still complete the task from the flow alone.
+
+## Number a list only for sequence
+
+A numbered list promises order: the reader takes step 2 after step 1. When order does not matter, the list takes bullets. When only one item exists, write a sentence, because a list of one is a sentence with a bullet in front.
+
+The sentence rules for steps are in [Sentence structure](/en/documentation/style-guide/writing/sentence-structure/).
+
+## Keep list items parallel
+
+Items in one list share one grammar: all start with a verb, or all start with a noun. Mixed grammar forces the reader to re-parse each item, and the list becomes slower to scan than a paragraph.
+
+Incorrect:
+
+```md
+- Create a bucket
+- Permissions for the bucket
+- Uploading the files
+```
+
+Correct:
+
+```md
+- Create a bucket
+- Set the bucket permissions
+- Upload the files
+```
+
+## Use tables for enumerable content
+
+Fields, limits, flags, defaults, and status codes belong in tables. Reference readers scan a table; they do not read it. Two rules protect that mode of reading.
+
+Phrase a column consistently. A column that reads `Enables the cache`, then `this option turns on logs`, then `compression on` describes one kind of fact in three shapes. Each new shape forces actual reading. Write `Enables the cache`, `Enables logs`, `Enables compression`.
+
+State the unit and the default for every value. A limit without a unit is not a fact: a cell with `100` leaves the reader to guess between megabytes, seconds, and requests. Write `100 MB`, and state the default where one exists.
+
+Introduce every table with a sentence that says what it shows. A table that arrives without context is data the reader must reverse-engineer.
+
+Never put a table in the middle of a numbered procedure. The table interrupts the sequence; place it before the steps or link it.

--- a/src/content/docs/en/pages/style-guide/formatting/text.mdx
+++ b/src/content/docs/en/pages/style-guide/formatting/text.mdx
@@ -66,7 +66,7 @@ Two standard forms cover almost every link sentence:
 
 Do not write `Learn more about...`, `To read more...`, `click here`, `this page`, or a bare URL in prose. Link text names the destination.
 
-A closing-section link carries its reason: `[Title](/path/) - one sentence on what the reader gets there.`
+A closing-section link carries its reason. In a `## Next steps` card or a `## Related resources` row, the title is the destination and the copy is one sentence on what the reader gets there.
 
 Link text is unique on the page. Two links with the same text must go to the same place, because a reader who sees the same words expects the same destination.
 

--- a/src/content/docs/en/pages/style-guide/how-we-docs.mdx
+++ b/src/content/docs/en/pages/style-guide/how-we-docs.mdx
@@ -1,0 +1,16 @@
+---
+title: How we write the docs
+description: >-
+  Understand how the documentation is produced: the toolchain and its checks, the two
+  languages every page ships in, and the readers it is written for.
+meta_tags: 'style guide, documentation process, docs as code'
+namespace: documentation_style_guide_how_we_docs
+permalink: /documentation/style-guide/how-we-docs/
+menu_namespace: styleGuideMenu
+---
+
+How the documentation is produced: the toolchain that gates it, the two languages it ships in, and the readers it serves.
+
+- [Docs as code](/en/documentation/style-guide/how-we-docs/docs-as-code/) - the public repository, the review flow, and the checks every change passes.
+- [Two languages, one source](/en/documentation/style-guide/how-we-docs/two-languages/) - English as the source of truth, and the Portuguese twin every page ships with.
+- [For people and agents](/en/documentation/style-guide/how-we-docs/for-people-and-agents/) - the design choices that keep pages useful to a human reader and a retrieval system alike.

--- a/src/content/docs/en/pages/style-guide/how-we-docs/docs-as-code.mdx
+++ b/src/content/docs/en/pages/style-guide/how-we-docs/docs-as-code.mdx
@@ -1,0 +1,45 @@
+---
+title: Docs as code
+description: >-
+  Understand how the documentation ships: a public repository, an issue-first
+  review flow, and automated checks on every change.
+meta_tags: 'style guide, docs as code, repository, checks'
+namespace: documentation_style_guide_hwd_docs_as_code
+permalink: /documentation/style-guide/how-we-docs/docs-as-code/
+menu_namespace: styleGuideMenu
+---
+
+The documentation is a codebase. Every page is a file in a public repository, and every change is a pull request. Every pull request passes the same automated checks before it ships.
+
+## One repository, one review
+
+The source lives at [aziontech/docs](https://github.com/aziontech/docs) on GitHub, open to external contributions. For significant changes, an issue comes before the pull request, so a maintainer can weigh in on the approach before the work starts. Minor fixes can go straight to a pull request.
+
+Two teams own the reviews: Developer Education gatekeeps the content, and UX Engineering gatekeeps the structure code. The issue templates on the repository route each request: report an error, request an addition, update content, or ask a question.
+
+## The checks every change passes
+
+The build gates a change four ways:
+
+| Check | What it catches |
+| --- | --- |
+| Site build | A page that does not compile: a broken component, malformed MDX, an invalid import |
+| Frontmatter validator | A missing, malformed, or duplicated `namespace` or `permalink` |
+| Sidebar check | A menu entry pointing at a permalink that does not exist, and a page unreachable from any menu |
+| Link checker | An internal link whose target page does not exist |
+
+A change that fails any of them does not merge.
+
+## Redirects
+
+A permalink that changes or disappears ships its redirect in the same change. Redirect pairs are declared in the repository and applied by the platform layer that serves the site.
+
+## Metadata
+
+Every page carries the same five frontmatter fields, and two of them are contracts. The `permalink` is unique per language, and the `namespace` pairs the page with its translation. The full contract is in [File conventions](/en/documentation/style-guide/conventions/frontmatter/).
+
+## Related resources
+
+- [File conventions](/en/documentation/style-guide/conventions/frontmatter/) - the frontmatter contract the validator enforces.
+- [Information architecture](/en/documentation/style-guide/content/information-architecture/) - where a page sits and how sections grow.
+- [Contributing on GitHub](https://github.com/aziontech/docs) - the repository, the issue templates, and the review flow.

--- a/src/content/docs/en/pages/style-guide/how-we-docs/docs-as-code.mdx
+++ b/src/content/docs/en/pages/style-guide/how-we-docs/docs-as-code.mdx
@@ -8,6 +8,9 @@ namespace: documentation_style_guide_hwd_docs_as_code
 permalink: /documentation/style-guide/how-we-docs/docs-as-code/
 menu_namespace: styleGuideMenu
 ---
+import FrameBox from '@aziontech/webkit/frame-box'
+import ItemList from '@aziontech/webkit/item-list'
+import DocItem from '@aziontech/webkit/doc-item'
 
 The documentation is a codebase. Every page is a file in a public repository, and every change is a pull request. Every pull request passes the same automated checks before it ships.
 
@@ -40,6 +43,10 @@ Every page carries the same five frontmatter fields, and two of them are contrac
 
 ## Related resources
 
-- [File conventions](/en/documentation/style-guide/conventions/frontmatter/) - the frontmatter contract the validator enforces.
-- [Information architecture](/en/documentation/style-guide/content/information-architecture/) - where a page sits and how sections grow.
-- [Contributing on GitHub](https://github.com/aziontech/docs) - the repository, the issue templates, and the review flow.
+<FrameBox>
+<ItemList>
+  <DocItem title="File conventions" href="/en/documentation/style-guide/conventions/frontmatter/">The frontmatter contract the validator enforces.</DocItem>
+  <DocItem title="Information architecture" href="/en/documentation/style-guide/content/information-architecture/">Where a page sits and how sections grow.</DocItem>
+  <DocItem title="Contributing on GitHub" href="https://github.com/aziontech/docs">The repository, the issue templates, and the review flow.</DocItem>
+</ItemList>
+</FrameBox>

--- a/src/content/docs/en/pages/style-guide/how-we-docs/for-people-and-agents.mdx
+++ b/src/content/docs/en/pages/style-guide/how-we-docs/for-people-and-agents.mdx
@@ -1,0 +1,29 @@
+---
+title: For people and agents
+description: >-
+  Write once for two readers: the design choices that keep pages useful to
+  people and to retrieval systems alike.
+meta_tags: 'style guide, agents, retrieval, AI readability'
+namespace: documentation_style_guide_hwd_people_agents
+permalink: /documentation/style-guide/how-we-docs/for-people-and-agents/
+menu_namespace: styleGuideMenu
+---
+
+A documentation page has two readers: a person on the page, and a machine that retrieves a piece of it to answer a question. The documentation is written once, for both.
+
+## Sections that stand alone
+
+A retrieval system does not return a page. It returns a chunk, usually one section, with no context around it. So every `##` section is written to be read alone. The heading names the content specifically enough to match a search, and the first sentence works without the section before it.
+
+## Diagrams as text
+
+A diagram is a Mermaid code fence, never an image. The text of the diagram reaches an agent reading the page as markdown; an image reference does not. A diagram also never stands alone: the prose beneath it walks the same flow.
+
+## One bar for every draft
+
+The vocabulary and pattern bans apply to every author. A page written by a person and one drafted with an agent meet the same bar: no repeated frames, no filler, no decorative dashes. The patterns are listed in [Word choice](/en/documentation/style-guide/writing/word-choice/).
+
+## Related resources
+
+- [Components](/en/documentation/style-guide/components/) - the Mermaid mechanics and the live component set.
+- [Word choice](/en/documentation/style-guide/writing/word-choice/) - the padding patterns and their replacements.

--- a/src/content/docs/en/pages/style-guide/how-we-docs/for-people-and-agents.mdx
+++ b/src/content/docs/en/pages/style-guide/how-we-docs/for-people-and-agents.mdx
@@ -8,6 +8,9 @@ namespace: documentation_style_guide_hwd_people_agents
 permalink: /documentation/style-guide/how-we-docs/for-people-and-agents/
 menu_namespace: styleGuideMenu
 ---
+import FrameBox from '@aziontech/webkit/frame-box'
+import ItemList from '@aziontech/webkit/item-list'
+import DocItem from '@aziontech/webkit/doc-item'
 
 A documentation page has two readers: a person on the page, and a machine that retrieves a piece of it to answer a question. The documentation is written once, for both.
 
@@ -25,5 +28,9 @@ The vocabulary and pattern bans apply to every author. A page written by a perso
 
 ## Related resources
 
-- [Components](/en/documentation/style-guide/components/) - the Mermaid mechanics and the live component set.
-- [Word choice](/en/documentation/style-guide/writing/word-choice/) - the padding patterns and their replacements.
+<FrameBox>
+<ItemList>
+  <DocItem title="Components" href="/en/documentation/style-guide/components/">The Mermaid mechanics and the live component set.</DocItem>
+  <DocItem title="Word choice" href="/en/documentation/style-guide/writing/word-choice/">The padding patterns and their replacements.</DocItem>
+</ItemList>
+</FrameBox>

--- a/src/content/docs/en/pages/style-guide/how-we-docs/two-languages.mdx
+++ b/src/content/docs/en/pages/style-guide/how-we-docs/two-languages.mdx
@@ -8,6 +8,9 @@ namespace: documentation_style_guide_hwd_two_languages
 permalink: /documentation/style-guide/how-we-docs/two-languages/
 menu_namespace: styleGuideMenu
 ---
+import FrameBox from '@aziontech/webkit/frame-box'
+import ItemList from '@aziontech/webkit/item-list'
+import DocItem from '@aziontech/webkit/doc-item'
 
 Every page ships in English and Brazilian Portuguese. The two versions are one page in two renderings, and the process keeps them from drifting apart.
 
@@ -25,6 +28,10 @@ The sentence rules serve the pair. Short sentences with simple tenses translate 
 
 ## Related resources
 
-- [Bilingual pages](/en/documentation/style-guide/conventions/bilingual/) - the full contract for a translation pair.
-- [Documentation terminology](/en/documentation/style-guide/writing/terminology/) - the naming rules and the terms that stay in English.
-- [Sentence structure](/en/documentation/style-guide/writing/sentence-structure/) - the sentence rules that make pages translatable.
+<FrameBox>
+<ItemList>
+  <DocItem title="Bilingual pages" href="/en/documentation/style-guide/conventions/bilingual/">The full contract for a translation pair.</DocItem>
+  <DocItem title="Documentation terminology" href="/en/documentation/style-guide/writing/terminology/">The naming rules and the terms that stay in English.</DocItem>
+  <DocItem title="Sentence structure" href="/en/documentation/style-guide/writing/sentence-structure/">The sentence rules that make pages translatable.</DocItem>
+</ItemList>
+</FrameBox>

--- a/src/content/docs/en/pages/style-guide/how-we-docs/two-languages.mdx
+++ b/src/content/docs/en/pages/style-guide/how-we-docs/two-languages.mdx
@@ -1,0 +1,30 @@
+---
+title: Two languages, one source
+description: >-
+  Follow the path a page takes through two languages: written in English
+  first, paired by namespace, and localized by rule.
+meta_tags: 'style guide, bilingual, translation, portuguese'
+namespace: documentation_style_guide_hwd_two_languages
+permalink: /documentation/style-guide/how-we-docs/two-languages/
+menu_namespace: styleGuideMenu
+---
+
+Every page ships in English and Brazilian Portuguese. The two versions are one page in two renderings, and the process keeps them from drifting apart.
+
+## English first
+
+English is the source of truth, and the order of work follows from it: the English page is written and finished, then translated. A Portuguese page written first has no source, and the English page that follows becomes a translation of a translation.
+
+## Paired by namespace
+
+The two versions share one `namespace`, identical character for character. That key is what connects a page to its translation, so the reader can switch languages on any page. Permalinks are localized: the Portuguese URL is translated and ASCII-folded.
+
+## Written to be translated
+
+The sentence rules serve the pair. Short sentences with simple tenses translate without restructuring, and a sentence that needs no restructuring is a sentence where meaning does not get lost. The vocabulary side is a set of fixed choices: which terms stay in English, and which Portuguese words are avoided.
+
+## Related resources
+
+- [Bilingual pages](/en/documentation/style-guide/conventions/bilingual/) - the full contract for a translation pair.
+- [Documentation terminology](/en/documentation/style-guide/writing/terminology/) - the naming rules and the terms that stay in English.
+- [Sentence structure](/en/documentation/style-guide/writing/sentence-structure/) - the sentence rules that make pages translatable.

--- a/src/content/docs/en/pages/style-guide/index.mdx
+++ b/src/content/docs/en/pages/style-guide/index.mdx
@@ -1,0 +1,30 @@
+---
+title: Style Guide
+description: >-
+  Write documentation the Azion way: voice, sentence structure, terminology,
+  formatting, content types, and file conventions.
+meta_tags: 'style guide, writing, documentation, conventions'
+namespace: documentation_style_guide
+permalink: /documentation/style-guide/
+menu_namespace: styleGuideMenu
+---
+
+This guide describes how Azion writes its documentation. Use it when you write a new page, translate one, or review someone else's work. The rules exist so that every page reads the same way, translates well, and stays useful when a machine retrieves one section alone.
+
+## What this guide covers
+
+- [Documentation voice](/en/documentation/style-guide/writing/voice/): the register every page uses.
+- [Sentence structure](/en/documentation/style-guide/writing/sentence-structure/): the sentence rules, adapted from ASD-STE100.
+- [Procedures](/en/documentation/style-guide/writing/procedures/): the step grammar every numbered procedure follows.
+- [Word choice](/en/documentation/style-guide/writing/word-choice/): the vocabulary to avoid and the padding patterns to cut.
+- [Documentation terminology](/en/documentation/style-guide/writing/terminology/): product names and translation rules.
+- [Headings](/en/documentation/style-guide/formatting/headings/), [text formatting](/en/documentation/style-guide/formatting/text/), [code](/en/documentation/style-guide/formatting/code/), [punctuation](/en/documentation/style-guide/formatting/punctuation/), and [numbers and units](/en/documentation/style-guide/formatting/numbers/): how content is formatted.
+- [Content structure](/en/documentation/style-guide/content/choose-a-content-type/): the page kinds and how to pick one, including [quickstarts](/en/documentation/style-guide/content/quickstart/) and [use cases](/en/documentation/style-guide/content/use-cases/).
+- [Information architecture](/en/documentation/style-guide/content/information-architecture/): the thirteen slots a product section can fill, in the order the reader meets them.
+- [File conventions](/en/documentation/style-guide/conventions/frontmatter/): frontmatter and [bilingual pages](/en/documentation/style-guide/conventions/bilingual/).
+- [Components](/en/documentation/style-guide/components/): the live MDX component set and the rules each one carries.
+- [How we write the docs](/en/documentation/style-guide/how-we-docs/): how the documentation is produced, in two languages, for people and agents.
+
+## The guide follows its own rules
+
+Every page in this section passes the rules it describes: the sentence caps, the heading rules, and the size targets. When a rule proves unworkable here, the rule changes before any writer is asked to follow it.

--- a/src/content/docs/en/pages/style-guide/writing/accessibility.mdx
+++ b/src/content/docs/en/pages/style-guide/writing/accessibility.mdx
@@ -1,0 +1,73 @@
+---
+title: Accessibility
+description: >-
+  Keep every page usable with a screen reader: descriptive titles and links,
+  no directional language, alt text, and explicit instructions.
+meta_tags: 'style guide, accessibility, alt text'
+namespace: documentation_style_guide_accessibility
+permalink: /documentation/style-guide/writing/accessibility/
+menu_namespace: styleGuideMenu
+---
+
+Some readers use a screen reader, some navigate with the keyboard, and some do not distinguish colors. The rules on this page keep the documentation usable for all of them. They follow the Web Content Accessibility Guidelines (WCAG) 2.2.
+
+## Write a descriptive, unique page title
+
+The title identifies the page in search results, in the browser tab, and in a screen reader's page announcement. A generic title identifies nothing there, and two pages with the same title are indistinguishable. Put the most specific information first, and never reuse a title.
+
+- Incorrect: `Troubleshooting`
+- Correct: `Troubleshoot DNS resolution errors`
+
+## Use one H1 and do not skip heading levels
+
+A screen reader user navigates from heading to heading, so the heading outline works as the page's table of contents. The `title` field in the frontmatter renders as the page's only H1. Start the body at `##`, and advance one level at a time. A jump from `##` to `####` implies a level that does not exist, and the outline loses its structure.
+
+The full heading rules are in [Headings](/en/documentation/style-guide/formatting/headings/).
+
+## Write link text that names the destination
+
+A screen reader can present the links of a page as a list, out of their sentences. In that list, "click here" and "read more" name nothing, and every generic link sounds like every other. Use the destination page's title as the link text.
+
+- Incorrect: `For the length caps, [click here](/en/documentation/style-guide/writing/sentence-structure/).`
+- Correct: `The length caps are in [Sentence structure](/en/documentation/style-guide/writing/sentence-structure/).`
+
+The formatting rules for links are in [Text formatting](/en/documentation/style-guide/formatting/text/).
+
+## Do not use directional language
+
+"The box on the right" and "the section below" describe a position. The position changes with the screen size, and it means nothing to a screen reader, which reads the page in one order. Name the element or the section instead.
+
+- Incorrect: `Click the button below.`
+- Correct: `Select **Save**.`
+- Incorrect: `See the section above.`
+- Correct: `Refer to the Prerequisites section.`
+
+## Write alt text that describes what the image conveys
+
+Alt text replaces the image for a screen reader user. Describe what the image conveys and why it is on the page, in under 150 characters. For a complex diagram, put the full description in the prose around the image and keep the alt text short.
+
+Do not open with "image of" or "picture of": the screen reader already announces the element as an image. Use empty alt text (`![]`) only for a purely decorative image. Do not stuff keywords, because alt text serves the reader, not the search ranking.
+
+- Incorrect: `![Screenshot](/assets/docs/images/uploads/request-flow.png)`
+- Incorrect: `![edge, cache, CDN, request flow, caching](/assets/docs/images/uploads/request-flow.png)`
+- Correct: `![Diagram of a request that flows from the client through Azion's distributed network to the origin](/assets/docs/images/uploads/request-flow.png)`
+
+## Do not rely on color alone in diagrams
+
+Color does not reach every reader: many readers do not distinguish it, and a screen reader does not announce it. In a diagram, use labels or shapes in addition to color, and write the legend with names, not colors.
+
+- Incorrect: `The green boxes are the cached responses.`
+- Correct: `The boxes labeled "cache hit" are the cached responses.`
+
+## Expand acronyms on first use
+
+Spell out each acronym at its first use on every page, because a reader lands on any page directly. The full rule is in [Word choice](/en/documentation/style-guide/writing/word-choice/).
+
+## Write explicit instructions
+
+An instruction names the control and the action, because "save your changes" leaves the reader to search the screen for the control. When an input has a format or a limit, state the requirement in the step.
+
+- Incorrect: `Save your changes.`
+- Correct: `Select **Save**.`
+- Incorrect: `Enter a value.`
+- Correct: `Enter the TTL in seconds.`

--- a/src/content/docs/en/pages/style-guide/writing/procedures.mdx
+++ b/src/content/docs/en/pages/style-guide/writing/procedures.mdx
@@ -1,0 +1,100 @@
+---
+title: Procedures
+description: >-
+  Write numbered steps with one action each, the canonical Console first
+  step, location before action, and one outcome sentence per procedure.
+meta_tags: 'style guide, procedures, steps, numbered lists'
+namespace: documentation_style_guide_procedures
+permalink: /documentation/style-guide/writing/procedures/
+menu_namespace: styleGuideMenu
+---
+
+## The first step
+
+Every numbered procedure in the documentation follows these rules, whatever kind of page it sits on. The first rule consolidates access and navigation into one step. Do not make "Log in" its own step when the next step is going somewhere.
+
+Console procedures start with the canonical string:
+
+```
+1. Access [Azion Console](https://console.azion.com/) > **<Product>**.
+```
+
+Fill in the product: `> **Object Storage**`, `> **Firewall**`. Deeper navigation extends the chain: `> **Applications** > **your application**`.
+
+A single-command procedure is not a numbered list. Write one lead-in sentence ending in a colon, then the command:
+
+```mdx
+To create the bucket with the Azion CLI:
+
+<Code lang="bash" code={`azion create bucket --name <your-bucket-name>`} />
+```
+
+Numbering starts when the procedure has two or more actions. An API procedure's lead-in names the method and endpoint: "Send a `POST` request to the buckets endpoint:" then the `curl` block.
+
+## One action per step
+
+A step holding two actions is a step where the second one gets skipped.
+
+- Incorrect: `Select **Save**, then purge the cache and confirm the TTL changed.`
+- Correct: three numbered steps, one for each action.
+
+Small movements that form one gesture may share a step, and therefore one sentence: `Enter a name and select **Read Only**.` This is the one place a single sentence carries two imperatives, and it overrides the sentence rules in [Sentence structure](/en/documentation/style-guide/writing/sentence-structure/).
+
+## Order within a step
+
+The reader orients, then acts. Location comes before the action:
+
+- Incorrect: `Select **Add Rule** in the Rules Engine tab.`
+- Correct: `In the **Rules Engine** tab, select **Add Rule**.`
+
+Purpose comes before the action. When a step exists for a reason the reader cannot see, lead with it: `To delete the rule, select **Delete**.`
+
+Condition comes before the action: `If the list is empty, select **Add**.`
+
+## Step grammar
+
+- Write in the imperative, active, present: `Select **Save**.` Never "You should select" or "The Save button should be selected."
+- Start an optional step with the literal word `(Optional)`: `3. (Optional) Enter a description for the rule.`
+- Mark sub-steps with lowercase letters (`a.`, `b.`) and sub-sub-steps with lowercase Roman numerals. If a step needs sub-sub-steps, the procedure wants splitting.
+- Bold the UI label and italicize the UI value: `Set **Workloads Access** to _Read Only_.`
+- Use the interface verbs only: select, go to, turn on, turn off, enter. Not click, hit, enable, disable. The table is in [Word choice](/en/documentation/style-guide/writing/word-choice/).
+- Use the interface's own words. If the button says **Save**, the step says select **Save**, not "confirm" or "apply". Do not improve on the interface's vocabulary in prose that describes it.
+- Do not use directional language. Name the element, not where it sits on the screen, per [Accessibility](/en/documentation/style-guide/writing/accessibility/).
+- Keep each sentence at 20 words and each step at one instruction. The procedural budget is in [Sentence structure](/en/documentation/style-guide/writing/sentence-structure/).
+
+## The lead-in
+
+Directly before the numbered list, one sentence states the goal and ends in a colon:
+
+```
+To deploy the ruleset for your application:
+```
+
+Use a colon when the sentence immediately precedes the steps. Use a period when material sits between them, such as an aside. Never write a partial sentence that the steps complete.
+
+## After the procedure
+
+End every procedure with one outcome sentence. State what the reader now has or sees, so they can tell they succeeded without asking.
+
+- `The bucket appears in the bucket list.`
+- `The response returns "state": "executed" with the bucket name.`
+
+When the interface shows no output, state the resulting state instead: `The bucket has the new access level.` Never write interface output, response codes, headers, or messages you have not seen the product produce. That distinction is what separates an outcome sentence from an invented fact.
+
+Warn about timing. If a result takes time to propagate, say so and say what to do: "New rules can take a few minutes to propagate. On an unexpected response, wait and retry before diagnosing."
+
+Follow-on tasks go in the page's `## Next steps` section, never in a "post-requisites" section.
+
+## Show the expected output
+
+Every command the reader runs is followed by the output they should see. Show the complete output when it is short, and the relevant excerpt when it is long. The output confirms the step worked before the next step depends on it.
+
+Input and output take different blocks: a `<Code>` block for the command the reader copies, a fence for the output they read. The mechanics are in [Code](/en/documentation/style-guide/formatting/code/).
+
+When a command produces no output, state the resulting state instead. When you can state neither, cut the command or restructure the step around a result the reader can check: a command the reader cannot verify is worse than one less command. Never write output you have not seen the command produce.
+
+## Multiple interfaces
+
+When a task has a Console, CLI, and API path, the paths go in a `<Tabs>` block: one procedure per panel, Console first. Each panel opens with its own lead-in naming the interface: `To create the bucket with the Azion CLI:`. The steps or the command follow directly, and the lead-in is never restated as a step. Never interleave two interfaces in one numbered list. The mechanics of the `<Tabs>` block are in [Components](/en/documentation/style-guide/components/).
+
+Include a panel only when you have run its procedure end to end. Leave out an interface you cannot verify yet, rather than filling its steps from the other panels.

--- a/src/content/docs/en/pages/style-guide/writing/sentence-structure.mdx
+++ b/src/content/docs/en/pages/style-guide/writing/sentence-structure.mdx
@@ -1,0 +1,111 @@
+---
+title: Sentence structure
+description: >-
+  Apply ASD-STE100 to every sentence: caps by content type, simple tenses,
+  active voice, and the rules that keep a sentence unambiguous.
+meta_tags: 'style guide, sentences, simplified technical english, ASD-STE100'
+namespace: documentation_style_guide_sentence_structure
+permalink: /documentation/style-guide/writing/sentence-structure/
+menu_namespace: styleGuideMenu
+---
+
+## Write for a reader who cannot ask
+
+The aerospace and defense industry publishes ASD-STE100, a controlled language for technical writing. Issue 9, dated 15 January 2025, contains 53 writing rules in 9 sections. The standard also carries a dictionary of about 900 approved words. Each word in that dictionary has one meaning and one part of speech.
+
+Azion documentation follows the sentence rules of this standard because its readers match the standard's target reader. Many readers work in a second language. No author is present to answer a question. Retrieval systems index these pages in sections and return one section, not the whole page. A sentence that follows these rules also translates to Portuguese with less drift.
+
+## Match the sentence cap to the content type
+
+ASD-STE100 sets stricter rules for procedures than for descriptions. Azion maps that split onto the four base forms.
+
+| Content type | Mode | Sentence cap |
+| --- | --- | --- |
+| Tutorial | Procedural | 20 words |
+| How-to | Procedural | 20 words |
+| Reference | Descriptive | 25 words |
+| Explanation | Descriptive | 25 words |
+
+A procedure gets the tighter cap because the reader executes each step under load. A step that the reader misreads becomes an action that fails. The caps count prose sentences only. Table cells, code, and command output are exempt.
+
+## Use simple tenses only
+
+Write with the imperative, the simple present, the simple past, and the simple future. Do not build tenses with auxiliary verbs. Prefer the simple present for product behavior, because the platform behaves the same way on every request.
+
+- Before: `The build has been completed.`
+- After: `The build is complete.`
+- Before: `Firewall will block the request.`
+- After: `Firewall blocks the request.`
+
+## Use an -ing word only as a noun
+
+Inside a sentence, an -ing word must be a noun or part of one, as in `caching` or `request logging`. Do not use an -ing word as a verb or as a trailing clause. A trailing clause hides who acts and when it happens.
+
+- Before: `The function validates the token, returning an error when the signature fails.`
+- After: `The function validates the token. When the signature fails, the function returns an error.`
+
+The same logic applies to task headings, which start with an imperative verb, not a gerund. The full rules are in [Headings](/en/documentation/style-guide/formatting/headings/).
+
+## Limit noun clusters to three words
+
+A stack of four or more nouns has no grammar between the words. The reader cannot tell which word modifies which. Break the cluster with prepositions. A product name counts as one unit, so **Real-Time Metrics** spends one of the three slots.
+
+- Before: `the request phase behavior execution order`
+- After: `the execution order of the behaviors in the request phase`
+
+## Keep the subject, the verb, and the articles
+
+Do not drop words to shorten a sentence. A sentence without its subject, verb, or articles reads faster and means less. When a sentence runs long, split it into two sentences.
+
+- Before: `Objects not cached are fetched from the origin.`
+- After: `When an object is not in the cache, Azion fetches it from the origin.`
+
+## Keep each paragraph on one topic
+
+Write one topic per paragraph, in six sentences at most. Retrieval systems cut pages into chunks, and a two-topic paragraph splits badly wherever the cut lands. Each fragment then carries half of the meaning.
+
+- Before: one paragraph that defines the cache key and then describes purge behavior.
+- After: one paragraph for the cache key, and a second paragraph for purge behavior.
+
+## Use a vertical list for a sequence
+
+Format three or more steps, conditions, or alternatives as a numbered or bulleted list. A sequence inside one prose sentence forces the reader to parse the order and the actions at the same time.
+
+Before:
+
+`Save the file, then run the build, and then deploy the application.`
+
+After:
+
+1. Save the file.
+2. Run the build.
+3. Deploy the application.
+
+## Use the same word for the same action
+
+Pick one verb for one action and repeat it across the page. A rotation of synonyms tells the reader that each verb names a different action.
+
+- Before: `Verify that the build passed. Then check that the deploy passed.`
+- After: `Verify that the build passed. Then verify that the deploy passed.`
+
+When a sentence describes a control in the Console, use the label that the Console shows. Do not improve on the vocabulary of the interface.
+
+ASD-STE100 pairs its rules with an approved dictionary. Rules 1.5 and 1.12 of the standard let a project approve its own technical names and technical verbs. Azion uses that allowance: the approved vocabulary is in [Word choice](/en/documentation/style-guide/writing/word-choice/) and in [Documentation terminology](/en/documentation/style-guide/writing/terminology/).
+
+## Check your draft
+
+Confirm each point before the page ships:
+
+- Every tense is simple, and product behavior uses the simple present.
+- Every -ing word works as a noun or as part of a noun.
+- Every noun cluster has at most three words, with a product name counted as one word.
+- Every sentence keeps its subject, its verb, and its articles.
+- Every paragraph covers one topic in at most six sentences.
+- Every sequence of three or more items is a vertical list.
+- Every action keeps the same verb across the page.
+
+## Sources
+
+- [ASD-STE100 official site](https://www.asd-ste100.org/): the standard, free to download.
+- [About STE](https://www.asd-ste100.org/about_STE.html): the 53 rules, the 9 sections, and the Issue 9 date.
+- [Google developer documentation style guide: headings](https://developers.google.com/style/headings): the case against a gerund as the first word of a heading.

--- a/src/content/docs/en/pages/style-guide/writing/terminology.mdx
+++ b/src/content/docs/en/pages/style-guide/writing/terminology.mdx
@@ -1,0 +1,55 @@
+---
+title: Documentation terminology
+description: >-
+  Apply the naming rules: the documentation product names and the terms that
+  stay in English.
+meta_tags: 'style guide, terminology, product names'
+namespace: documentation_style_guide_terminology
+permalink: /documentation/style-guide/writing/terminology/
+menu_namespace: styleGuideMenu
+---
+
+## Use the documentation product names
+
+Every product has one documentation name, and every page uses that name. Take the current name from the product's Overview page, the root of its section. This guide does not restate the names, because a copy is wrong the day a name changes.
+
+When a marketing name differs from the documentation name, write the marketing name once, in parentheses, at the first mention. After that, the documentation name stands alone.
+
+Azion renamed its products and platform resources over time. The old names still appear in old pages, URLs, and directory names, so they can look current. Treat these names as history, not as synonyms.
+
+## Name a module as a product
+
+**Applications**, **Firewall**, and **Connectors** are platform resources: capabilities of the platform itself. The modules of a resource are products. Name the product first, with the resource as context.
+
+- Correct: `Web Application Firewall (WAF) is a Firewall module that inspects HTTP and HTTPS requests.`
+- Incorrect: `Firewall is a product that includes WAF.`
+
+## Give a plural-form name a singular verb
+
+A product name names one product, whatever its form. Applications, Functions, and Connectors each take a singular verb: `Applications caches content`, `Functions runs your code` — never `Applications cache`. Portuguese agrees the same way: `Functions executa suas funções`, never `executam`.
+
+## Lowercase the thing the customer builds
+
+A product name is capitalized. The thing a customer creates with it is a common noun, and it stays lowercase.
+
+- Correct: `Use **Applications** to build your own applications.`
+- Correct: `**Functions** runs your functions on Azion's distributed network.`
+- Incorrect: `Deploy your first Application.`
+
+The distinction keeps the product name meaningful. A page that capitalizes both leaves the reader unable to tell the product from the object.
+
+## Keep historical names in historical documents
+
+Changelogs, release notes, and dated agreements record what was true on the day of publication. These documents keep the product names they shipped with. A Terms of Service from 2020 keeps the names that were correct in 2020.
+
+Do not rename products in a historical document. An updated name rewrites the record and detaches the text from its date.
+
+## Leave these terms in English
+
+These terms are generic technical vocabulary, not product names. They stay in English in both languages:
+
+`data center` · `serverless` · `on-premise` · `template` · `compliance` · `e-commerce` · `e-mail` · `keywords` · `meta description`
+
+A translation creates a second name for a concept the reader already knows in English. The documentation uses one term for one concept, on every page.
+
+The strings `edge` and `edge computing` also stay untranslated where they already appear. That is guidance for translation, not permission to use them. New text names Azion's distributed network instead.

--- a/src/content/docs/en/pages/style-guide/writing/voice.mdx
+++ b/src/content/docs/en/pages/style-guide/writing/voice.mdx
@@ -1,0 +1,66 @@
+---
+title: Documentation voice
+description: >-
+  Write in second person, simple present, and active voice: imperative steps,
+  behavior instead of quality claims, and sentences that keep their grammar.
+meta_tags: 'style guide, voice, writing'
+namespace: documentation_style_guide_voice
+permalink: /documentation/style-guide/writing/voice/
+menu_namespace: styleGuideMenu
+---
+
+## Address the reader as "you"
+
+Documentation speaks to the person who does the work. Second person keeps the reader inside the sentence, as the subject of the verb. "The user" turns the reader into a third party and pushes the verb toward the future.
+
+- Before: `The user will create a bucket.`
+- After: `You create a bucket.`
+
+## Use the simple present tense
+
+Describe product behavior in the simple present. The present states what the platform does every time, and that is the claim a reader acts on.
+
+- Before: `Applications will cache content on Azion's distributed network.`
+- After: `Applications caches content on Azion's distributed network.`
+
+[Sentence structure](/en/documentation/style-guide/writing/sentence-structure/) owns the full tense rules, including the ban on tenses built with auxiliary verbs.
+
+## Use the active voice
+
+The active voice names the actor. The passive hides the actor, and the actor is often the answer the reader came for.
+
+- Before: `A cache policy is applied to the request.`
+- After: `Rules Engine applies a cache policy to the request.`
+
+The passive version leaves open who applies the policy: the platform, the browser, or the reader. In descriptive text, the passive is acceptable only when the actor is genuinely unknown or is the platform itself. Never use the passive in a step.
+
+## Write steps in the imperative
+
+A step is an instruction, so it starts with the verb: `Select **Save**.`, never "You should select" or "The button should be selected". [Procedures](/en/documentation/style-guide/writing/procedures/) owns the step grammar.
+
+## Describe behavior, not quality
+
+Documentation describes behavior and limits. It does not sell, because the reader already chose the product. An adjective that claims quality gives the reader nothing to act on; a behavior and a limit do.
+
+- Before: `Applications offers powerful, flexible caching capabilities.`
+- After: `Applications caches content on Azion's distributed network. The default TTL is 60 seconds.`
+
+The rewrite replaces two adjectives with facts the reader can test. The vocabulary rules are in [Word choice](/en/documentation/style-guide/writing/word-choice/).
+
+## Split long sentences, do not clip them
+
+Short sentences carry technical content better than long ones. Short is not the same as clipped: never drop a subject, a verb, or an article to shorten a sentence. When a sentence runs long, split it in two instead. [Sentence structure](/en/documentation/style-guide/writing/sentence-structure/) owns this rule and the length caps.
+
+## Do not use contractions
+
+Write "do not", "cannot", and "it is". Contractions read casually and translate unevenly.
+
+- Before: `You don't need to configure the origin again.`
+- After: `You do not need to configure the origin again.`
+
+## Do not write "we"
+
+Never write "we". The actor is "Azion" or "you". "We" names neither the platform nor the reader, so the reader cannot tell who acts.
+
+- Before: `We recommend a TTL of 60 seconds.`
+- After: `Azion recommends a TTL of 60 seconds.`

--- a/src/content/docs/en/pages/style-guide/writing/word-choice.mdx
+++ b/src/content/docs/en/pages/style-guide/writing/word-choice.mdx
@@ -1,0 +1,139 @@
+---
+title: Word choice
+description: >-
+  Cut the filler vocabulary, avoid empty adjectives, keep the words that
+  describe behavior, and trace every number and name to a source.
+meta_tags: 'style guide, word choice, vocabulary'
+namespace: documentation_style_guide_word_choice
+permalink: /documentation/style-guide/writing/word-choice/
+menu_namespace: styleGuideMenu
+---
+
+## Cut the filler vocabulary
+
+Some words appear in drafts as decoration and carry no technical meaning. Delete the padding and keep the sentence: "it is important to note that" and "note that" add nothing. Prefer the short form: "to" instead of "in order to", "because" instead of "due to the fact that", and "can" instead of "has the ability to".
+
+Prefer the plain verb: "use" instead of "utilize" and "leverage", and "cover" instead of "delve into". Replace a vague quantity with the real one: name the range instead of "a wide range of", and count the options instead of "various".
+
+- Before: `In order to leverage the various caching options, note that the setup is straightforward.`
+- After: `To cache content, set the TTL and the cache key.`
+
+Keep a word from this family when it carries technical meaning. Cut it when it decorates.
+
+## Avoid empty adjectives
+
+An empty adjective claims quality without describing behavior. Drop the adjective and state what the product does, what it withstands, or what it covers. [Documentation voice](/en/documentation/style-guide/writing/voice/) owns the register rule. This page covers the vocabulary.
+
+The test is whether the word claims *quality* or describes *behavior*. "Robust security" asks the reader to trust an adjective. "A robust retry with exponential backoff" names the mechanism, and the adjective now describes something testable. Keep a word that passes this test. Replace one that does not.
+
+The same failure hides in framing phrases. Write "Use for" instead of "Perfect for" or "Essential for", and "Use when" instead of "Best for". State the action directly instead of "empowers you to", and drop "modern", "seamless", and "cutting-edge" as modifiers.
+
+- Before: `Applications offers powerful, seamless caching, perfect for modern e-commerce.`
+- After: `Applications caches content on Azion's distributed network.`
+
+*Significance inflation* is the same failure aimed at a concept: a sentence about how important something is, in place of what it does. "Caching plays a crucial role in modern web performance" gives the reader nothing to act on. State what the thing does and what its limits are.
+
+## Cut the padding patterns
+
+Five patterns add words without adding information.
+
+*Participle padding* is a trailing `-ing` clause: "…reducing latency and improving performance, ensuring a better experience." Cut the clause and keep the claim that is measurable. The sentence-level rule against trailing participles is in [Sentence structure](/en/documentation/style-guide/writing/sentence-structure/).
+
+*Negative parallelism* is the shape "It's not just X, it's Y." Say Y.
+
+*False ranges* connect items that are not on a scale: "from configuration to deployment to monitoring". List the actual set instead.
+
+*Undefined "you can"* promises without content: "You can configure various options." Either name the options or link to the page that names them.
+
+*Generic conclusions* restate the page without adding anything. End on the last concrete fact, or on a link worth following.
+
+## Vary the shape of consecutive sentences
+
+Two sentences in a row that open with the same words, or that share the same grammatical shape, read as a template even when every fact in them is right:
+
+- Before: `An edge node that holds a valid copy answers from cache. An edge node that holds no valid copy fetches the object from the origin.`
+- After: `When a node holds a valid copy, it answers from cache. Otherwise the node fetches the object from the origin.`
+
+Three techniques break the pattern: lead with the condition rather than the subject; contrast with a connective such as `Otherwise` instead of naming the subject twice; and let one sentence carry two clauses when they are one thought. A paragraph whose sentences all run the same mid-length reads the same way, so vary the length and prefer short.
+
+## Name things in headings
+
+A heading names a thing or a task. A rhetorical question does neither.
+
+- Before: `What is caching?`
+- After: `Caching`
+- Before: `Why use Tiered Cache?`
+- After: `When to use Tiered Cache`
+
+## Avoid these words on every page
+
+Do not call a task "simple", "easy", "straightforward", or "obvious", and do not soften a step with "just" or "simply". If the task were easy, the reader would not be here, and these words tell a stuck reader to feel embarrassed.
+
+Do not write "please". Documentation instructs. It does not ask.
+
+Do not anchor a page in time with "currently", "at the time of writing", "will soon", "now available", "recently", or "new" as a modifier. All of them age badly, and nobody returns to fix them. No month or year appears outside a changelog: say what is true and let the changelog carry the timeline. A date a build step generates, such as the last-updated column on a Guides and tutorials hub, is exempt, because nothing written by hand goes stale there.
+
+Write "for example" and "that is", never "e.g." and "i.e.".
+
+## Use the interface verbs
+
+Each interface action takes one verb, the same verb on every page:
+
+| Use | Not |
+| --- | --- |
+| select | click, hit, tap |
+| go to | navigate to |
+| turn on, turn off | enable, disable (for switches and toggles) |
+| enter | type in, input |
+| refer to | see, check out |
+
+"Enable" and "disable" stay legitimate for describing state in prose: "When the module is enabled, requests pass through it."
+
+Do not use directional language. Name the element instead, per [Accessibility](/en/documentation/style-guide/writing/accessibility/).
+
+The step grammar that uses these verbs is in [Procedures](/en/documentation/style-guide/writing/procedures/).
+
+## Use inclusive language
+
+The documentation addresses the reader as "you", so the generic reader never needs a gendered pronoun. A generic third party — an attacker, a developer — takes "they", never "he" or "she".
+
+Gendered and ableist idioms follow the same rule. Write `validate`, not `sanity check`.
+
+A role or a profession takes a neutral noun. Write `camera operator`, not `cameraman`.
+
+Replace a loaded technical term when the industry accepts an alternative:
+
+| Avoid | Use |
+| --- | --- |
+| whitelist | allowlist |
+| blacklist | blocklist |
+| master/slave | primary/replica |
+
+Do not use culture-specific references or idioms. They make sense in one locale, and they do not survive translation. Every page here ships in two languages, per [Bilingual pages](/en/documentation/style-guide/conventions/bilingual/).
+
+## Drop the article before a product name
+
+A product name is a proper noun, so it takes no article.
+
+- Incorrect: `Access the Azion Console.`
+- Correct: `Access Azion Console.`
+
+The article returns when a common noun follows the name, because the article then belongs to that noun: `The Application Accelerator module speeds up dynamic content.`
+
+## Use American English spelling
+
+Write `organize`, `behavior`, and `license`. British spellings drift into pages copied from vendor documentation, so check the ones that differ.
+
+## Expand acronyms on first use
+
+The first use on every page spells out the term and puts the acronym in parentheses: `time to live (TTL)`. After that, the acronym stands alone. A reader lands on any page directly, from a search result, so a definition on another page does not exist for them.
+
+Product names are not acronyms. Write the name as the rules in [Documentation terminology](/en/documentation/style-guide/writing/terminology/) require, and do not expand it.
+
+## Confirm every specific
+
+An invented specific is the worst failure in documentation. A wrong limit, default, field name, flag, or error string looks exactly like a correct one. The reader discovers the difference only when they try it and it fails.
+
+Every number, field name, and command comes from somewhere you can point to: the product itself, its API, or the team that owns it. When you cannot confirm a value, leave it out. A page that says less is recoverable. A page with a confident wrong value is not, because nobody knows to check it.
+
+Product names follow their own rules, in [Documentation terminology](/en/documentation/style-guide/writing/terminology/).

--- a/src/content/docs/pt-br/pages/guia-de-estilo/como-documentamos.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/como-documentamos.mdx
@@ -1,0 +1,16 @@
+---
+title: Como escrevemos a documentação
+description: >-
+  Entenda como a documentação é produzida: a toolchain e suas verificações, os
+  dois idiomas de cada página e os leitores para quem ela é escrita.
+meta_tags: 'style guide, documentation process, docs as code'
+namespace: documentation_style_guide_how_we_docs
+permalink: /documentacao/guia-de-estilo/como-documentamos/
+menu_namespace: styleGuideMenu
+---
+
+Como a documentação é produzida: a toolchain que a verifica, os dois idiomas em que ela é publicada e os leitores que ela atende.
+
+- [Docs as code](/pt-br/documentacao/guia-de-estilo/como-documentamos/docs-as-code/) - o repositório público, o fluxo de revisão e as verificações que toda mudança passa.
+- [Dois idiomas, uma fonte](/pt-br/documentacao/guia-de-estilo/como-documentamos/dois-idiomas/) - o inglês como fonte de verdade e o par em português que toda página tem.
+- [Para pessoas e agentes](/pt-br/documentacao/guia-de-estilo/como-documentamos/para-pessoas-e-agentes/) - as escolhas de design que mantêm as páginas úteis para um leitor humano e para um sistema de retrieval.

--- a/src/content/docs/pt-br/pages/guia-de-estilo/como-documentamos/docs-as-code.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/como-documentamos/docs-as-code.mdx
@@ -8,6 +8,9 @@ namespace: documentation_style_guide_hwd_docs_as_code
 permalink: /documentacao/guia-de-estilo/como-documentamos/docs-as-code/
 menu_namespace: styleGuideMenu
 ---
+import FrameBox from '@aziontech/webkit/frame-box'
+import ItemList from '@aziontech/webkit/item-list'
+import DocItem from '@aziontech/webkit/doc-item'
 
 A documentação é uma base de código. Cada página é um arquivo em um repositório público, e cada mudança é um pull request. Cada pull request passa pelas mesmas verificações automáticas antes de ser publicado.
 
@@ -40,6 +43,10 @@ Toda página carrega os mesmos cinco campos de frontmatter, e dois deles são co
 
 ## Recursos relacionados
 
-- [Convenções de arquivo](/pt-br/documentacao/guia-de-estilo/convencoes/frontmatter/) - o contrato de frontmatter que o validador aplica.
-- [Arquitetura de informação](/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura-de-informacao/) - onde uma página fica e como as seções crescem.
-- [Contribuir no GitHub](https://github.com/aziontech/docs) - o repositório, os templates de issue e o fluxo de revisão.
+<FrameBox>
+<ItemList>
+  <DocItem title="Convenções de arquivo" href="/pt-br/documentacao/guia-de-estilo/convencoes/frontmatter/">O contrato de frontmatter que o validador aplica.</DocItem>
+  <DocItem title="Arquitetura de informação" href="/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura-de-informacao/">Onde uma página fica e como as seções crescem.</DocItem>
+  <DocItem title="Contribuir no GitHub" href="https://github.com/aziontech/docs">O repositório, os templates de issue e o fluxo de revisão.</DocItem>
+</ItemList>
+</FrameBox>

--- a/src/content/docs/pt-br/pages/guia-de-estilo/como-documentamos/docs-as-code.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/como-documentamos/docs-as-code.mdx
@@ -1,0 +1,45 @@
+---
+title: Docs as code
+description: >-
+  Entenda como a documentação é publicada: um repositório público, um fluxo de
+  revisão que começa na issue e verificações automáticas em toda mudança.
+meta_tags: 'style guide, docs as code, repository, checks'
+namespace: documentation_style_guide_hwd_docs_as_code
+permalink: /documentacao/guia-de-estilo/como-documentamos/docs-as-code/
+menu_namespace: styleGuideMenu
+---
+
+A documentação é uma base de código. Cada página é um arquivo em um repositório público, e cada mudança é um pull request. Cada pull request passa pelas mesmas verificações automáticas antes de ser publicado.
+
+## Um repositório, uma revisão
+
+O código-fonte vive em [aziontech/docs](https://github.com/aziontech/docs) no GitHub, aberto a contribuições externas. Para mudanças significativas, a issue vem antes do pull request, para que um mantenedor avalie a abordagem antes do trabalho começar. Correções menores podem ir direto para um pull request.
+
+Dois times fazem as revisões: Developer Education guarda o conteúdo, e UX Engineering guarda o código de estrutura. Os templates de issue do repositório encaminham cada pedido: reportar um erro, pedir uma adição, atualizar conteúdo ou fazer uma pergunta.
+
+## As verificações que toda mudança passa
+
+O build verifica uma mudança de quatro formas:
+
+| Verificação | O que ela captura |
+| --- | --- |
+| Build do site | Uma página que não compila: um componente quebrado, MDX malformado, um import inválido |
+| Validador de frontmatter | Um `namespace` ou `permalink` ausente, malformado ou duplicado |
+| Verificação de sidebar | Uma entrada de menu apontando para um permalink que não existe, e uma página inalcançável por qualquer menu |
+| Verificador de links | Um link interno cuja página de destino não existe |
+
+Uma mudança que falha em qualquer uma delas não é mesclada.
+
+## Redirects
+
+Um permalink que muda ou desaparece publica seu redirect na mesma mudança. Os pares de redirect são declarados no repositório e aplicados pela camada da plataforma que serve o site.
+
+## Metadados
+
+Toda página carrega os mesmos cinco campos de frontmatter, e dois deles são contratos. O `permalink` é único por idioma, e o `namespace` conecta a página à sua tradução. O contrato completo está em [Convenções de arquivo](/pt-br/documentacao/guia-de-estilo/convencoes/frontmatter/).
+
+## Recursos relacionados
+
+- [Convenções de arquivo](/pt-br/documentacao/guia-de-estilo/convencoes/frontmatter/) - o contrato de frontmatter que o validador aplica.
+- [Arquitetura de informação](/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura-de-informacao/) - onde uma página fica e como as seções crescem.
+- [Contribuir no GitHub](https://github.com/aziontech/docs) - o repositório, os templates de issue e o fluxo de revisão.

--- a/src/content/docs/pt-br/pages/guia-de-estilo/como-documentamos/dois-idiomas.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/como-documentamos/dois-idiomas.mdx
@@ -1,0 +1,30 @@
+---
+title: Dois idiomas, uma fonte
+description: >-
+  Acompanhe o caminho de uma página pelos dois idiomas: escrita primeiro em
+  inglês, pareada por namespace e localizada por regra.
+meta_tags: 'style guide, bilingual, translation, portuguese'
+namespace: documentation_style_guide_hwd_two_languages
+permalink: /documentacao/guia-de-estilo/como-documentamos/dois-idiomas/
+menu_namespace: styleGuideMenu
+---
+
+Toda página é publicada em inglês e em português do Brasil. As duas versões são uma página em duas renderizações, e o processo impede que elas se separem.
+
+## Inglês primeiro
+
+O inglês é a fonte de verdade, e a ordem do trabalho vem daí: a página em inglês é escrita e finalizada, depois traduzida. Uma página em português escrita primeiro não tem fonte, e a página em inglês que vem depois vira uma tradução de uma tradução.
+
+## Pareadas por namespace
+
+As duas versões compartilham um `namespace`, idêntico caractere por caractere. Essa chave é o que conecta uma página à sua tradução, e é ela que permite ao leitor trocar de idioma em qualquer página. Os permalinks são localizados: a URL em português é traduzida e sem acentos.
+
+## Escrita para ser traduzida
+
+As regras de frase servem ao par. Frases curtas com tempos verbais simples traduzem sem reestruturação, e onde não há reestruturação o significado não se perde. O lado do vocabulário é um conjunto de escolhas fixas: quais termos ficam em inglês, e quais palavras do português são evitadas.
+
+## Recursos relacionados
+
+- [Páginas bilíngues](/pt-br/documentacao/guia-de-estilo/convencoes/paginas-bilingues/) - o contrato completo de um par de tradução.
+- [Terminologia da documentação](/pt-br/documentacao/guia-de-estilo/escrita/terminologia/) - as regras de nomes e os termos que ficam em inglês.
+- [Estrutura de frases](/pt-br/documentacao/guia-de-estilo/escrita/estrutura-de-frases/) - as regras de frase que tornam as páginas traduzíveis.

--- a/src/content/docs/pt-br/pages/guia-de-estilo/como-documentamos/dois-idiomas.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/como-documentamos/dois-idiomas.mdx
@@ -8,6 +8,9 @@ namespace: documentation_style_guide_hwd_two_languages
 permalink: /documentacao/guia-de-estilo/como-documentamos/dois-idiomas/
 menu_namespace: styleGuideMenu
 ---
+import FrameBox from '@aziontech/webkit/frame-box'
+import ItemList from '@aziontech/webkit/item-list'
+import DocItem from '@aziontech/webkit/doc-item'
 
 Toda página é publicada em inglês e em português do Brasil. As duas versões são uma página em duas renderizações, e o processo impede que elas se separem.
 
@@ -25,6 +28,10 @@ As regras de frase servem ao par. Frases curtas com tempos verbais simples tradu
 
 ## Recursos relacionados
 
-- [Páginas bilíngues](/pt-br/documentacao/guia-de-estilo/convencoes/paginas-bilingues/) - o contrato completo de um par de tradução.
-- [Terminologia da documentação](/pt-br/documentacao/guia-de-estilo/escrita/terminologia/) - as regras de nomes e os termos que ficam em inglês.
-- [Estrutura de frases](/pt-br/documentacao/guia-de-estilo/escrita/estrutura-de-frases/) - as regras de frase que tornam as páginas traduzíveis.
+<FrameBox>
+<ItemList>
+  <DocItem title="Páginas bilíngues" href="/pt-br/documentacao/guia-de-estilo/convencoes/paginas-bilingues/">O contrato completo de um par de tradução.</DocItem>
+  <DocItem title="Terminologia da documentação" href="/pt-br/documentacao/guia-de-estilo/escrita/terminologia/">As regras de nomes e os termos que ficam em inglês.</DocItem>
+  <DocItem title="Estrutura de frases" href="/pt-br/documentacao/guia-de-estilo/escrita/estrutura-de-frases/">As regras de frase que tornam as páginas traduzíveis.</DocItem>
+</ItemList>
+</FrameBox>

--- a/src/content/docs/pt-br/pages/guia-de-estilo/como-documentamos/para-pessoas-e-agentes.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/como-documentamos/para-pessoas-e-agentes.mdx
@@ -8,6 +8,9 @@ namespace: documentation_style_guide_hwd_people_agents
 permalink: /documentacao/guia-de-estilo/como-documentamos/para-pessoas-e-agentes/
 menu_namespace: styleGuideMenu
 ---
+import FrameBox from '@aziontech/webkit/frame-box'
+import ItemList from '@aziontech/webkit/item-list'
+import DocItem from '@aziontech/webkit/doc-item'
 
 Uma página de documentação tem dois leitores: uma pessoa na página, e uma máquina que recupera um pedaço dela para responder uma pergunta. A documentação é escrita uma vez, para os dois.
 
@@ -25,5 +28,9 @@ As proibições de vocabulário e de padrões valem para qualquer autor. Uma pá
 
 ## Recursos relacionados
 
-- [Componentes](/pt-br/documentacao/guia-de-estilo/componentes/) - a mecânica do Mermaid e o conjunto de componentes ativos.
-- [Escolha de palavras](/pt-br/documentacao/guia-de-estilo/escrita/escolha-de-palavras/) - os padrões de enchimento e suas substituições.
+<FrameBox>
+<ItemList>
+  <DocItem title="Componentes" href="/pt-br/documentacao/guia-de-estilo/componentes/">A mecânica do Mermaid e o conjunto de componentes ativos.</DocItem>
+  <DocItem title="Escolha de palavras" href="/pt-br/documentacao/guia-de-estilo/escrita/escolha-de-palavras/">Os padrões de enchimento e suas substituições.</DocItem>
+</ItemList>
+</FrameBox>

--- a/src/content/docs/pt-br/pages/guia-de-estilo/como-documentamos/para-pessoas-e-agentes.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/como-documentamos/para-pessoas-e-agentes.mdx
@@ -1,0 +1,29 @@
+---
+title: Para pessoas e agentes
+description: >-
+  Escreva uma vez para dois leitores: as escolhas de design que mantêm as
+  páginas úteis para pessoas e para sistemas de retrieval.
+meta_tags: 'style guide, agents, retrieval, AI readability'
+namespace: documentation_style_guide_hwd_people_agents
+permalink: /documentacao/guia-de-estilo/como-documentamos/para-pessoas-e-agentes/
+menu_namespace: styleGuideMenu
+---
+
+Uma página de documentação tem dois leitores: uma pessoa na página, e uma máquina que recupera um pedaço dela para responder uma pergunta. A documentação é escrita uma vez, para os dois.
+
+## Seções que ficam de pé sozinhas
+
+Um sistema de retrieval não retorna uma página. Ele retorna um chunk, em geral uma seção, sem o contexto ao redor. Então toda seção `##` é escrita para ser lida sozinha. O título nomeia o conteúdo com especificidade suficiente para corresponder a uma busca, e a primeira frase funciona sem a seção anterior.
+
+## Diagramas como texto
+
+Um diagrama é um fence de código Mermaid, nunca uma imagem. O texto do diagrama chega a um agente que lê a página como markdown; uma referência de imagem, não. Um diagrama também nunca fica sozinho: a prosa abaixo dele percorre o mesmo fluxo.
+
+## Uma régua para todo rascunho
+
+As proibições de vocabulário e de padrões valem para qualquer autor. Uma página escrita por uma pessoa e uma rascunhada com um agente passam pela mesma régua: sem molduras repetidas, sem enchimento, sem travessões decorativos. Os padrões estão listados em [Escolha de palavras](/pt-br/documentacao/guia-de-estilo/escrita/escolha-de-palavras/).
+
+## Recursos relacionados
+
+- [Componentes](/pt-br/documentacao/guia-de-estilo/componentes/) - a mecânica do Mermaid e o conjunto de componentes ativos.
+- [Escolha de palavras](/pt-br/documentacao/guia-de-estilo/escrita/escolha-de-palavras/) - os padrões de enchimento e suas substituições.

--- a/src/content/docs/pt-br/pages/guia-de-estilo/componentes.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/componentes.mdx
@@ -9,19 +9,11 @@ permalink: /documentacao/guia-de-estilo/componentes/
 menu_namespace: styleGuideMenu
 ---
 
-As páginas de documentação são MDX, e esta página é o vocabulário completo de componentes. Um componente ausente desta página não está disponível: um import inventado falha o build, e os componentes legados que resolvem são banidos na próxima seção, com os motivos.
-
-## Não use estes componentes
-
-Estes renderizam, mas não fazem parte do vocabulário deste site — legado do fork da documentação do Astro, sem manutenção, vários estilizados com variáveis de tema que este site não define mais:
-
-`Card` · `Badge` · `FileTree` · `Checklist` · `Spoiler` · `Since` · `Button` · `TabBox` · `Breadcrumb`
-
-Os nove compilam e emitem markup, então nada falha no build quando um deles passa. Os riscos concretos: `FileTree` injeta um bloco `<html><body>` aninhado na página; `Since` consulta o registro do npm na renderização e reporta versões do Astro; `TabBox` carrega conteúdo fixo de npm e yarn; `Card` chama um serviço externo de screenshot; `Button` duplica o `LinkButton` sem as convenções dele. Se você precisa do que um deles faria, use uma tabela, um aside ou o `LinkButton`.
+As páginas de documentação são MDX, e esta página é o vocabulário completo de componentes: cada entrada é um componente do design system, `@aziontech/webkit`, ou um wrapper fino sobre um. Um componente ausente desta página não está disponível: um import dele falha o build.
 
 ## Asides
 
-Sem import. Asides são escritos como diretivas remark, e são a construção mais comum depois dos links.
+Sem import. Asides são escritos como diretivas remark e renderizam o `DocCallout` do design system; são a construção mais comum depois dos links.
 
 ```mdx
 :::note
@@ -38,27 +30,31 @@ You are viewing the latest version. For accounts that are not migrated, refer to
 :::
 ```
 
-Tipos válidos: `note`, `tip`, `caution`, `danger`.
+Tipos válidos: `note`, `tip`, `caution`, `danger`. `caution` renderiza como o tipo warning do callout.
 
 **`:::warning` não é válido** e não renderiza como esperado. Use `:::caution`.
 
-O texto entre colchetes substitui o título traduzido automaticamente. Em páginas em português, localize: `:::note[nota]`, `:::tip[dica]`, `:::caution[Atenção]`.
+- Um callout contém apenas prosa inline: frases, links, código inline. Uma lista, um fence ou uma tabela dentro dele sai da caixa; coloque-os antes ou depois do aside.
+- O callout não tem linha de título. O texto entre colchetes é mantido como introdução à cópia (`Você sabia? — ...`), então use-o só quando as primeiras palavras precisarem dele. Em páginas em português, localize: `:::note[nota]`, `:::tip[dica]`, `:::caution[Atenção]`.
 
-## LinkButton
+## DocButton
 
-A call to action da casa.
+A call to action da casa. Um wrapper sobre o Button do design system que mantém o estilo de botão dentro do corpo do artigo.
 
 ```mdx
-import LinkButton from 'azion-webkit/linkbutton'
+import DocButton from '~/components/webkit/DocButton.vue'
 
-<LinkButton severity="secondary" label="Real-Time Purge reference" link="/en/documentation/products/build/applications/real-time-purge/" />
+<DocButton href="/pt-br/documentacao/produtos/build/applications/real-time-purge/" label="Referência de Real-Time Purge" kind="secondary" size="medium" />
 ```
 
-Props em uso: `link`, `label`, `severity="secondary"`, `outlined`, `icon`, `iconPos`.
+- `href` e `label` são obrigatórios. Sem diretiva client: o botão é um link estático.
+- `kind`: omita para a ação primária; `secondary` para um link de referência. `outlined`, `text` e `danger` também existem.
+- Sempre `size="medium"`.
+- `icon` recebe uma classe de ícone, sempre antes do label. `target="_blank"` abre um destino externo em nova aba.
 
 ## Code
 
-Wrapper sobre o expressive-code. Fornece um botão de copiar.
+Renderiza o `CodeBlock` do design system, com uma aba de linguagem e um botão de copiar. Blocos com fence renderizam o mesmo componente.
 
 ```mdx
 import Code from '~/components/Code/Code.astro'
@@ -78,7 +74,7 @@ Tags de linguagem em uso: `bash`, `sh`, `json`, `javascript`, `js`, `typescript`
 
 ## Tabs e Fragment
 
-O padrão multi-interface: uma tarefa, um painel por interface.
+O padrão multi-interface: uma tarefa, um painel por interface. Renderiza o `TabView` do design system, com todos os painéis mantidos no HTML.
 
 ```mdx
 import Tabs from '~/components/tabs/Tabs'
@@ -107,7 +103,7 @@ import Code from '~/components/Code/Code.astro'
 - `client:visible` é obrigatório. Sem ele, as tabs renderizam e não alternam.
 - Todo `tab.x` precisa de um `panel.x` correspondente.
 - **Linhas em branco ao redor de markdown dentro de um Fragment são obrigatórias**, ou o markdown renderiza como um único parágrafo literal.
-- O primeiro painel é o padrão; coloque o Console primeiro, a menos que exista um motivo para não fazer isso.
+- A primeira tab é o padrão, e os painéis são pareados com as tabs pela chave; coloque o Console primeiro, a menos que exista um motivo para não fazer isso.
 - Chaves canônicas: `tab.console`, `tab.api`, `tab.cli`, mais `tab.apiv3` / `tab.apiv4` para APIs versionadas.
 - O `sharedStore="package-managers"` opcional sincroniza a seleção entre grupos de tabs de uma página.
 
@@ -116,12 +112,14 @@ import Code from '~/components/Code/Code.astro'
 Selos de status.
 
 ```mdx
-import Tag from 'primevue/tag';
+import Tag from '~/components/webkit/Tag.vue'
 
-<Tag severity="info" client:only="vue" value="Preview" />
+<Tag severity="info">Preview</Tag>
 ```
 
-`client:only="vue"` é obrigatório. Sem ele, o selo renderiza e não hidrata.
+- Sem diretiva client: o selo é HTML estático.
+- `severity` é `success`, `info`, `warning` ou `danger`. `info` é o chip neutro de rótulo, usado para "Preview" e selos de produto; os outros três são cores de status.
+- O label vai nos filhos. `value="Preview"` também é aceito.
 
 ## Video
 
@@ -136,7 +134,7 @@ Sem import. Emite o iframe mais os metadados `VideoObject` do schema.org.
 />
 ```
 
-`src` precisa ser uma URL de **embed** do YouTube. `src` e `title` são obrigatórios.
+`src` precisa ser uma URL de **embed** do YouTube. `src` e `title` são obrigatórios. Para uma captura de tela ou um arquivo de clipe, use Figura.
 
 ## Diagramas Mermaid
 
@@ -151,6 +149,134 @@ flowchart LR
 ````
 
 Nomeie cada nó e cada aresta em palavras, e nunca dependa de cor sozinha para carregar uma distinção. Um diagrama nunca fica sozinho: páginas de arquitetura e de caso de uso mantêm o fluxo de dados numerado abaixo dele.
+
+## Passos
+
+Um passo a passo numerado: cada passo é um título com um corpo opcional, e os números vêm da ordem na página.
+
+```mdx
+import DocSteps from '@aziontech/webkit/doc-steps'
+import DocStep from '@aziontech/webkit/doc-step'
+
+<DocSteps>
+  <DocStep title="Crie o bucket">
+
+  No [Azion Console](https://console.azion.com/), acesse **Object Storage** e selecione **+ Bucket**.
+
+  </DocStep>
+  <DocStep title="Dê um nome">
+
+  Nomes de bucket precisam ser únicos entre todos os buckets existentes.
+
+  </DocStep>
+</DocSteps>
+```
+
+- Sem diretiva client.
+- Nunca escreva o número: reordenar os passos os renumera.
+- Um `DocStep` precisa estar dentro de um `DocSteps`; sozinho, ele lança um erro. Linhas em branco ao redor do markdown dentro de um passo são obrigatórias.
+
+## Figura
+
+Uma captura de tela, um clipe ou um diagrama emoldurado, com uma introdução opcional acima e uma legenda abaixo.
+
+```mdx
+import DocFrame from '@aziontech/webkit/doc-frame'
+
+<DocFrame
+  src="/assets/docs/images/uploads/real-time-metrics-overview.png"
+  alt="Visão geral do fluxo de consulta do Real-Time Metrics"
+  caption="O fluxo de consulta, do console à fonte de dados."
+/>
+```
+
+- `src` recebe uma imagem ou um clipe (`.mp4`, `.webm`). Dê um `alt` a uma imagem. Sem `src`, a moldura envolve os filhos, como um fence `mermaid`.
+- `caption` e `hint` são strings simples; os slots de mesmo nome (`<Fragment slot="caption">`) carregam uma legenda com link ou código inline.
+- `autoplay` reproduz um clipe sem som, inline e em loop, sem controles.
+
+## Cards
+
+Uma grade de cards de navegação, para uma página que se abre em seções.
+
+```mdx
+import DocCardGroup from '@aziontech/webkit/doc-card-group'
+import DocCard from '@aziontech/webkit/doc-card'
+
+<DocCardGroup cols={2}>
+  <DocCard title="Build" href="/pt-br/documentacao/produtos/build/" label="Applications, functions e connectors." />
+  <DocCard title="Secure" href="/pt-br/documentacao/produtos/secure/">Firewall, WAF e proteção contra DDoS.</DocCard>
+</DocCardGroup>
+```
+
+- Sem diretiva client.
+- `cols` é 2, 3 ou 4; a grade colapsa para uma coluna no celular.
+- `href` transforma o card inteiro em link. `label` é a cópia; os filhos a substituem quando a cópia precisa de um link ou de código inline.
+- Opcionais: `icon` recebe uma classe PrimeIcons (`pi pi-bolt`), `overline` uma linha pequena acima do título, `link` um texto de call to action em uma linha de fechamento.
+
+## Itens relacionados
+
+Uma lista emoldurada de linhas, cada uma com um nome e uma frase, para um leitor escolhendo o que ler em seguida.
+
+```mdx
+import ItemList from '@aziontech/webkit/item-list'
+import DocItem from '@aziontech/webkit/doc-item'
+
+<ItemList>
+  <DocItem title="Cache Settings" href="/pt-br/documentacao/produtos/build/applications/cache-settings/">Como um edge node decide o que guardar e por quanto tempo.</DocItem>
+  <DocItem title="Rules Engine" href="/pt-br/documentacao/produtos/build/applications/rules-engine/">Condições e comportamentos nas fases de requisição e resposta.</DocItem>
+</ItemList>
+```
+
+- Sem diretiva client. `ItemList` é a moldura que traça as linhas entre os itens.
+- `href` transforma a linha em link; uma URL externa recebe a seta para fora. O `icon` opcional recebe uma classe PrimeIcons.
+
+## Entrada de changelog
+
+Uma entrada datada: rótulo e versão à esquerda, as notas à direita, com uma âncora derivada do rótulo.
+
+```mdx
+import DocUpdate from '@aziontech/webkit/doc-update'
+
+<DocUpdate label="10 de julho de 2026" description="Bot Manager 1.3.0" tags={['Marketplace']}>
+
+**Bot Manager** agora traz nove novas regras estáticas e dois novos argumentos.
+
+</DocUpdate>
+```
+
+- Sem diretiva client. Linhas em branco ao redor do markdown interno são obrigatórias.
+- `label` é a âncora, em slug. Duas entradas com o mesmo rótulo precisam de valores distintos de `anchor`.
+- `description` é a linha abaixo do rótulo; `tags` é um array de rótulos curtos.
+
+## Prompt
+
+Um bloco de texto literal que o leitor entrega a um agente, em fonte mono e com um controle de copiar. Não é um bloco de código: sem linguagem, sem highlighting.
+
+```mdx
+import DocPrompt from '@aziontech/webkit/doc-prompt'
+
+<DocPrompt client:visible title="Experimente">Crie uma application com cache habilitado e faça o deploy.</DocPrompt>
+```
+
+- `client:visible` é obrigatório: o controle de copiar e o de expandir precisam dele.
+- `kind="line"` faz uma única linha com rolagem em vez de um parágrafo limitado a quatro linhas. `title` e `icon` são opcionais.
+
+## Glosa inline
+
+Um termo no meio da prosa que mostra sua definição ao passar o mouse ou receber foco, com um link opcional.
+
+```mdx
+import DocTooltip from '@aziontech/webkit/doc-tooltip'
+
+A <DocTooltip client:visible headline="Cache key" tip="O identificador que um edge node monta a partir de uma requisição." cta="Leia mais" href="/pt-br/documentacao/produtos/build/applications/cache-settings/">cache key</DocTooltip> decide o que corresponde.
+```
+
+- `client:visible` é obrigatório; sem ele o termo renderiza e nunca abre.
+- `tip` é a definição, `headline` a introdução em negrito, `cta` mais `href` o link.
+
+## Fornecidos pelo layout
+
+`DocPageHeader` (a partir de `title` e `description` no frontmatter), `DocOnThisPage`, `DocPagination` e o contrato tipográfico `DocProse` renderizam ao redor de toda página. Nunca os escreva.
 
 ---
 
@@ -168,7 +294,7 @@ Disponíveis: `apiv4Rollout`, `JourneyAPI`, `InterfaceNote`, `LetsEncryptExpirat
 
 ## SectionBasicContent
 
-Bloco de hero, usado em páginas de vitrine de templates. Recebe `description` e um array `buttons`, com o conteúdo em um `<Fragment slot="content">`. Leia uma página de vitrine existente antes de usar.
+O bloco de cabeçalho de uma página de vitrine de template. Importe de `~/components/SectionBasicContent/SectionBasicContent.vue`. Recebe `description` e um array `buttons`, com o resto da página em um `<Fragment slot="content">`. Cada botão recebe `label`, `link` e, opcionalmente, `severity: "secondary"`, `outlined: true`, `icon` e `target`. Um botão sem `link` não renderiza nada. Leia uma página de vitrine existente antes de usar.
 
 ## GuidesTable
 

--- a/src/content/docs/pt-br/pages/guia-de-estilo/componentes.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/componentes.mdx
@@ -1,0 +1,234 @@
+---
+title: Componentes
+description: >-
+  Use o conjunto de componentes MDX ativos das páginas de documentação: asides,
+  tabs, blocos de código, vídeos, diagramas e as regras de cada um.
+meta_tags: 'style guide, components, MDX'
+namespace: documentation_style_guide_components
+permalink: /documentacao/guia-de-estilo/componentes/
+menu_namespace: styleGuideMenu
+---
+
+As páginas de documentação são MDX, e esta página é o vocabulário completo de componentes. Um componente ausente desta página não está disponível: um import inventado falha o build, e os componentes legados que resolvem são banidos na próxima seção, com os motivos.
+
+## Não use estes componentes
+
+Estes renderizam, mas não fazem parte do vocabulário deste site — legado do fork da documentação do Astro, sem manutenção, vários estilizados com variáveis de tema que este site não define mais:
+
+`Card` · `Badge` · `FileTree` · `Checklist` · `Spoiler` · `Since` · `Button` · `TabBox` · `Breadcrumb`
+
+Os nove compilam e emitem markup, então nada falha no build quando um deles passa. Os riscos concretos: `FileTree` injeta um bloco `<html><body>` aninhado na página; `Since` consulta o registro do npm na renderização e reporta versões do Astro; `TabBox` carrega conteúdo fixo de npm e yarn; `Card` chama um serviço externo de screenshot; `Button` duplica o `LinkButton` sem as convenções dele. Se você precisa do que um deles faria, use uma tabela, um aside ou o `LinkButton`.
+
+## Asides
+
+Sem import. Asides são escritos como diretivas remark, e são a construção mais comum depois dos links.
+
+```mdx
+:::note
+Bucket names must be unique across all existing buckets.
+:::
+
+:::tip
+**Increase limits** <br></br>
+Contact [technical support](/en/documentation/services/support/) to request a higher limit for your plan.
+:::
+
+:::caution[important]
+You are viewing the latest version. For accounts that are not migrated, refer to the [legacy reference](/en/documentation/products/build/edge-application/v3/).
+:::
+```
+
+Tipos válidos: `note`, `tip`, `caution`, `danger`.
+
+**`:::warning` não é válido** e não renderiza como esperado. Use `:::caution`.
+
+O texto entre colchetes substitui o título traduzido automaticamente. Em páginas em português, localize: `:::note[nota]`, `:::tip[dica]`, `:::caution[Atenção]`.
+
+## LinkButton
+
+A call to action da casa.
+
+```mdx
+import LinkButton from 'azion-webkit/linkbutton'
+
+<LinkButton severity="secondary" label="Real-Time Purge reference" link="/en/documentation/products/build/applications/real-time-purge/" />
+```
+
+Props em uso: `link`, `label`, `severity="secondary"`, `outlined`, `icon`, `iconPos`.
+
+## Code
+
+Wrapper sobre o expressive-code. Fornece um botão de copiar.
+
+```mdx
+import Code from '~/components/Code/Code.astro'
+
+<Code lang="bash" code={`azion deploy --local`} />
+```
+
+Aceita apenas `code` e `lang`.
+
+**O valor é um template literal de JavaScript.** Backticks e `${` dentro dele precisam de escape, e uma continuação de linha precisa de barra invertida dupla. Quando um snippet contém um dos dois, isso é motivo para usar `<Code>` em vez de um fence, porque você controla o escape.
+
+Blocos com fence também são o estilo da casa. Use um fence para a saída que o leitor lê, e `<Code>` para a entrada que o leitor copia.
+
+Tags de linguagem em uso: `bash`, `sh`, `json`, `javascript`, `js`, `typescript`, `ts`, `hcl`, `graphql`, `shell`, `text`, `plaintext`. Terraform é `hcl`, não `terraform`.
+
+---
+
+## Tabs e Fragment
+
+O padrão multi-interface: uma tarefa, um painel por interface.
+
+```mdx
+import Tabs from '~/components/tabs/Tabs'
+import Code from '~/components/Code/Code.astro'
+
+<Tabs client:visible>
+    <Fragment slot="tab.console">Console</Fragment>
+    <Fragment slot="tab.api">API</Fragment>
+
+<Fragment slot="panel.console">
+
+1. Access [Azion Console](https://console.azion.com/) > **Object Storage**.
+2. Select **+ Bucket**.
+
+</Fragment>
+
+<Fragment slot="panel.api">
+
+<Code lang="bash" code={`curl ...`} />
+
+</Fragment>
+
+</Tabs>
+```
+
+- `client:visible` é obrigatório. Sem ele, as tabs renderizam e não alternam.
+- Todo `tab.x` precisa de um `panel.x` correspondente.
+- **Linhas em branco ao redor de markdown dentro de um Fragment são obrigatórias**, ou o markdown renderiza como um único parágrafo literal.
+- O primeiro painel é o padrão; coloque o Console primeiro, a menos que exista um motivo para não fazer isso.
+- Chaves canônicas: `tab.console`, `tab.api`, `tab.cli`, mais `tab.apiv3` / `tab.apiv4` para APIs versionadas.
+- O `sharedStore="package-managers"` opcional sincroniza a seleção entre grupos de tabs de uma página.
+
+## Tag
+
+Selos de status.
+
+```mdx
+import Tag from 'primevue/tag';
+
+<Tag severity="info" client:only="vue" value="Preview" />
+```
+
+`client:only="vue"` é obrigatório. Sem ele, o selo renderiza e não hidrata.
+
+## Video
+
+Sem import. Emite o iframe mais os metadados `VideoObject` do schema.org.
+
+```mdx
+<Video
+  src="https://www.youtube.com/embed/BV4jRPpADw8"
+  title="Local development with Azion CLI"
+  description="How the CLI supports local debugging and faster workflows."
+  uploadDate="2023-10-17"
+/>
+```
+
+`src` precisa ser uma URL de **embed** do YouTube. `src` e `title` são obrigatórios.
+
+## Diagramas Mermaid
+
+Um diagrama é um fence de código `mermaid`, não uma imagem. O texto chega a um agente que busca o twin em markdown; uma referência de imagem, não.
+
+````md
+```mermaid
+flowchart LR
+  Client --> Edge[Edge node]
+  Edge --> Origin[Origin server]
+```
+````
+
+Nomeie cada nó e cada aresta em palavras, e nunca dependa de cor sozinha para carregar uma distinção. Um diagrama nunca fica sozinho: páginas de arquitetura e de caso de uso mantêm o fluxo de dados numerado abaixo dele.
+
+---
+
+## Snippets compartilhados
+
+Blocos reutilizáveis em `~/includes/snippets/`, cada um com uma variante `en/` e uma `pt/`. Note que a pasta do português é `pt/`, não `pt-br/`.
+
+```mdx
+import Apiv4Rollout from '~/includes/snippets/apiv4Rollout/en/snippet.mdx'
+
+<Apiv4Rollout />
+```
+
+Disponíveis: `apiv4Rollout`, `JourneyAPI`, `InterfaceNote`, `LetsEncryptExpiration`, `RulesEngineExecution`.
+
+## SectionBasicContent
+
+Bloco de hero, usado em páginas de vitrine de templates. Recebe `description` e um array `buttons`, com o conteúdo em um `<Fragment slot="content">`. Leia uma página de vitrine existente antes de usar.
+
+## GuidesTable
+
+Renderiza o hub de Guias e tutoriais como uma tabela de nome, última atualização e dificuldade. Usado na página de hub de uma seção de produto, e em nenhum outro lugar.
+
+```mdx
+import GuidesTable from '~/components/GuidesTable.astro'
+
+<GuidesTable
+  lang="en"
+  prefixes={['/documentation/build/cache/guides/', '/documentation/build/cache/tutorials/']}
+  exclude={['/documentation/build/cache/guides/']}
+/>
+```
+
+- `prefixes` — prefixos de permalink cujas páginas preenchem a tabela. `exclude` remove a própria página de hub.
+- A data vem do último commit do arquivo no git, lida no momento do build. Nunca escreva a data à mão. Um arquivo sem commit ou de um clone raso mostra um traço.
+- A dificuldade vem do campo opcional `difficulty` do frontmatter: `Beginner`, `Intermediate` ou `Advanced`. O valor fica em inglês nas páginas dos dois idiomas; o componente localiza o rótulo.
+- As linhas ordenam da mais recente para a mais antiga, depois por título.
+- Os mesmos prefixos vão no campo `covers` da linha do menu, para que as páginas passem na verificação de posse da sidebar.
+
+---
+
+## GlossaryFilter
+
+Filtro client-side sobre uma tabela de glossário. Usado na página de Glossário de um produto, e em nenhum outro lugar.
+
+```mdx
+import GlossaryFilter from '~/components/GlossaryFilter.astro'
+
+<GlossaryFilter lang="pt-br">
+
+| Termo | Definição |
+| --- | --- |
+| cache key | O identificador que um edge node monta a partir de uma requisição para decidir se duas requisições correspondem ao mesmo objeto em cache. |
+
+</GlossaryFilter>
+```
+
+- O filho é uma tabela pipe de GFM, `| Termo | Definição |`. Linhas em branco ao redor dela são obrigatórias.
+- `lang` localiza o placeholder do filtro e a mensagem de estado vazio: `en` ou `pt-br`.
+- Cada linha do corpo recebe uma âncora derivada do termo, com ASCII-folding (`ação múltipla` → `#acao-multipla`), então uma definição aceita deep link. As âncoras existem sem JavaScript.
+- O filtro é um aprimoramento progressivo: sem JavaScript, a tabela inteira renderiza. A correspondência ignora maiúsculas e acentos, sobre a linha inteira.
+
+## Tabelas e quebras de linha
+
+Tabelas são pipe tables de GFM simples. A rolagem horizontal é adicionada automaticamente; não as envolva você mesmo.
+
+`<br />` ou `<br></br>`. **Um `<br>` sem fechamento quebra o build** — MDX exige toda tag fechada.
+
+## Regras de MDX que quebram builds
+
+- `<` e `{` soltos na prosa são interpretados como JSX. Escape-os ou use backticks.
+- Toda tag precisa estar fechada ou ser autofechada.
+- Nenhum H1 no corpo; o `title` o renderiza.
+- `---` entre seções principais é o estilo da casa, cerca de três por página. Nunca imediatamente depois do bloco de frontmatter.
+- Os imports vêm logo depois do bloco de frontmatter, antes de qualquer prosa.
+
+## Recursos relacionados
+
+- [Código](/pt-br/documentacao/guia-de-estilo/formatacao/codigo/) - quando um fence carrega saída e um bloco `<Code>` carrega entrada.
+- [Formatação de texto](/pt-br/documentacao/guia-de-estilo/formatacao/texto/) - links, negrito, itálico e monospace ao redor dos componentes.
+- [Escolher um tipo de conteúdo](/pt-br/documentacao/guia-de-estilo/conteudo/escolher-um-tipo-de-conteudo/) - os tipos de página que estes componentes servem.

--- a/src/content/docs/pt-br/pages/guia-de-estilo/componentes.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/componentes.mdx
@@ -8,6 +8,9 @@ namespace: documentation_style_guide_components
 permalink: /documentacao/guia-de-estilo/componentes/
 menu_namespace: styleGuideMenu
 ---
+import FrameBox from '@aziontech/webkit/frame-box'
+import ItemList from '@aziontech/webkit/item-list'
+import DocItem from '@aziontech/webkit/doc-item'
 
 As páginas de documentação são MDX, e esta página é o vocabulário completo de componentes: cada entrada é um componente do design system, `@aziontech/webkit`, ou um wrapper fino sobre um. Um componente ausente desta página não está disponível: um import dele falha o build.
 
@@ -196,7 +199,7 @@ import DocFrame from '@aziontech/webkit/doc-frame'
 
 ## Cards
 
-Uma grade de cards de navegação, para uma página que se abre em seções.
+Uma grade de cards de navegação, para uma página que se abre em seções. É a seção `## Próximos passos` que fecha uma página: um card por destino, com o motivo como texto.
 
 ```mdx
 import DocCardGroup from '@aziontech/webkit/doc-card-group'
@@ -215,20 +218,24 @@ import DocCard from '@aziontech/webkit/doc-card'
 
 ## Itens relacionados
 
-Uma lista emoldurada de linhas, cada uma com um nome e uma frase, para um leitor escolhendo o que ler em seguida.
+Uma lista emoldurada de linhas, cada uma com um nome e uma frase, para um leitor escolhendo o que ler em seguida. É a seção `## Relacionados` que fecha uma página.
 
 ```mdx
+import FrameBox from '@aziontech/webkit/frame-box'
 import ItemList from '@aziontech/webkit/item-list'
 import DocItem from '@aziontech/webkit/doc-item'
 
+<FrameBox>
 <ItemList>
   <DocItem title="Cache Settings" href="/pt-br/documentacao/produtos/build/applications/cache-settings/">Como um edge node decide o que guardar e por quanto tempo.</DocItem>
   <DocItem title="Rules Engine" href="/pt-br/documentacao/produtos/build/applications/rules-engine/">Condições e comportamentos nas fases de requisição e resposta.</DocItem>
 </ItemList>
+</FrameBox>
 ```
 
-- Sem diretiva client. `ItemList` é a moldura que traça as linhas entre os itens.
+- Sem diretiva client. `FrameBox` desenha o perímetro; `ItemList` traça as linhas entre os itens.
 - `href` transforma a linha em link; uma URL externa recebe a seta para fora. O `icon` opcional recebe uma classe PrimeIcons.
+- A cópia é uma frase: o que a coisa é, ou por que o leitor iria até lá. Código inline e links são permitidos; blocos, não.
 
 ## Entrada de changelog
 
@@ -355,6 +362,10 @@ Tabelas são pipe tables de GFM simples. A rolagem horizontal é adicionada auto
 
 ## Recursos relacionados
 
-- [Código](/pt-br/documentacao/guia-de-estilo/formatacao/codigo/) - quando um fence carrega saída e um bloco `<Code>` carrega entrada.
-- [Formatação de texto](/pt-br/documentacao/guia-de-estilo/formatacao/texto/) - links, negrito, itálico e monospace ao redor dos componentes.
-- [Escolher um tipo de conteúdo](/pt-br/documentacao/guia-de-estilo/conteudo/escolher-um-tipo-de-conteudo/) - os tipos de página que estes componentes servem.
+<FrameBox>
+<ItemList>
+  <DocItem title="Código" href="/pt-br/documentacao/guia-de-estilo/formatacao/codigo/">Quando um fence carrega saída e um bloco `<Code>` carrega entrada.</DocItem>
+  <DocItem title="Formatação de texto" href="/pt-br/documentacao/guia-de-estilo/formatacao/texto/">Links, negrito, itálico e monospace ao redor dos componentes.</DocItem>
+  <DocItem title="Escolher um tipo de conteúdo" href="/pt-br/documentacao/guia-de-estilo/conteudo/escolher-um-tipo-de-conteudo/">Os tipos de página que estes componentes servem.</DocItem>
+</ItemList>
+</FrameBox>

--- a/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/arquitetura-de-informacao.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/arquitetura-de-informacao.mdx
@@ -1,0 +1,86 @@
+---
+title: Arquitetura de informação
+description: >-
+  Siga a estrutura alvo da documentação da Azion: o esqueleto de seção de
+  produto, a ordem da jornada do leitor e onde uma página nova entra.
+meta_tags: 'style guide, information architecture, navigation, sidebar'
+namespace: documentation_style_guide_information_architecture
+permalink: /documentacao/guia-de-estilo/conteudo/arquitetura-de-informacao/
+menu_namespace: styleGuideMenu
+---
+
+Esta página define a estrutura alvo da documentação da Azion. Seções novas seguem esta estrutura, e as seções existentes convergem para ela conforme são revisadas. Não copie a estrutura de uma seção existente: este padrão vence.
+
+Dois princípios organizam tudo. As seções seguem a ordem da jornada do leitor com o produto. Cada seção contém um [tipo de conteúdo](/pt-br/documentacao/guia-de-estilo/conteudo/escolher-um-tipo-de-conteudo/), então a jornada decide onde a seção fica e o tipo decide como as páginas dela são.
+
+## O esqueleto de seção de produto
+
+Toda seção de produto segue esta ordem. A tabela mostra o que cada slot contém e quando ele existe.
+
+| Ordem | Slot | Obrigatório | Contém |
+| --- | --- | --- | --- |
+| 1 | Overview | Sim | A página raiz do produto: o que o produto é, o que ele faz, quando usar |
+| 2 | Quickstart | Sim | [Páginas de quickstart](/pt-br/documentacao/guia-de-estilo/conteudo/quickstart/): de não usar o produto ao menor resultado funcional |
+| 3 | Como funciona | Quando o produto precisa de explicação | [Páginas de conceito](/pt-br/documentacao/guia-de-estilo/conteudo/conceito/): o mecanismo, o custo, como escolher entre opções |
+| 4 | Features e capacidades | Quando o produto tem superfícies próprias | As superfícies do próprio produto, como um rules engine, um cache ou uma API de runtime |
+| 5 | Guias e tutoriais | Quando o produto tem tarefas | Um [hub de navegação](/pt-br/documentacao/guia-de-estilo/conteudo/hubs-de-navegacao/) que lista os [guias how-to](/pt-br/documentacao/guia-de-estilo/conteudo/guias-how-to/) e os [tutoriais](/pt-br/documentacao/guia-de-estilo/conteudo/tutoriais/) |
+| 6 | Exemplos | Opcional | Código funcional que o leitor copia, agrupado por linguagem ou por tarefa |
+| 7 | Referência | Quando o produto tem configurações | [Páginas de referência](/pt-br/documentacao/guia-de-estilo/conteudo/referencia/): campos, valores, padrões |
+| 8 | Limites | Quando o produto tem limites | A tabela de limites, dimensionada por plano |
+| 9 | Best practices | Opcional | Como operar bem o produto, e o raciocínio por trás de cada recomendação |
+| 10 | Troubleshooting | Quando o produto tem sintomas conhecidos | [Páginas de troubleshooting](/pt-br/documentacao/guia-de-estilo/conteudo/troubleshooting/): sintoma, causa, correção |
+| 11 | Glossário | Sim | [Páginas de glossário](/pt-br/documentacao/guia-de-estilo/conteudo/glossario/): os termos que a documentação do produto usa, definidos em uma tabela filtrável |
+| 12 | Pricing | Sim | Um link para a seção do produto na página de pricing |
+| 13 | Changelog | Sim | Um link para as entradas de changelog do produto |
+
+Dois slots têm uma forma fixa na sidebar.
+
+**Guias e tutoriais é uma linha que abre uma página.** A linha aponta para um hub cujo corpo é uma única tabela: nome, última atualização e dificuldade, uma linha por guia e por tutorial. A sidebar nunca expande essa linha, e o leitor abre um guia a partir da tabela. Uma seção com quarenta guias continua sendo uma linha na sidebar, então a sidebar segue mostrando o produto inteiro.
+
+A tabela é gerada, não escrita. A data vem do último commit do arquivo e a dificuldade de um campo `difficulty` no frontmatter, então o hub não diverge das páginas que lista.
+
+**Referência é um grupo fixo.** A sidebar mostra um pai **Referência** com uma linha por página de referência. O nome do grupo é o mesmo em toda seção de produto, então o leitor encontra os campos no mesmo lugar em todas.
+
+Outras linhas podem se agrupar da mesma forma. Um grupo é um pai de menu, não uma página, e fica em um único nível. Dois modos existem:
+
+- **Grupos fixos** guardam as páginas de um slot sob o nome padrão do slot. Referência é o caso canônico, e as variantes de interface do Quickstart se agrupam da mesma forma.
+- **Grupos de mesmo tipo** guardam páginas de fechamento relacionadas sob um pai temático. **Gerenciamento** guarda Limites, Preços e Changelog: as páginas que o leitor consulta sobre a operação do produto.
+
+Não agrupe linhas que funcionam bem planas. Um pai custa um clique ao leitor em cada visita, então um grupo precisa se pagar.
+
+Um produto com módulos repete o padrão um nível abaixo. Um módulo com superfície própria ganha uma subseção com o mesmo esqueleto, reduzido às partes de que precisa.
+
+Quickstart é o único slot que se divide por interface. Um produto cujo primeiro uso muda entre Azion Console, a Azion CLI, a API ou um agente de IA dá a cada interface a própria página. As páginas ficam agrupadas sob Quickstart, com o Console primeiro. O grupo é um pai da barra lateral, não uma página, e cada página documenta uma interface do início ao fim. Uma página continua sendo o piso: divida quando uma interface tem público próprio de primeiro uso e passos próprios, não para completar o conjunto.
+
+A seção de onboarding de plataforma em `/documentation/get-started/` é outra coisa com nome parecido. Quickstart é o slot por produto. Get started é a porta de entrada da plataforma, e não pertence a nenhum produto.
+
+## A ordem, e o que justifica um slot
+
+- **A ordem espelha a adoção.** Um slot nunca fica à frente da sua etapa.
+- **Pricing e Changelog fecham a seção.** O leitor os consulta em vez de passar por eles.
+- **A coluna Obrigatório decide o que é publicado.** Todo outro slot existe somente quando conteúdo real o preenche.
+- **Nunca adicione um slot para completar o padrão**, e nunca mantenha um vazio como marcador.
+- **Cresça dividindo um slot que a seção já tem:** Guias e tutoriais em grupos de tarefa nomeados na página de hub, Quickstart por interface, Features e capacidades por superfície.
+- **Os treze nunca aumentam em número.**
+
+## Pricing e limites
+
+- **Pricing é um link, nunca uma página.** O slot 12 aponta para `/documentation/platform/pricing/#<produto>`. Confirme que a âncora resolve antes de publicar.
+- **Nunca repita um preço, uma cota ou uma métrica de cobrança** em uma página de produto. Um preço duplicado fica errado no dia em que muda.
+- **Nomeie o plano quando a disponibilidade faz parte do comportamento**, e use o link de pricing para os números.
+- **Limites são dimensionados por plano.** Um número único esconde a diferença de todo leitor que está em outro plano.
+- **O contrato da tabela de limites fica em [Referência](/pt-br/documentacao/guia-de-estilo/conteudo/referencia/):** unidades, padrões e limites ajustáveis.
+- **Limites ocupam o slot 9 quando o conjunto vale ser consultado sozinho.** Uma seção `## Limites` na página de referência cobre um conjunto curto.
+
+## Posicione uma página nova
+
+Conteúdo que nenhum produto possui sozinho vive ao lado dos produtos, não dentro de um deles. Decida pelo leitor que a página serve:
+
+- A página documenta um produto: entra na seção desse produto, no slot que o tipo de conteúdo indica.
+- A página explica a plataforma, contas ou billing: entra em Fundamentals.
+- A página diagnostica problemas de plataforma ou leva ao time de suporte: entra em Suporte.
+- A página resolve um cenário de negócio do início ao fim: é um [caso de uso](/pt-br/documentacao/guia-de-estilo/conteudo/casos-de-uso/), e entra em Guias.
+- A página mostra como produtos se combinam em um design: entra em Architectures.
+- A página reúne links de uma área: é um [hub de navegação](/pt-br/documentacao/guia-de-estilo/conteudo/hubs-de-navegacao/), e precisa de um público real antes de existir.
+
+Quando nenhuma seção serve, abra uma issue antes de criar uma. Uma seção nova muda a navegação para todos os leitores.

--- a/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/arquitetura.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/arquitetura.mdx
@@ -8,6 +8,9 @@ namespace: documentation_style_guide_architecture
 permalink: /documentacao/guia-de-estilo/conteudo/arquitetura/
 menu_namespace: styleGuideMenu
 ---
+import FrameBox from '@aziontech/webkit/frame-box'
+import ItemList from '@aziontech/webkit/item-list'
+import DocItem from '@aziontech/webkit/doc-item'
 
 ## Propósito
 
@@ -43,11 +46,15 @@ O título nomeia o design como um sintagma nominal: `Content delivery on a distr
 - **`### Dataflow`**: um passo a passo numerado do que vai para onde, com no máximo seis itens.
 - **`## Componentes`**: o que cada parte faz e por que está ali.
 - **`## Implementação`**: links para os guias how-to, e apenas links.
-- **`## Recursos relacionados`**: a seção de fechamento, como links em lista, cada um com sua razão.
+- **`## Recursos relacionados`**: a seção de fechamento, uma lista de `DocItem`, cada linha com sua razão.
 
 ## Template
 
-````md
+````mdx
+import FrameBox from '@aziontech/webkit/frame-box'
+import ItemList from '@aziontech/webkit/item-list'
+import DocItem from '@aziontech/webkit/doc-item'
+
 <Qual problema este design resolve, e para quem.>
 
 ## Diagrama de arquitetura
@@ -76,7 +83,11 @@ flowchart LR
 
 ## Recursos relacionados
 
-- [<Página relacionada>](<URL da página>) - <o que o leitor encontra ali>.
+<FrameBox>
+<ItemList>
+  <DocItem title="<Página relacionada>" href="<URL da página>"><o que o leitor encontra ali>.</DocItem>
+</ItemList>
+</FrameBox>
 ````
 
 ## Regras
@@ -124,7 +135,11 @@ A request moves through the design in this order:
 
 ## Relacionados
 
-- [Páginas de conceito](/pt-br/documentacao/guia-de-estilo/conteudo/conceito/): a mesma forma base, para uma ideia em vez de um sistema.
-- [Guias multiproduto](/pt-br/documentacao/guia-de-estilo/conteudo/guias-multiproduto/): a página que constrói o que esta descreve.
-- [Imagens](/pt-br/documentacao/guia-de-estilo/formatacao/imagens/): texto alternativo e caminhos de assets.
-- [Escolher um tipo de conteúdo](/pt-br/documentacao/guia-de-estilo/conteudo/escolher-um-tipo-de-conteudo/): o catálogo completo de tipos de página.
+<FrameBox>
+<ItemList>
+  <DocItem title="Páginas de conceito" href="/pt-br/documentacao/guia-de-estilo/conteudo/conceito/">A mesma forma base, para uma ideia em vez de um sistema.</DocItem>
+  <DocItem title="Guias multiproduto" href="/pt-br/documentacao/guia-de-estilo/conteudo/guias-multiproduto/">A página que constrói o que esta descreve.</DocItem>
+  <DocItem title="Imagens" href="/pt-br/documentacao/guia-de-estilo/formatacao/imagens/">Texto alternativo e caminhos de assets.</DocItem>
+  <DocItem title="Escolher um tipo de conteúdo" href="/pt-br/documentacao/guia-de-estilo/conteudo/escolher-um-tipo-de-conteudo/">O catálogo completo de tipos de página.</DocItem>
+</ItemList>
+</FrameBox>

--- a/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/arquitetura.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/arquitetura.mdx
@@ -1,0 +1,130 @@
+---
+title: Páginas de arquitetura
+description: >-
+  Escreva uma página de arquitetura: o diagrama, o dataflow, os componentes e
+  os links para os guias que implementam o design.
+meta_tags: 'style guide, architecture, explanation'
+namespace: documentation_style_guide_architecture
+permalink: /documentacao/guia-de-estilo/conteudo/arquitetura/
+menu_namespace: styleGuideMenu
+---
+
+## Propósito
+
+Uma página de arquitetura mostra como vários produtos formam um design. O leitor quer entender o formato de uma solução antes de construí-la.
+
+Ela aplica a forma base de **explicação**, a mesma de uma [página de conceito](/pt-br/documentacao/guia-de-estilo/conteudo/conceito/). A diferença é o assunto: uma página de conceito explica uma coisa, uma página de arquitetura explica como muitas coisas se encaixam.
+
+## Quando usar
+
+Escreva uma página de arquitetura quando:
+
+- Uma solução precisa de mais de um produto, e a relação entre eles é o ponto.
+- O leitor precisa ver a ordem de uma requisição ou de um dataflow para entender o design.
+- Um guia fica redesenhando o mesmo sistema em texto corrido.
+
+Não escreva uma página de arquitetura quando:
+
+- O assunto é um produto ou uma ideia. Escreva uma [página de conceito](/pt-br/documentacao/guia-de-estilo/conteudo/conceito/).
+- O leitor quer construir a coisa. Escreva um [guia multiproduto](/pt-br/documentacao/guia-de-estilo/conteudo/guias-multiproduto/) e aponte para ele daqui.
+- O design não pode ser desenhado. Um design que você não consegue desenhar é um design que você ainda não entende bem o suficiente para publicar.
+
+## Registro
+
+Descritivo: 25 palavras por frase, voz ativa, passiva apenas quando o agente é desconhecido. Tom: explicativo, claro, sistemático. [Estrutura de frases](/pt-br/documentacao/guia-de-estilo/escrita/estrutura-de-frases/) tem as regras.
+
+## Estrutura
+
+O título nomeia o design como um sintagma nominal: `Content delivery on a distributed network`. O parágrafo de abertura diz qual problema o design resolve e para quem.
+
+**Seções obrigatórias, nesta ordem**
+
+- **`## Diagrama de arquitetura`**: o diagrama como um bloco de código `mermaid`, e depois um parágrafo que o lê.
+- **`### Dataflow`**: um passo a passo numerado do que vai para onde, com no máximo seis itens.
+- **`## Componentes`**: o que cada parte faz e por que está ali.
+- **`## Implementação`**: links para os guias how-to, e apenas links.
+- **`## Recursos relacionados`**: a seção de fechamento, como links em lista, cada um com sua razão.
+
+## Template
+
+````md
+<Qual problema este design resolve, e para quem.>
+
+## Diagrama de arquitetura
+
+```mermaid
+flowchart LR
+  <o design, como texto que um agente consegue ler>
+```
+
+<Um parágrafo que lê o diagrama: o que olhar primeiro, e o que depende do quê.>
+
+### Dataflow
+
+1. <O que se move primeiro, e para onde vai.>
+2. <O que a plataforma faz com isso.>
+3. <Onde o fluxo termina.>
+
+## Componentes
+
+- **<Nome do componente>**: <o que faz e por que está ali>.
+- **<Nome do componente>**: <o que faz e por que está ali>.
+
+## Implementação
+
+- [<Guia how-to que implementa este design>](<URL do guia>) - <por que o leitor o segue>.
+
+## Recursos relacionados
+
+- [<Página relacionada>](<URL da página>) - <o que o leitor encontra ali>.
+````
+
+## Regras
+
+- **Desenhe o diagrama em `mermaid`.** O diagrama é texto, então um agente que busca o gêmeo em markdown lê o próprio design em vez de uma referência de imagem. Não use imagem para um diagrama de arquitetura.
+- **O diagrama nunca fica sozinho.** O dataflow numerado carrega o significado, e ele permanece mesmo quando o diagrama é renderizado.
+- **Rotule cada nó e cada aresta com palavras**, e nunca dependa apenas de cor para carregar uma distinção.
+- **Nomeie cada componente e diga por que ele está ali.** Uma lista de nomes de produto é uma lista de peças.
+- **Aponte para a implementação, não a coloque aqui.** Os passos vão em um [guia multiproduto](/pt-br/documentacao/guia-de-estilo/conteudo/guias-multiproduto/).
+- **Escreva só as seções que você consegue confirmar.** Uma seção obrigatória cujo conteúdo você não consegue confirmar com o time que cuida do produto fica de fora até que consiga, nunca é preenchida com um palpite.
+
+## Exemplos
+
+- [Implante sites Jamstack em uma rede distribuída](/pt-br/documentacao/architectures/jamstack/implantacao-aplicacoes-jamstack/): um diagrama, um dataflow numerado, os componentes envolvidos e links para a implementação.
+
+Este trecho, de uma página em inglês, mostra a abertura, a seção do diagrama e o dataflow:
+
+````mdx
+This design delivers a site's content from locations close to users. It reduces latency and the load on the origin infrastructure. Use it when your team delivers static-heavy sites and applications.
+
+## Architecture diagram
+
+```mermaid
+flowchart LR
+  Client -->|HTTP request| Node[Nó da Azion]
+  Node --> Rules[Rules Engine]
+  Rules --> Cache[Cache layer]
+  Cache -->|Cache hit| Client
+  Cache -->|Cache miss| Origin[Origin server]
+  Origin --> Cache
+```
+
+O diagrama mostra o caminho de uma requisição e de sua resposta em uma aplicação na rede distribuída da Azion. A requisição do cliente chega a um node na rede distribuída da Azion, onde Rules Engine e a camada de cache a processam. O conteúdo que não está em cache vem do servidor de origem, e a resposta retorna ao cliente pelo mesmo node.
+
+### Dataflow
+
+A request moves through the design in this order:
+
+1. Um cliente envia uma requisição HTTP ou HTTPS para um domínio associado a uma aplicação.
+2. No node da Azion, Rules Engine processa a requisição. Ele aplica políticas de cache e comportamentos de otimização de imagem na fase de request.
+3. A camada de cache avalia a requisição. Em uma correspondência de cache key, o node entrega o objeto a partir do cache.
+4. Em um cache miss, o node encaminha a requisição ao servidor de origem. A origem responde, e o node armazena o conteúdo em cache.
+5. Antes de a resposta retornar ao cliente, Rules Engine processa as políticas da fase de response. O node então entrega o conteúdo ao usuário.
+````
+
+## Relacionados
+
+- [Páginas de conceito](/pt-br/documentacao/guia-de-estilo/conteudo/conceito/): a mesma forma base, para uma ideia em vez de um sistema.
+- [Guias multiproduto](/pt-br/documentacao/guia-de-estilo/conteudo/guias-multiproduto/): a página que constrói o que esta descreve.
+- [Imagens](/pt-br/documentacao/guia-de-estilo/formatacao/imagens/): texto alternativo e caminhos de assets.
+- [Escolher um tipo de conteúdo](/pt-br/documentacao/guia-de-estilo/conteudo/escolher-um-tipo-de-conteudo/): o catálogo completo de tipos de página.

--- a/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/casos-de-uso.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/casos-de-uso.mdx
@@ -9,6 +9,9 @@ namespace: documentation_style_guide_use_cases
 permalink: /documentacao/guia-de-estilo/conteudo/casos-de-uso/
 menu_namespace: styleGuideMenu
 ---
+import FrameBox from '@aziontech/webkit/frame-box'
+import ItemList from '@aziontech/webkit/item-list'
+import DocItem from '@aziontech/webkit/doc-item'
 
 ## Propósito
 
@@ -56,7 +59,7 @@ Procedural: 20 palavras por frase, uma instrução por passo, imperativo e ativo
 - **Verificação**: uma seção `## Verifique a configuração` com uma checagem por requisito e o resultado esperado.
 - **Medição de resultados**: uma seção `## Medindo resultados` nomeando as métricas que mostram a configuração funcionando, e onde ler cada uma.
 - **Best practices**: uma seção `## Best practices` com as recomendações e o raciocínio por trás de cada uma.
-- **Próximos passos**: um fechamento `## Próximos passos` com links em marcadores na forma `[Título](/caminho/) - motivo`.
+- **Próximos passos**: um fechamento `## Próximos passos`, um `DocCardGroup` com um card por destino: o título, o link e o motivo como texto do card.
 
 **Componentes opcionais**
 
@@ -74,7 +77,10 @@ O limite que mantém um caso de uso honesto é o teto de quatro seções em `## 
 
 Copie o template e substitua cada `<placeholder>`:
 
-````md
+````mdx
+import DocCardGroup from '@aziontech/webkit/doc-card-group'
+import DocCard from '@aziontech/webkit/doc-card'
+
 <Cenário. Três a cinco frases: o que o time tem, o que ele
 precisa e o que esta página configura.>
 
@@ -152,7 +158,9 @@ Para <alcançar o resultado desta etapa>:
 
 ## Próximos passos
 
-- [<Título>](/caminho/) - <por que o leitor seguiria o link>
+<DocCardGroup cols={2}>
+  <DocCard title="<Título>" href="/caminho/" label="<por que o leitor seguiria o link>" />
+</DocCardGroup>
 ````
 
 ## Regras
@@ -194,8 +202,12 @@ Cada linha nomeia um requisito de negócio, traduz para uma necessidade técnica
 
 ## Relacionados
 
-- [Guias multiproduto](/pt-br/documentacao/guia-de-estilo/conteudo/guias-multiproduto/): a mesma forma base, sem o enquadramento de negócio.
-- [Páginas de arquitetura](/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura/): o tipo a escrever quando não há nada a configurar.
-- [Guias how-to](/pt-br/documentacao/guia-de-estilo/conteudo/guias-how-to/): o tipo a escrever quando a configuração é uma tarefa só.
-- [Arquitetura de informação](/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura-de-informacao/): onde os casos de uso ficam, e por que vivem fora de um produto.
-- [Escolher um tipo de conteúdo](/pt-br/documentacao/guia-de-estilo/conteudo/escolher-um-tipo-de-conteudo/): o catálogo completo de tipos de página.
+<FrameBox>
+<ItemList>
+  <DocItem title="Guias multiproduto" href="/pt-br/documentacao/guia-de-estilo/conteudo/guias-multiproduto/">A mesma forma base, sem o enquadramento de negócio.</DocItem>
+  <DocItem title="Páginas de arquitetura" href="/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura/">O tipo a escrever quando não há nada a configurar.</DocItem>
+  <DocItem title="Guias how-to" href="/pt-br/documentacao/guia-de-estilo/conteudo/guias-how-to/">O tipo a escrever quando a configuração é uma tarefa só.</DocItem>
+  <DocItem title="Arquitetura de informação" href="/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura-de-informacao/">Onde os casos de uso ficam, e por que vivem fora de um produto.</DocItem>
+  <DocItem title="Escolher um tipo de conteúdo" href="/pt-br/documentacao/guia-de-estilo/conteudo/escolher-um-tipo-de-conteudo/">O catálogo completo de tipos de página.</DocItem>
+</ItemList>
+</FrameBox>

--- a/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/casos-de-uso.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/casos-de-uso.mdx
@@ -1,0 +1,201 @@
+---
+title: Casos de uso
+description: >-
+  Escreva uma página de caso de uso: um cenário de negócio virando
+  especificação executável, com produtos exigidos, arquitetura e resultados
+  medidos.
+meta_tags: 'style guide, use cases, guides, spec driven documentation'
+namespace: documentation_style_guide_use_cases
+permalink: /documentacao/guia-de-estilo/conteudo/casos-de-uso/
+menu_namespace: styleGuideMenu
+---
+
+## Propósito
+
+Uma página de caso de uso transforma um cenário de negócio em uma configuração que alguém consegue construir e verificar. O leitor chega com uma situação, não com uma tarefa: uma loja que fica lenta durante uma promoção, um evento ao vivo que precisa alcançar mais uma região.
+
+Um caso de uso é uma especificação, não um artigo. Ele carrega em uma página tudo de que o implementador precisa: os produtos que o cenário exige, a arquitetura, a configuração, as verificações e as métricas que mostram o resultado funcionando. Esse implementador muitas vezes é um agente, então a página é escrita para ser executada, não para ser lida.
+
+Casos de uso vivem na seção Guias, nunca dentro de um produto.
+
+## Quando usar
+
+**Reconheça um caso de uso por:**
+
+- Um leitor que chegou com uma situação de negócio, e não com uma tarefa.
+- Uma tabela de requisitos ligando cada necessidade de negócio ao produto que a atende.
+- Um resultado que continua mensurável depois que a configuração funciona.
+- Uma especificação completa o bastante para um agente executar sem fazer perguntas.
+
+**Continua sendo um caso de uso quando:**
+
+- Configura quatro coisas ou menos. Mais de quatro significa que são dois casos de uso.
+- Aponta para o procedimento genérico em vez de repeti-lo aqui.
+- É publicado sem demo, porque nenhuma existe. Nunca descreva uma demo que não roda.
+
+**Escreva outra coisa quando:**
+
+- Não há nada a configurar. A página explica um design, então escreva uma [página de arquitetura](/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura/).
+- A configuração é uma tarefa só. Isso é um [guia how-to](/pt-br/documentacao/guia-de-estilo/conteudo/guias-how-to/).
+- O objetivo é técnico e não precisa de enquadramento de negócio. Isso é um [guia multiproduto](/pt-br/documentacao/guia-de-estilo/conteudo/guias-multiproduto/).
+- O leitor não tem cenário, só o produto. Isso é um [tutorial](/pt-br/documentacao/guia-de-estilo/conteudo/tutoriais/).
+
+## Registro
+
+Procedural: 20 palavras por frase, uma instrução por passo, imperativo e ativo. Tom: preciso, claro, objetivo, sóbrio. [Estrutura de frases](/pt-br/documentacao/guia-de-estilo/escrita/estrutura-de-frases/) tem as regras.
+
+## Estrutura
+
+**Componentes obrigatórios**
+
+- **Cenário**: três a cinco frases nomeando o que o time tem, o que ele precisa e o que esta página configura. Seguidas de uma linha declarando o que o caso de uso não cobre.
+- **Pré-requisitos**: uma seção `## Pré-requisitos`, cada item um link ou um comando de uma linha quando existe um.
+- **Produtos exigidos**: a tabela de requisitos. Uma linha por requisito, nomeando a necessidade técnica, o produto que a atende e a página que a documenta.
+- **Arquitetura de referência**: uma seção `## Arquitetura de referência` com um diagrama em `mermaid` e um `### Fluxo de dados` numerado abaixo dele.
+- **Configuração**: uma seção `## Configure <coisa>` por requisito, no máximo quatro, cada uma com um procedimento que termina com sua frase de resultado.
+- **Verificação**: uma seção `## Verifique a configuração` com uma checagem por requisito e o resultado esperado.
+- **Medição de resultados**: uma seção `## Medindo resultados` nomeando as métricas que mostram a configuração funcionando, e onde ler cada uma.
+- **Best practices**: uma seção `## Best practices` com as recomendações e o raciocínio por trás de cada uma.
+- **Próximos passos**: um fechamento `## Próximos passos` com links em marcadores na forma `[Título](/caminho/) - motivo`.
+
+**Componentes opcionais**
+
+- **Demo**: uma seção `## Demo` apontando para um exemplo em execução, um template ou um repositório. Omita quando não existir; nunca descreva uma demo que não roda.
+
+As seções mantêm essa ordem. O que governa a página é a proporção, não o comprimento. Um caso de uso é mais longo do que os outros tipos por definição: ele é uma especificação, e quem implementa a partir dele não pode preencher uma lacuna perguntando. O peso da página fica nas seções que quem implementa executa:
+
+- **As seções de configuração sustentam a página.** No máximo quatro, e juntas elas são a maior parte dela. Se não são, a página está descrevendo um cenário em vez de construir um.
+- **Cenário, pré-requisitos, demo e próximos passos ficam curtos.** Cada um orienta e encaminha. Um cenário que passa de dois parágrafos está vendendo.
+- **Arquitetura de referência, verificação, medição e best practices ficam entre os dois.** Cada uma carrega conteúdo real — um diagrama, uma verificação que roda, um sinal a observar — e nenhuma delas é lugar para expandir.
+
+O limite que mantém um caso de uso honesto é o teto de quatro seções em `## Configure`, não um comprimento. Comprimir nunca é a solução, porque o que se comprime é o diagrama, o output do comando e o valor concreto — as partes sem as quais quem implementa não consegue seguir.
+
+## Template
+
+Copie o template e substitua cada `<placeholder>`:
+
+````md
+<Cenário. Três a cinco frases: o que o time tem, o que ele
+precisa e o que esta página configura.>
+
+<Uma linha nomeando o que este caso de uso não cobre.>
+
+## Pré-requisitos
+
+- <Um link ou um comando de uma linha quando existe um>
+
+---
+
+## Produtos exigidos
+
+| Requisito | Necessidade técnica | Produto | Documentado em |
+| --- | --- | --- | --- |
+| <O que o cenário exige> | <O que isso exige tecnicamente> | <Produto> | [<Página>](/caminho/) |
+
+---
+
+## Arquitetura de referência
+
+```mermaid
+flowchart LR
+  <o design, como texto que um agente consegue ler>
+```
+
+### Fluxo de dados
+
+1. <O que chega primeiro, e para onde vai.>
+2. <O que a plataforma faz com isso.>
+3. <Onde o fluxo termina.>
+
+---
+
+## Configure <a primeira coisa específica>
+
+Para <alcançar o resultado desta etapa>:
+
+1. <Uma instrução no imperativo.>
+2. <Uma instrução no imperativo.>
+
+<O resultado: o que o leitor agora tem.>
+
+## Configure <a coisa específica seguinte>
+
+<...>
+
+---
+
+## Verifique a configuração
+
+- <Uma checagem por requisito, com o resultado que o leitor deve ver.>
+
+---
+
+## Demo
+
+- [<Exemplo em execução ou template>](/caminho/) - <o que ele demonstra>.
+
+---
+
+## Medindo resultados
+
+| Métrica | Onde ler | Como é quando funciona |
+| --- | --- | --- |
+| <Métrica> | <Dashboard, query ou header> | <A direção ou a faixa esperada> |
+
+---
+
+## Best practices
+
+- **<Recomendação>**: <o que ela faz, e a razão por trás dela>.
+
+---
+
+## Próximos passos
+
+- [<Título>](/caminho/) - <por que o leitor seguiria o link>
+````
+
+## Regras
+
+- **Escreva uma especificação, não um artigo.** Todo valor é concreto, todo comando roda, e nenhum passo diz "dependendo da sua configuração". O leitor pode ser um agente, e um agente não resolve uma ambiguidade perguntando.
+- **Mostre o output depois de cada comando.** O leitor vê como o sucesso se parece antes que o próximo passo dependa dele. A regra está em [Procedimentos](/pt-br/documentacao/guia-de-estilo/escrita/procedimentos/).
+- **Reduza o cenário a uma configuração construível.** Declare assim: `Um <time> que <tem isto> configura <esta configuração> para que <este resultado verificável>.` Se a frase precisa de um "e também", são dois casos de uso.
+- **Comece pela tabela de requisitos.** Cada linha é um requisito que você confirmou no produto. Um requisito que você não consegue confirmar não entra na tabela.
+- **Deixe no corpo o que é específico deste caso de uso. Aponte para o que vale para todos.** O caminho genérico é um link; a página carrega o que o cenário muda.
+- **Limite a configuração a quatro seções.** Mais de quatro significa que o caso de uso é largo demais. Divida em vez de aumentar o limite.
+- **Faça o diagrama em `mermaid`.** O diagrama é texto, então um agente lendo o markdown twin recebe o design, não uma referência de imagem. O fluxo de dados numerado continua carregando o significado: o diagrama nunca fica sozinho.
+- **Separe verificação de medição.** Verificação é uma checagem única de que a configuração está correta. Medição é o sinal contínuo de que ela continua funcionando.
+- **Mantenha as best practices como recomendações com razões.** Uma recomendação sem a razão é uma instrução na seção errada, e o lugar dela é no procedimento.
+- **Nunca faça uma afirmação comercial.** Sem economia de custo, sem porcentagem, sem concorrente, sem nome de cliente e sem afirmar que uma configuração torna alguém compliance.
+- **Números de exemplo não são limites.** Um número que enquadra o cenário fica no parágrafo de cenário e não aparece em nenhum outro lugar.
+- **Nunca invente nome de produto, campo ou valor.** Tire os nomes de produto de [Terminologia da documentação](/pt-br/documentacao/guia-de-estilo/escrita/terminologia/), e campos e valores do produto, não de uma URL ou de um caminho de diretório.
+
+## Exemplos
+
+Este exemplo, em inglês, mostra o cenário, a linha do que não é coberto e a tabela de requisitos de um caso de uso de e-commerce:
+
+```mdx
+A retail team runs a storefront on Azion and expects heavy traffic during a seasonal sale. The catalogue pages are identical for every visitor, the cart is personal, and the checkout accepts a limited number of requests per customer. This page configures caching for the catalogue, a cache bypass for the cart, and a rate limit on checkout.
+
+This use case does not cover payment processing or inventory synchronization.
+
+---
+
+## Required products
+
+| Requirement | Technical need | Product | Documented at |
+| --- | --- | --- | --- |
+| Páginas de catálogo entregues rápido sob carga | Armazenar respostas idênticas em cache na rede distribuída da Azion | Applications | [Cache Settings](/pt-br/documentacao/build/cache/reference/cache-settings/) |
+| Cart stays personal | Bypass cache for authenticated paths | Applications | [Rules Engine](/en/documentation/build/applications/reference/rules-engine/) |
+| Checkout resists abuse | Rate limit by client identity | Firewall | [Rules Engine for Firewall](/en/documentation/secure/firewall/reference/rules-engine/) |
+```
+
+Cada linha nomeia um requisito de negócio, traduz para uma necessidade técnica e aponta para a página que a documenta. O leitor consegue conferir cada afirmação antes de rodar um único passo.
+
+## Relacionados
+
+- [Guias multiproduto](/pt-br/documentacao/guia-de-estilo/conteudo/guias-multiproduto/): a mesma forma base, sem o enquadramento de negócio.
+- [Páginas de arquitetura](/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura/): o tipo a escrever quando não há nada a configurar.
+- [Guias how-to](/pt-br/documentacao/guia-de-estilo/conteudo/guias-how-to/): o tipo a escrever quando a configuração é uma tarefa só.
+- [Arquitetura de informação](/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura-de-informacao/): onde os casos de uso ficam, e por que vivem fora de um produto.
+- [Escolher um tipo de conteúdo](/pt-br/documentacao/guia-de-estilo/conteudo/escolher-um-tipo-de-conteudo/): o catálogo completo de tipos de página.

--- a/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/changelog.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/changelog.mdx
@@ -1,0 +1,101 @@
+---
+title: Páginas de changelog
+description: >-
+  Escreva uma entrada de changelog: um registro somente por acréscimo, que
+  mantém os nomes de produto da época e diz o que mudou para o leitor.
+meta_tags: 'style guide, changelog, release notes'
+namespace: documentation_style_guide_changelog
+permalink: /documentacao/guia-de-estilo/conteudo/changelog/
+menu_namespace: styleGuideMenu
+---
+
+## Propósito
+
+Um changelog registra mudanças notáveis na plataforma, das mais novas para as mais antigas. Ele é um **registro**, não uma das quatro formas do Diátaxis: não ensina, não instrui e não explica. O leitor o consulta para responder uma pergunta, que é o que mudou e quando.
+
+## Quando usar
+
+- Adicione uma entrada quando uma mudança altera o que o leitor pode fazer, ver ou configurar.
+- Adicione quando um valor padrão muda, um limite se move ou uma funcionalidade é removida.
+
+Não adicione uma entrada quando:
+
+- Nada mudou para o leitor. Uma refatoração interna não é entrada de changelog.
+- A mudança precisa de instruções. Escreva o [guia how-to](/pt-br/documentacao/guia-de-estilo/conteudo/guias-how-to/) e aponte para ele na entrada.
+- A mudança merece raciocínio. Escreva a [página de conceito](/pt-br/documentacao/guia-de-estilo/conteudo/conceito/) e aponte para ela.
+
+## Registro
+
+Descritivo: 25 palavras por frase, voz ativa, passiva apenas quando o agente é desconhecido. Tom: factual, claro, impessoal. [Estrutura de frases](/pt-br/documentacao/guia-de-estilo/escrita/estrutura-de-frases/) tem as regras.
+
+## Estrutura
+
+Uma entrada fica sob um heading de data e tem de três a seis parágrafos curtos, sem headings próprios. Quando uma release agrupa entradas por área, o heading do produto desce um nível abaixo do heading da área.
+
+**Componentes obrigatórios**
+
+- **Um heading de data**: `## <dia> de <mês> de <ano>`, das mais novas para as mais antigas. Datas são permitidas em changelogs e apenas em changelogs.
+- **A frase de abertura**: `**<Produto>** agora <verbo> <capacidade>.`, com o detalhe concreto: a flag, o campo ou o valor padrão.
+- **O que significa na prática**: o que funciona sem configuração agora, ou o que se comporta de outra forma.
+- **Quem não é afetado**: configurações existentes, versões anteriores, contas que não aderiram.
+- **O link de fechamento**: `Para mais informações, consulte [<a página que documenta a mudança>](/pt-br/documentacao/.../).`
+
+**Componentes opcionais**
+
+- **Um heading de produto**: `### <Produto> <versão>`, sob o heading de data, quando a release nomeia um produto ou uma versão.
+- **Passos de migração ou adesão**: com um exemplo de código, quando uma API, a CLI ou uma configuração mudou.
+
+## Template
+
+```md
+## <dia> de <mês> de <ano>
+
+### <Produto> <versão, quando existe>
+
+**<Produto>** agora <verbo> <capacidade>, <o detalhe concreto: a flag, o campo ou o valor padrão>.
+
+<O que isso significa na prática: o que funciona sem configuração agora, ou o que se comporta de outra forma.>
+
+<Quem não é afetado: configurações existentes, versões anteriores, contas que não aderiram — e como aderir.>
+
+<Quando uma API, a CLI ou uma configuração mudou: a migração ou a adesão, com um exemplo de código.>
+
+Para mais informações, consulte [<a página que documenta a mudança>](/pt-br/documentacao/.../).
+```
+
+## Regras
+
+- **Abra com o produto como sujeito.** `**<Produto>** agora <verbo> <capacidade>.` Tempo presente, nunca `nós`, nunca `a Azion tem o prazer de`.
+- **Diga quem não é afetado.** A primeira pergunta do leitor sobre qualquer mudança é se ela o quebra; responda antes que ele pergunte.
+- **Mostre a migração ou a adesão quando a superfície mudou.** Uma mudança de API, CLI ou configuração recebe um exemplo de código; duas linhas bastam.
+- **Feche cada entrada com o link da documentação.** Uma entrada que documenta a funcionalidade por completo é uma página arquivada no lugar errado.
+- **Nunca reescreva uma entrada.** Corrija com uma nova entrada datada; o log é somente por acréscimo.
+- **Mantenha os nomes de produto da época.** Um registro datado mantém os nomes com que foi escrito; apenas entradas novas usam os nomes atuais.
+- **Termine a página na entrada mais antiga.** Um changelog não tem seção de fechamento: sem Próximos passos e sem Recursos relacionados.
+
+## Exemplos
+
+- [Arquivo do changelog](/pt-br/documentacao/changelog/archive/): entradas agrupadas por ano, cada uma nomeando o produto e a mudança. Ainda sem versão em português.
+
+Esta entrada, de um changelog em inglês, mostra o heading de data, o heading de área e a forma da entrada:
+
+```mdx
+## July 10, 2026
+
+### Marketplace
+
+#### Bot Manager 1.3.0 and Bot Manager Lite 0.2.0
+
+**Bot Manager** now has new versions for both plans: Bot Manager Lite 0.2.0 and Bot Manager 1.3.0 for the standard plan. The standard plan was formerly named Advanced.
+
+The release adds nine new static rules and two new arguments. The `good_fingerprint_list` argument allows listed fingerprints to bypass Bot Manager validation. The `block_ai_bots` argument blocks known AI user agents automatically.
+
+This release does not upgrade existing installations. To get the new Lite version, launch [Bot Manager Lite](https://console.azion.com/marketplace/solution/azion/bot-manager-lite) through Azion Marketplace. The standard version of [Azion Bot Manager](/en/documentation/products/secure/firewall/bot-manager/) remains available on demand, upon request to the Service Delivery team.
+
+For more information, refer to [Azion Bot Manager Lite](/en/documentation/products/secure/firewall/bot-manager-lite/).
+```
+
+## Relacionados
+
+- [Terminologia da documentação](/pt-br/documentacao/guia-de-estilo/escrita/terminologia/): a isenção de nomes históricos que vale aqui.
+- [Escolher um tipo de conteúdo](/pt-br/documentacao/guia-de-estilo/conteudo/escolher-um-tipo-de-conteudo/): o catálogo completo de tipos de página.

--- a/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/changelog.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/changelog.mdx
@@ -8,6 +8,9 @@ namespace: documentation_style_guide_changelog
 permalink: /documentacao/guia-de-estilo/conteudo/changelog/
 menu_namespace: styleGuideMenu
 ---
+import FrameBox from '@aziontech/webkit/frame-box'
+import ItemList from '@aziontech/webkit/item-list'
+import DocItem from '@aziontech/webkit/doc-item'
 
 ## Propósito
 
@@ -97,5 +100,9 @@ For more information, refer to [Azion Bot Manager Lite](/en/documentation/produc
 
 ## Relacionados
 
-- [Terminologia da documentação](/pt-br/documentacao/guia-de-estilo/escrita/terminologia/): a isenção de nomes históricos que vale aqui.
-- [Escolher um tipo de conteúdo](/pt-br/documentacao/guia-de-estilo/conteudo/escolher-um-tipo-de-conteudo/): o catálogo completo de tipos de página.
+<FrameBox>
+<ItemList>
+  <DocItem title="Terminologia da documentação" href="/pt-br/documentacao/guia-de-estilo/escrita/terminologia/">A isenção de nomes históricos que vale aqui.</DocItem>
+  <DocItem title="Escolher um tipo de conteúdo" href="/pt-br/documentacao/guia-de-estilo/conteudo/escolher-um-tipo-de-conteudo/">O catálogo completo de tipos de página.</DocItem>
+</ItemList>
+</FrameBox>

--- a/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/conceito.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/conceito.mdx
@@ -8,6 +8,9 @@ namespace: documentation_style_guide_concept
 permalink: /documentacao/guia-de-estilo/conteudo/conceito/
 menu_namespace: styleGuideMenu
 ---
+import FrameBox from '@aziontech/webkit/frame-box'
+import ItemList from '@aziontech/webkit/item-list'
+import DocItem from '@aziontech/webkit/doc-item'
 
 ## Propósito
 
@@ -45,7 +48,7 @@ O título é `Como <X> funciona`, `Sobre <X>` ou uma frase nominal curta: `Como 
 - **Frase-roteiro**: a introdução termina com uma frase que nomeia os mecanismos que as seções `##` cobrem, na ordem.
 - **Seções de mecanismo**: uma seção `##` em frase nominal por mecanismo, espelhando a frase-roteiro.
 - **O problema, o mecanismo e o trade-off**: cada seção cobre os três. Uma explicação que apresenta só vantagens é marketing.
-- **Recursos relacionados**: um fechamento `## Recursos relacionados` com a página de referência e os guias how-to que aplicam o conceito.
+- **Recursos relacionados**: um fechamento `## Recursos relacionados`, uma lista de `DocItem` com a página de referência e os guias how-to que aplicam o conceito, cada linha com seu motivo.
 
 **Componentes opcionais**
 
@@ -57,7 +60,11 @@ O título é `Como <X> funciona`, `Sobre <X>` ou uma frase nominal curta: `Como 
 
 Copie o template e substitua cada `<placeholder>`:
 
-```md
+```mdx
+import FrameBox from '@aziontech/webkit/frame-box'
+import ItemList from '@aziontech/webkit/item-list'
+import DocItem from '@aziontech/webkit/doc-item'
+
 <Uma declaração de como o sistema se comporta.>
 <Uma frase-roteiro que nomeia os mecanismos que as
 seções cobrem, na ordem.>
@@ -73,8 +80,12 @@ ele se comporta e o que ele custa.>
 
 ## Recursos relacionados
 
-- [<A página de referência>](/caminho/) - <o que o leitor encontra lá>
-- [<O guia how-to que aplica o conceito>](/caminho/) - <por que o leitor seguiria o link>
+<FrameBox>
+<ItemList>
+  <DocItem title="<A página de referência>" href="/caminho/"><o que o leitor encontra lá></DocItem>
+  <DocItem title="<O guia how-to que aplica o conceito>" href="/caminho/"><por que o leitor seguiria o link></DocItem>
+</ItemList>
+</FrameBox>
 ```
 
 ## Regras
@@ -107,7 +118,11 @@ End users send requests to Azion's distributed network, where content is cached.
 
 ## Relacionados
 
-- [Páginas de arquitetura](/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura/): a mesma forma base, para um design que atravessa produtos.
-- [Referência](/pt-br/documentacao/guia-de-estilo/conteudo/referencia/): onde as configurações e os limites pertencem.
-- [Guias how-to](/pt-br/documentacao/guia-de-estilo/conteudo/guias-how-to/): onde os passos pertencem.
-- [Escolher um tipo de conteúdo](/pt-br/documentacao/guia-de-estilo/conteudo/escolher-um-tipo-de-conteudo/): o catálogo completo de tipos de página.
+<FrameBox>
+<ItemList>
+  <DocItem title="Páginas de arquitetura" href="/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura/">A mesma forma base, para um design que atravessa produtos.</DocItem>
+  <DocItem title="Referência" href="/pt-br/documentacao/guia-de-estilo/conteudo/referencia/">Onde as configurações e os limites pertencem.</DocItem>
+  <DocItem title="Guias how-to" href="/pt-br/documentacao/guia-de-estilo/conteudo/guias-how-to/">Onde os passos pertencem.</DocItem>
+  <DocItem title="Escolher um tipo de conteúdo" href="/pt-br/documentacao/guia-de-estilo/conteudo/escolher-um-tipo-de-conteudo/">O catálogo completo de tipos de página.</DocItem>
+</ItemList>
+</FrameBox>

--- a/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/conceito.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/conceito.mdx
@@ -1,0 +1,113 @@
+---
+title: Páginas de conceito
+description: >-
+  Escreva uma página de conceito: explique por que algo funciona assim, nomeie
+  as alternativas e declare o trade-off.
+meta_tags: 'style guide, concept, explanation'
+namespace: documentation_style_guide_concept
+permalink: /documentacao/guia-de-estilo/conteudo/conceito/
+menu_namespace: styleGuideMenu
+---
+
+## Propósito
+
+Uma página de conceito constrói entendimento. O leitor não está no meio de uma tarefa; ele quer entender como algo funciona e por que é construído assim, normalmente antes de decidir usar.
+
+Ela aplica a forma base de **explicação**, uma das quatro formas do Diátaxis. Quando um design combina vários produtos, escreva uma [página de arquitetura](/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura/): é a mesma forma base, com diagrama e dataflow.
+
+## Quando usar
+
+Escreva uma página de conceito quando:
+
+- O leitor quer a razão de o produto funcionar assim, e não os passos.
+- Um guia how-to ganha um preâmbulo longo, ou uma página de referência para para justificar um design.
+- A página precisa comparar alternativas e nomear um trade-off.
+
+Não escreva uma página de conceito quando:
+
+- O leitor precisa consultar um valor, um campo ou um limite. Escreva uma [página de referência](/pt-br/documentacao/guia-de-estilo/conteudo/referencia/).
+- O leitor precisa de passos para uma tarefa. Escreva um [guia how-to](/pt-br/documentacao/guia-de-estilo/conteudo/guias-how-to/) ou um [tutorial](/pt-br/documentacao/guia-de-estilo/conteudo/tutoriais/).
+- O assunto é como vários produtos formam um design. Escreva uma [página de arquitetura](/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura/).
+
+Este é o tipo de página que mais falta. Quando outro tipo começa a explicar, escreva a página de conceito e mantenha aquele tipo limpo.
+
+## Registro
+
+Descritivo: 25 palavras por frase, voz ativa, passiva apenas quando o agente é genuinamente desconhecido ou é a própria plataforma. Tom: explicativo, descritivo, equilibrado, paciente. [Estrutura de frases](/pt-br/documentacao/guia-de-estilo/escrita/estrutura-de-frases/) tem as regras.
+
+## Estrutura
+
+O título é `Como <X> funciona`, `Sobre <X>` ou uma frase nominal curta: `Como o Tiered Cache funciona`.
+
+**Componentes obrigatórios**
+
+- **Abertura**: uma declaração de como o sistema se comporta, nos termos do leitor antes de nomear qualquer objeto da Azion. Nunca `Esta página explica`.
+- **Frase-roteiro**: a introdução termina com uma frase que nomeia os mecanismos que as seções `##` cobrem, na ordem.
+- **Seções de mecanismo**: uma seção `##` em frase nominal por mecanismo, espelhando a frase-roteiro.
+- **O problema, o mecanismo e o trade-off**: cada seção cobre os três. Uma explicação que apresenta só vantagens é marketing.
+- **Recursos relacionados**: um fechamento `## Recursos relacionados` com a página de referência e os guias how-to que aplicam o conceito.
+
+**Componentes opcionais**
+
+- **Termos principais**: o vocabulário que o leitor precisa, definido uma vez cada.
+- **Alternativas**: as outras formas de resolver o problema, e o que cada uma abre mão.
+- **Um diagrama**: quando a relação é mais fácil de desenhar do que de descrever. Desenhe como um bloco de código `mermaid`, e rotule cada nó com palavras.
+
+## Template
+
+Copie o template e substitua cada `<placeholder>`:
+
+```md
+<Uma declaração de como o sistema se comporta.>
+<Uma frase-roteiro que nomeia os mecanismos que as
+seções cobrem, na ordem.>
+
+## <Frase nominal que nomeia o primeiro mecanismo>
+
+<O problema contra o qual este mecanismo trabalha, como
+ele se comporta e o que ele custa.>
+
+## <Frase nominal que nomeia o próximo mecanismo>
+
+<...>
+
+## Recursos relacionados
+
+- [<A página de referência>](/caminho/) - <o que o leitor encontra lá>
+- [<O guia how-to que aplica o conceito>](/caminho/) - <por que o leitor seguiria o link>
+```
+
+## Regras
+
+- **Abra com comportamento, não com moldura.** Declare como o sistema se comporta; nunca `Esta página explica`.
+- **Explique a coisa antes do objeto da Azion.** `Cache stores a copy of a response on the edge node that fetched it. The edge node answers later requests for the same object from that copy, without reaching the origin.` Só depois os objetos que a realizam. Uma abertura em que todo sujeito é um produto ou objeto da Azion é um inventário, não uma explicação.
+- **Espelhe a frase-roteiro.** Uma seção `##` em frase nominal por mecanismo, na ordem em que a frase-roteiro os nomeia. Uma seção cortada da página é cortada da frase-roteiro na mesma edição.
+- **Declare o trade-off.** Toda escolha de design custa algo, então diga o quê. Uma explicação que apresenta só vantagens é marketing.
+- **Sem procedimentos.** Aponte o [guia how-to](/pt-br/documentacao/guia-de-estilo/conteudo/guias-how-to/) que aplica o conceito.
+- **Mantenha as alternativas aqui.** Alternativas e "em vez de" vivem nas páginas de conceito e em nenhum outro lugar.
+- **Use a voz passiva de forma restrita.** Apenas quando o agente é genuinamente desconhecido ou é a própria plataforma.
+- **Faça os diagramas carregarem significado, e desenhe em `mermaid`.** Um diagrama em texto alcança um agente que lê o gêmeo em markdown; uma imagem não. Diga em prosa o que o diagrama mostra, e nunca dependa apenas de cor.
+- **Discuta, não enumere.** Uma página que vira tabela de campos quer ser [referência](/pt-br/documentacao/guia-de-estilo/conteudo/referencia/).
+- **Defina cada termo uma vez**, onde o leitor o encontra primeiro, e depois aponte para ele.
+- **Evite afirmações que expiram.** `Atualmente` e `em breve` envelhecem mal e ninguém volta.
+
+## Exemplos
+
+Este exemplo, em inglês, mostra a abertura, a frase-roteiro e a primeira seção de mecanismo de uma página de conceito sobre o Tiered Cache:
+
+```mdx
+**Tiered Cache** is a Cache module that creates an additional cache layer between Azion's distributed network and the origin servers. With the module active, content stays cached for longer periods and the origin receives fewer requests. Tiered Cache is designed for objects that can remain in cache for a long period of time. The module is available on request: activation goes through the Sales team.
+
+Its behavior depends on five mechanisms: the cache layers, the second-layer region, the TTL requirements, the Bypass Cache limitation, and the purge order.
+
+## Cache layers
+
+End users send requests to Azion's distributed network, where content is cached. Without Tiered Cache, a request that misses the first cache layer goes to the origin. Tiered Cache adds a second cache layer between that first layer and the origin servers. The tiered layer can answer a request that misses the first layer, so the request does not reach the origin. Content stays cached for longer periods, and the origin receives fewer requests.
+```
+
+## Relacionados
+
+- [Páginas de arquitetura](/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura/): a mesma forma base, para um design que atravessa produtos.
+- [Referência](/pt-br/documentacao/guia-de-estilo/conteudo/referencia/): onde as configurações e os limites pertencem.
+- [Guias how-to](/pt-br/documentacao/guia-de-estilo/conteudo/guias-how-to/): onde os passos pertencem.
+- [Escolher um tipo de conteúdo](/pt-br/documentacao/guia-de-estilo/conteudo/escolher-um-tipo-de-conteudo/): o catálogo completo de tipos de página.

--- a/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/escolher-um-tipo-de-conteudo.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/escolher-um-tipo-de-conteudo.mdx
@@ -1,0 +1,123 @@
+---
+title: Escolher um tipo de conteúdo
+description: >-
+  Escolha um tipo de conteúdo: as quatro formas base, o catálogo completo de
+  tipos de página construídos a partir delas e os testes que os separam.
+meta_tags: 'style guide, content types, diataxis'
+namespace: documentation_style_guide_choose_content_type
+permalink: /documentacao/guia-de-estilo/conteudo/escolher-um-tipo-de-conteudo/
+menu_namespace: styleGuideMenu
+---
+
+## Escolha a forma pelo objetivo do leitor
+
+Toda página de documentação é escrita em uma de quatro formas base, do Diátaxis. A forma decide a estrutura da página e as suas [regras de frase](/pt-br/documentacao/guia-de-estilo/escrita/estrutura-de-frases/). Escolha a forma pelo que o leitor quer fazer, não pelo que você quer escrever.
+
+| O leitor quer | A forma é |
+| --- | --- |
+| Aprender o produto ao construir algo que funciona | [Tutorial](/pt-br/documentacao/guia-de-estilo/conteudo/tutoriais/) |
+| Realizar uma tarefa específica que já tem em mente | [Guia how-to](/pt-br/documentacao/guia-de-estilo/conteudo/guias-how-to/) |
+| Consultar um fato: um limite, um campo, um flag, um código de resposta | [Referência](/pt-br/documentacao/guia-de-estilo/conteudo/referencia/) |
+| Entender por que algo funciona do jeito que funciona | Explicação, como página de [conceito](/pt-br/documentacao/guia-de-estilo/conteudo/conceito/) ou [arquitetura](/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura/) |
+
+As formas respondem "como escrevo esta página". O catálogo de tipos de página responde "qual página eu construo".
+
+## Os tipos de página
+
+Um tipo de página é uma forma base mais um lugar na [arquitetura de informação](/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura-de-informacao/) e um template. Este é o catálogo completo. Toda página da documentação é um destes tipos.
+
+| Tipo | Forma base | Obrigatório por produto | Propósito |
+| --- | --- | --- | --- |
+| [Visão geral](/pt-br/documentacao/guia-de-estilo/conteudo/visao-geral/) | Referência | Sim | A raiz do produto: o que o produto é, o que faz, quando usar |
+| [Quickstart](/pt-br/documentacao/guia-de-estilo/conteudo/quickstart/) | Tutorial | Sim | De não usar o produto ao menor resultado funcional |
+| [Tutorial](/pt-br/documentacao/guia-de-estilo/conteudo/tutoriais/) | Tutorial | Não | Ensinar o produto ao construir um objetivo que o autor escolheu |
+| [Guia how-to](/pt-br/documentacao/guia-de-estilo/conteudo/guias-how-to/) | How-to | Não | Completar uma tarefa com a qual o leitor chegou |
+| [Guia multiproduto](/pt-br/documentacao/guia-de-estilo/conteudo/guias-multiproduto/) | How-to | Não | Alcançar um objetivo que cruza produtos, em um caminho recomendado |
+| [Caso de uso](/pt-br/documentacao/guia-de-estilo/conteudo/casos-de-uso/) | How-to | Não | Implementar um cenário de negócio do início ao fim, como uma spec que um agente segue |
+| [Troubleshooting](/pt-br/documentacao/guia-de-estilo/conteudo/troubleshooting/) | How-to | Não | De um sintoma que o leitor vê a um conserto |
+| [Referência](/pt-br/documentacao/guia-de-estilo/conteudo/referencia/) | Referência | Não | Consultar campos, valores, padrões e limites |
+| [Conceito](/pt-br/documentacao/guia-de-estilo/conteudo/conceito/) | Explicação | Não | Entender como algo funciona e por que é construído assim |
+| [Arquitetura](/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura/) | Explicação | Não | Como produtos se combinam em um design |
+| [Changelog](/pt-br/documentacao/guia-de-estilo/conteudo/changelog/) | Registro | Não | Registrar mudanças notáveis, somente por acréscimo |
+| [Glossário](/pt-br/documentacao/guia-de-estilo/conteudo/glossario/) | Referência | Sim | Definir os termos que a documentação do produto usa, em uma tabela filtrável |
+| [Hub de navegação](/pt-br/documentacao/guia-de-estilo/conteudo/hubs-de-navegacao/) | Nenhuma | Não | Direcionar leitores para dentro. Links mais uma frase de orientação |
+
+## Slots não são tipos
+
+Um slot é uma posição na seção de produto; um tipo é o formato de uma página. A [arquitetura de informação](/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura-de-informacao/) lista treze slots, e este catálogo tem treze tipos. O tamanho igual é coincidência: as duas listas não se mapeiam uma na outra.
+
+Vários slots compartilham um tipo. Limites, Exemplos e Features e capacidades contêm páginas de referência, colocadas em slots diferentes porque o leitor chega a elas em momentos diferentes. Best practices e Como funciona contêm páginas de conceito. Um slot também pode conter vários tipos: Guias e tutoriais contém um hub de navegação, os guias how-to e os tutoriais. Adicionar um slot nunca adiciona um tipo, e uma página que não cabe em nenhum tipo é uma página cujo tipo de conteúdo ainda não foi decidido.
+
+## Tipos que a Azion não usa
+
+Alguns tipos comuns em outras documentações estão ausentes de propósito, porque cada um se dissolve no catálogo:
+
+- **FAQ**: uma lista de perguntas é uma lista de páginas disfarçada. Direcione cada resposta ao seu tipo, e a pergunta vira um heading que a busca encontra.
+- **Configuration**: exemplos de configurações e valores são conteúdo de referência. O tipo adiciona um segundo nome para a mesma página.
+- **Guias de design, implementação e solução**: três nomes para conteúdo que o catálogo já tem. Um objetivo que cruza produtos é um [guia multiproduto](/pt-br/documentacao/guia-de-estilo/conteudo/guias-multiproduto/). Um cenário de negócio construído do início ao fim é um [caso de uso](/pt-br/documentacao/guia-de-estilo/conteudo/casos-de-uso/). O raciocínio por trás de um design é uma página de [conceito](/pt-br/documentacao/guia-de-estilo/conteudo/conceito/) ou de [arquitetura](/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura/).
+- **Guia de integração com terceiros**: um guia how-to que cruza a interface de um fornecedor. As [regras de terceiros](/pt-br/documentacao/guia-de-estilo/conteudo/guias-how-to/) cobrem esse caso.
+- **Diretrizes de API** ainda não são cobertas por este guia.
+
+## Separe tutoriais de guias how-to
+
+Tutoriais e guias how-to contêm passos. Eles servem leitores opostos, e essa é a distinção que mais importa.
+
+O leitor de tutorial ainda não sabe o que quer. Ele aprende, e você ensina. Você escolhe o objetivo, garante o resultado e mantém as decisões longe do leitor. "Faça o deploy da sua primeira aplicação" é um tutorial: o leitor não tem uma aplicação em mente, e qualquer aplicação serve.
+
+O leitor de how-to já sabe o que quer. Ele chegou com um problema. Você remove obstáculos; você não ensina. "Configurar políticas de cache" é um how-to: o leitor tem um problema de cache e quer o problema resolvido.
+
+Dois testes separam as formas na prática. Se você escreve "você também pode" ou "dependendo da sua configuração", a página é um how-to, porque tutoriais não ramificam. Se você interrompe os passos para explicar o que é um bucket, a página é um tutorial ou uma página de conceito, não um how-to.
+
+## Separe referência de conceito
+
+Referência e explicação descrevem; nenhuma das duas formas instrui. Elas diferem no uso: uma é um mapa que o leitor consulta, a outra é uma discussão que o leitor lê.
+
+Referência é o mapa. Ela é completa, consistente e deliberadamente simples. Ninguém lê uma referência de cima a baixo. Se o leitor que procura um valor de limite pula uma frase, essa frase não pertence à página.
+
+Explicação é a discussão. Ela traz contexto, alternativas e razões. É a única forma onde "por quê" e "em vez de" pertencem. Uma decisão de design, uma comparação entre abordagens ou o contexto de uma funcionalidade vivem em uma página de [conceito](/pt-br/documentacao/guia-de-estilo/conteudo/conceito/) ou [arquitetura](/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura/) e em nenhum outro lugar.
+
+## Separe guias multiproduto de casos de uso
+
+As duas formas partem do how-to e as duas cruzam produtos, então vale declarar a divisão.
+
+Um guia multiproduto parte de um objetivo técnico. O leitor sabe o que quer construir e precisa da rota entre os produtos. Ele termina quando a tarefa está feita.
+
+Um caso de uso parte de um cenário de negócio. O leitor chega com uma situação, não com uma tarefa. A página nomeia os produtos que o cenário exige, mostra a arquitetura, configura tudo e prova que funciona. Ele é escrito como uma especificação que um agente executa. É por isso que carrega uma tabela de requisitos e um resultado mensurável, que o guia multiproduto não tem.
+
+O teste: se você consegue declarar o objetivo sem nomear um setor ou uma situação de negócio, é um guia multiproduto.
+
+## Mantenha uma forma por página
+
+Uma página que mistura formas é o defeito estrutural mais comum em documentação. Uma página de referência que para no meio para guiar o leitor pelo Console é duas páginas em um arquivo. O mesmo vale para um how-to que pausa para explicar arquitetura, ou um tutorial que vira uma tabela de parâmetros no meio do caminho.
+
+O teste é barato: leia a página uma vez como cada um dos quatro leitores das formas base. Se dois deles querem metades diferentes, são duas páginas. Divida.
+
+## Conecte as formas entre si
+
+Uma forma por página funciona porque links conectam as páginas. Cada forma aponta em uma direção previsível.
+
+| Uma página desta forma | Aponta para | Quando |
+| --- | --- | --- |
+| Tutorial | Os guias how-to do seu produto | Em uma seção final "Próximos passos" |
+| Guia how-to | Referência | Para cada configuração que os passos tocam |
+| Referência | O guia how-to que muda uma configuração | Com parcimônia: no máximo um link por configuração |
+| Conceito ou arquitetura | A referência e os guias que implementam o design | Onde o design encontra a prática |
+
+Links são bidirecionais. Quando a página A aponta para a página B por uma tarefa, a página B aponta de volta para a página A onde o leitor retorna.
+
+---
+
+## Leia todas as páginas de tipo de conteúdo do mesmo jeito
+
+Cada página desta seção descreve um tipo de conteúdo ou um padrão, e todas usam as mesmas seções na mesma ordem. Quando você sabe onde uma regra fica em uma página, você sabe onde ela fica em todas.
+
+| Seção | Responde |
+| --- | --- |
+| Propósito | O que esse tipo de página faz, e o que ela não é |
+| Quando usar | Quando escrever uma, e quando escrever outra coisa |
+| Registro | Procedural ou descritivo: o limite de frase, e o tom em poucos adjetivos |
+| Estrutura | Os componentes obrigatórios e opcionais |
+| Template | O esqueleto para copiar |
+| Regras | As regras específicas desse tipo de página |
+| Exemplos | Páginas que seguem o padrão |
+| Relacionados | As páginas vizinhas neste guia |

--- a/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/glossario.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/glossario.mdx
@@ -9,6 +9,9 @@ namespace: documentation_style_guide_glossary
 permalink: /documentacao/guia-de-estilo/conteudo/glossario/
 menu_namespace: styleGuideMenu
 ---
+import FrameBox from '@aziontech/webkit/frame-box'
+import ItemList from '@aziontech/webkit/item-list'
+import DocItem from '@aziontech/webkit/doc-item'
 
 ## Propósito
 
@@ -66,7 +69,11 @@ O primeiro glossário de produto é o [glossário do Cache](/pt-br/documentacao/
 
 ## Relacionados
 
-- [Arquitetura de informação](/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura-de-informacao/) - o slot que o glossário preenche em toda seção de produto.
-- [Terminologia da documentação](/pt-br/documentacao/guia-de-estilo/escrita/terminologia/) - as regras de nomes que o glossário nunca repete.
-- [Componentes](/pt-br/documentacao/guia-de-estilo/componentes/) - a mecânica do GlossaryFilter.
-- [Páginas de conceito](/pt-br/documentacao/guia-de-estilo/conteudo/conceito/) - para onde um termo vai quando três frases não bastam.
+<FrameBox>
+<ItemList>
+  <DocItem title="Arquitetura de informação" href="/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura-de-informacao/">O slot que o glossário preenche em toda seção de produto.</DocItem>
+  <DocItem title="Terminologia da documentação" href="/pt-br/documentacao/guia-de-estilo/escrita/terminologia/">As regras de nomes que o glossário nunca repete.</DocItem>
+  <DocItem title="Componentes" href="/pt-br/documentacao/guia-de-estilo/componentes/">A mecânica do GlossaryFilter.</DocItem>
+  <DocItem title="Páginas de conceito" href="/pt-br/documentacao/guia-de-estilo/conteudo/conceito/">Para onde um termo vai quando três frases não bastam.</DocItem>
+</ItemList>
+</FrameBox>

--- a/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/glossario.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/glossario.mdx
@@ -1,0 +1,72 @@
+---
+title: Páginas de glossário
+description: >-
+  Escreva o glossário de um produto com termos específicos da Azion: uma
+  tabela filtrável e alfabética cujas definições apontam as páginas onde o
+  termo é usado.
+meta_tags: 'style guide, glossary, terms, definitions'
+namespace: documentation_style_guide_glossary
+permalink: /documentacao/guia-de-estilo/conteudo/glossario/
+menu_namespace: styleGuideMenu
+---
+
+## Propósito
+
+Um glossário define os termos que a documentação de um produto usa. É material de consulta: o leitor chega com uma palavra, encontra a definição e segue um link quando a definição não basta.
+
+Um glossário guarda o vocabulário específico da Azion: produtos, módulos, objetos da plataforma e os termos que a Azion usa do seu próprio jeito. Um termo genérico da indústria, como CDN, serverless ou virtual machine, pertence ao [Learning Center](https://www.azion.com/pt-br/learning/), não a um glossário da documentação. Um termo que a indústria também usa, mas que a Azion usa de forma diferente, mantém a entrada aqui e aponta o Learning Center para o sentido genérico.
+
+Não é uma página de regras de nomes. Os nomes de produto pertencem à [Terminologia da documentação](/pt-br/documentacao/guia-de-estilo/escrita/terminologia/); o glossário define o que os termos significam para o leitor.
+
+## Quando usar
+
+Toda seção de produto carrega um glossário, um slot obrigatório do [esqueleto da seção de produto](/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura-de-informacao/). Escreva o glossário quando a seção é construída, e estenda quando uma página introduz um termo que o leitor precisa dominar para acompanhar a prosa.
+
+Não escreva uma entrada para um termo que nenhuma página usa. Não escreva uma entrada para um termo genérico da indústria: aponte o artigo do [Learning Center](https://www.azion.com/pt-br/learning/) na página que precisa dele. Não use o glossário para explicar em profundidade. Um termo que precisa de mais de três frases precisa de uma [página de conceito](/pt-br/documentacao/guia-de-estilo/conteudo/conceito/), e a definição aponta para ela.
+
+## Registro
+
+Descritivo: 25 palavras por frase. O tom é neutro e lexicográfico: uma definição diz o que o termo é, sem vender e sem história.
+
+## Estrutura
+
+- Uma frase de orientação nomeando o produto cujos termos a página define.
+- Um componente `<GlossaryFilter>` envolvendo uma tabela GFM, `| Termo | Definição |`. O componente adiciona a caixa de filtro e dá a cada linha uma âncora derivada do termo (`#cache-key`). Mecânica em [Componentes](/pt-br/documentacao/guia-de-estilo/componentes/).
+- Nenhuma seção de fechamento. A tabela é a página.
+
+## Template
+
+```mdx
+import GlossaryFilter from '~/components/GlossaryFilter.astro'
+
+Definições dos termos que a documentação de **<Produto>** usa.
+
+<GlossaryFilter lang="pt-br">
+
+| Termo | Definição |
+| --- | --- |
+| <termo> | <O que o termo é, em uma a três frases, apontando a página canônica no próprio texto.> |
+
+</GlossaryFilter>
+```
+
+## Regras
+
+- **As linhas ordenam alfabeticamente pelo termo, por idioma.** A página em português alfabetiza pelo termo em português; termos da lista que fica em inglês mantêm a forma inglesa e ordenam por ela.
+- **Um termo fica em minúscula**, a menos que seja um nome de produto ou outro nome próprio.
+- **Uma definição tem de uma a três frases**, e a primeira diz o que o termo é. Aponte a página canônica no próprio texto da definição.
+- **Toda definição corresponde a uma página da documentação.** O glossário registra como a documentação usa um termo; ele nunca introduz um.
+- **O glossário é uma estrutura de crosslinks.** Cada definição aponta sua página canônica no próprio texto e as páginas onde o leitor encontra o termo. Toda entrada mantém um caminho de volta para a documentação.
+- **Mover uma entrada nunca quebra um crosslink.** Quando uma entrada migra para o Learning Center, toda página que apontava a entrada recebe o novo destino na mesma mudança.
+- **Linhas em branco ao redor da tabela dentro do componente são obrigatórias**, ou a tabela renderiza como um único parágrafo literal.
+
+## Exemplos
+
+O primeiro glossário de produto é o [glossário do Cache](/pt-br/documentacao/build/cache/glossario/): doze termos, cada definição apontando sua página canônica.
+
+## Relacionados
+
+- [Arquitetura de informação](/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura-de-informacao/) - o slot que o glossário preenche em toda seção de produto.
+- [Terminologia da documentação](/pt-br/documentacao/guia-de-estilo/escrita/terminologia/) - as regras de nomes que o glossário nunca repete.
+- [Componentes](/pt-br/documentacao/guia-de-estilo/componentes/) - a mecânica do GlossaryFilter.
+- [Páginas de conceito](/pt-br/documentacao/guia-de-estilo/conteudo/conceito/) - para onde um termo vai quando três frases não bastam.

--- a/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/guias-how-to.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/guias-how-to.mdx
@@ -1,0 +1,137 @@
+---
+title: Guias how-to
+description: >-
+  Escreva um guia how-to: comece pelo resultado, remova obstáculos em vez de
+  ensinar e mantenha cada passo com uma instrução imperativa.
+meta_tags: 'style guide, how-to'
+namespace: documentation_style_guide_how_to_guides
+permalink: /documentacao/guia-de-estilo/conteudo/guias-how-to/
+menu_namespace: styleGuideMenu
+---
+
+## Propósito
+
+Um guia how-to leva um leitor com um problema até o problema resolvido. O leitor já sabe o que quer. A página remove os obstáculos entre ele e o resultado; ela não ensina.
+
+## Quando usar
+
+- O leitor chegou com uma tarefa específica e uma situação real.
+- Não use um how-to para o leitor que está aprendendo o produto: essa página é um [tutorial](/pt-br/documentacao/guia-de-estilo/conteudo/tutoriais/).
+- Um how-to cuja tarefa é um conserto é uma [página de troubleshooting](/pt-br/documentacao/guia-de-estilo/conteudo/troubleshooting/).
+- Na dúvida, [Escolher um tipo de conteúdo](/pt-br/documentacao/guia-de-estilo/conteudo/escolher-um-tipo-de-conteudo/) tem o roteiro.
+
+## Registro
+
+Procedural: 20 palavras por frase, uma instrução por passo, imperativo e ativo. Tom: diretivo, claro, eficiente. [Estrutura de frases](/pt-br/documentacao/guia-de-estilo/escrita/estrutura-de-frases/) tem as regras.
+
+## Estrutura
+
+**Componentes obrigatórios**
+
+- **Frase de escopo**: a abertura declara, em uma frase, o que a página permite ao leitor fazer e a partir de onde. Nunca `Neste guia`.
+- **Pré-requisitos**: uma seção `## Pré-requisitos` quando a página tem algum, em lista; cada item é um link ou um comando de uma linha. Um único pré-requisito é uma frase, não uma lista.
+- **Seções de tarefa**: um `##` por tarefa, cada um uma frase verbal no imperativo.
+- **Lead-in**: logo antes de cada procedimento, uma frase terminada em dois-pontos, como `Para criar o bucket:`.
+- **Frase de resultado**: todo procedimento termina declarando o que o leitor agora tem ou vê.
+- **Próximos passos**: uma seção final `## Próximos passos` com um ou dois links em lista, cada um no formato `[Título](/caminho/) - motivo`.
+
+**Componentes opcionais**
+
+- **Tabs por interface**: um bloco `<Tabs>` quando uma tarefa roda em mais de uma interface, painel do Console primeiro, um procedimento completo por painel.
+- **Um aside** com o caminho alternativo, quando a tarefa genuinamente ramifica.
+
+## Template
+
+Copie o template e substitua cada `<placeholder>`.
+
+```md
+[Uma frase de escopo: o que a página permite ao leitor
+fazer, e a partir de onde.]
+
+## Pré-requisitos
+
+- <Um link ou um comando de uma linha por item>
+
+---
+
+## <Frase verbal no imperativo que nomeia a tarefa>
+
+Para <alcançar o resultado da tarefa>:
+
+1. <Uma instrução imperativa.>
+2. <Uma instrução imperativa.>
+
+<O resultado: o que o leitor agora tem ou vê.>
+
+---
+
+## <Próxima tarefa, se a página cobre uma sequência>
+
+---
+
+## Próximos passos
+
+- [<Título>](/caminho/) - <por que o leitor seguiria o link>
+```
+
+Separe as seções principais da página com uma régua `---`, e nunca coloque uma logo depois do frontmatter.
+
+## Regras
+
+- **Nomeie a tarefa no título.** Uma frase verbal curta no imperativo: `Criar um bucket`, `Alterar as permissões de um bucket`. Não um gerúndio, não uma pergunta, não um prefixo `Como ...` — o verbo carrega o título. O prefixo está aposentado em páginas novas e reescritas.
+- **Abra com uma frase de escopo.** Declare o que a página permite ao leitor fazer e a partir de onde: `Você pode criar um bucket pelo Azion Console, pela Azion CLI ou pela API.`
+- **Uma tarefa por heading.** Um heading que cobre duas tarefas vira dois headings.
+- **Acrescente informação depois de cada heading.** A primeira frase de uma seção de tarefa deve acrescentar informação que o heading não dá; o lead-in carrega a seção.
+- **Siga as regras de passos.** Os passos seguem [Procedimentos](/pt-br/documentacao/guia-de-estilo/escrita/procedimentos/), e todo procedimento termina com sua frase de resultado.
+- **Mostre o output depois de cada comando.** O leitor vê como o sucesso se parece antes que o próximo passo dependa dele. A regra está em [Procedimentos](/pt-br/documentacao/guia-de-estilo/escrita/procedimentos/).
+- **Ramifique onde a tarefa ramifica.** Tarefas com mais de uma interface usam um bloco `<Tabs>`, painel do Console primeiro — nunca seções sequenciais por interface.
+- **Não ensine.** Uma frase de contexto, depois os passos. Um parágrafo de contexto pertence a uma página de conceito; aponte para ela.
+- **Use um verbo por ação**, em todas as menções da página.
+- **Aponte para os vizinhos.** Guias how-to irmãos e a página de referência do produto, no corpo ou em `## Próximos passos`.
+- **Mande um objetivo que cruza produtos** para um [guia multiproduto](/pt-br/documentacao/guia-de-estilo/conteudo/guias-multiproduto/).
+- **Aponte para fora em produtos de terceiros.** Nomeie o passo do fornecedor; não documente a interface dele.
+
+## Exemplos
+
+O trecho a seguir mostra a frase de escopo, os pré-requisitos e o painel do Console da primeira tarefa:
+
+```mdx
+Você pode criar um bucket do [Object Storage](/pt-br/documentacao/produtos/store/object-storage/) e alterar as permissões pelo Azion Console, pela CLI ou pela API.
+
+## Pré-requisitos
+
+Para usar os procedimentos da CLI, você precisa da Azion CLI instalada e de um personal token configurado.
+
+---
+
+## Criar um bucket
+
+<Tabs client:visible>
+    <Fragment slot="tab.console">Console</Fragment>
+    <Fragment slot="tab.cli">CLI</Fragment>
+    <Fragment slot="tab.api">API</Fragment>
+
+<Fragment slot="panel.console">
+
+Para criar o bucket pelo Azion Console:
+
+1. Acesse [Azion Console](https://console.azion.com/) > **Object Storage**.
+2. Selecione **+ Bucket**.
+3. Digite um **Bucket Name** de 6 a 63 caracteres.
+4. Defina **Workloads Access** como _Read Only_, _Read-Write_ ou _Restricted_.
+5. Selecione **Save**.
+
+O bucket aparece na lista de buckets.
+
+</Fragment>
+
+</Tabs>
+```
+
+- [Crie regras de request e response](/pt-br/documentacao/build/applications/guides/rules-engine/): duas tarefas em uma página, cada uma com passos numerados e imperativos.
+
+## Relacionados
+
+- [Tutoriais](/pt-br/documentacao/guia-de-estilo/conteudo/tutoriais/): a página para o leitor que está aprendendo.
+- [Páginas de troubleshooting](/pt-br/documentacao/guia-de-estilo/conteudo/troubleshooting/): o how-to cuja tarefa é um conserto.
+- [Referência](/pt-br/documentacao/guia-de-estilo/conteudo/referencia/): onde cada configuração que um guia toca está documentada.

--- a/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/guias-how-to.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/guias-how-to.mdx
@@ -8,6 +8,9 @@ namespace: documentation_style_guide_how_to_guides
 permalink: /documentacao/guia-de-estilo/conteudo/guias-how-to/
 menu_namespace: styleGuideMenu
 ---
+import FrameBox from '@aziontech/webkit/frame-box'
+import ItemList from '@aziontech/webkit/item-list'
+import DocItem from '@aziontech/webkit/doc-item'
 
 ## Propósito
 
@@ -33,7 +36,7 @@ Procedural: 20 palavras por frase, uma instrução por passo, imperativo e ativo
 - **Seções de tarefa**: um `##` por tarefa, cada um uma frase verbal no imperativo.
 - **Lead-in**: logo antes de cada procedimento, uma frase terminada em dois-pontos, como `Para criar o bucket:`.
 - **Frase de resultado**: todo procedimento termina declarando o que o leitor agora tem ou vê.
-- **Próximos passos**: uma seção final `## Próximos passos` com um ou dois links em lista, cada um no formato `[Título](/caminho/) - motivo`.
+- **Próximos passos**: uma seção final `## Próximos passos`, um `DocCardGroup` com um ou dois cards: o título, o link e o motivo como texto do card.
 
 **Componentes opcionais**
 
@@ -44,7 +47,10 @@ Procedural: 20 palavras por frase, uma instrução por passo, imperativo e ativo
 
 Copie o template e substitua cada `<placeholder>`.
 
-```md
+```mdx
+import DocCardGroup from '@aziontech/webkit/doc-card-group'
+import DocCard from '@aziontech/webkit/doc-card'
+
 [Uma frase de escopo: o que a página permite ao leitor
 fazer, e a partir de onde.]
 
@@ -71,7 +77,9 @@ Para <alcançar o resultado da tarefa>:
 
 ## Próximos passos
 
-- [<Título>](/caminho/) - <por que o leitor seguiria o link>
+<DocCardGroup cols={2}>
+  <DocCard title="<Título>" href="/caminho/" label="<por que o leitor seguiria o link>" />
+</DocCardGroup>
 ```
 
 Separe as seções principais da página com uma régua `---`, e nunca coloque uma logo depois do frontmatter.
@@ -132,6 +140,10 @@ O bucket aparece na lista de buckets.
 
 ## Relacionados
 
-- [Tutoriais](/pt-br/documentacao/guia-de-estilo/conteudo/tutoriais/): a página para o leitor que está aprendendo.
-- [Páginas de troubleshooting](/pt-br/documentacao/guia-de-estilo/conteudo/troubleshooting/): o how-to cuja tarefa é um conserto.
-- [Referência](/pt-br/documentacao/guia-de-estilo/conteudo/referencia/): onde cada configuração que um guia toca está documentada.
+<FrameBox>
+<ItemList>
+  <DocItem title="Tutoriais" href="/pt-br/documentacao/guia-de-estilo/conteudo/tutoriais/">A página para o leitor que está aprendendo.</DocItem>
+  <DocItem title="Páginas de troubleshooting" href="/pt-br/documentacao/guia-de-estilo/conteudo/troubleshooting/">O how-to cuja tarefa é um conserto.</DocItem>
+  <DocItem title="Referência" href="/pt-br/documentacao/guia-de-estilo/conteudo/referencia/">Onde cada configuração que um guia toca está documentada.</DocItem>
+</ItemList>
+</FrameBox>

--- a/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/guias-multiproduto.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/guias-multiproduto.mdx
@@ -8,6 +8,9 @@ namespace: documentation_style_guide_multi_product_guides
 permalink: /documentacao/guia-de-estilo/conteudo/guias-multiproduto/
 menu_namespace: styleGuideMenu
 ---
+import FrameBox from '@aziontech/webkit/frame-box'
+import ItemList from '@aziontech/webkit/item-list'
+import DocItem from '@aziontech/webkit/doc-item'
 
 ## Propósito
 
@@ -41,7 +44,7 @@ Procedural: 20 palavras por frase, uma instrução por passo, imperativo e ativo
 - **Pré-requisitos**: uma seção `## Pré-requisitos`, em lista; cada item é um link ou um comando de uma linha. Um único pré-requisito é uma frase, não uma lista.
 - **Etapas**: um `##` por etapa do fluxo, nunca por produto, cada um com um heading imperativo que nomeia a etapa. Cada etapa nomeia seu produto na entrada, contém um procedimento comum e se sustenta sozinha.
 - **Frase de resultado**: todo procedimento termina declarando o que o leitor agora tem ou vê.
-- **Próximos passos**: uma seção final `## Próximos passos` com links em lista, cada um no formato `[Título](/caminho/) - motivo`.
+- **Próximos passos**: uma seção final `## Próximos passos`, um `DocCardGroup` com um card por destino: o título, o link e o motivo como texto do card.
 
 **Componentes opcionais**
 
@@ -52,7 +55,10 @@ Procedural: 20 palavras por frase, uma instrução por passo, imperativo e ativo
 
 Copie o template e substitua cada `<placeholder>`.
 
-```md
+```mdx
+import DocCardGroup from '@aziontech/webkit/doc-card-group'
+import DocCard from '@aziontech/webkit/doc-card'
+
 [Uma ou duas frases: o problema primeiro, depois os
 produtos, pelo papel.]
 
@@ -81,7 +87,9 @@ Para <alcançar o resultado da etapa>:
 
 ## Próximos passos
 
-- [<Título>](/caminho/) - <por que o leitor seguiria o link>
+<DocCardGroup cols={2}>
+  <DocCard title="<Título>" href="/caminho/" label="<por que o leitor seguiria o link>" />
+</DocCardGroup>
 ```
 
 Separe as seções principais da página com uma régua `---`, e nunca coloque uma logo depois do frontmatter.
@@ -127,7 +135,11 @@ The Application Accelerator module is enabled for the application.
 
 ## Relacionados
 
-- [Guias how-to](/pt-br/documentacao/guia-de-estilo/conteudo/guias-how-to/): a forma base que este tipo aplica.
-- [Páginas de arquitetura](/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura/): a página que descreve o design que este guia constrói.
-- [Arquitetura de informação](/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura-de-informacao/): onde fica um guia que não pertence a nenhuma seção de produto.
-- [Escolher um tipo de conteúdo](/pt-br/documentacao/guia-de-estilo/conteudo/escolher-um-tipo-de-conteudo/): o catálogo completo de tipos de página.
+<FrameBox>
+<ItemList>
+  <DocItem title="Guias how-to" href="/pt-br/documentacao/guia-de-estilo/conteudo/guias-how-to/">A forma base que este tipo aplica.</DocItem>
+  <DocItem title="Páginas de arquitetura" href="/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura/">A página que descreve o design que este guia constrói.</DocItem>
+  <DocItem title="Arquitetura de informação" href="/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura-de-informacao/">Onde fica um guia que não pertence a nenhuma seção de produto.</DocItem>
+  <DocItem title="Escolher um tipo de conteúdo" href="/pt-br/documentacao/guia-de-estilo/conteudo/escolher-um-tipo-de-conteudo/">O catálogo completo de tipos de página.</DocItem>
+</ItemList>
+</FrameBox>

--- a/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/guias-multiproduto.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/guias-multiproduto.mdx
@@ -1,0 +1,133 @@
+---
+title: Guias multiproduto
+description: >-
+  Escreva um guia para um objetivo que atravessa produtos: um caminho
+  recomendado, organizado por etapa do fluxo e não por produto.
+meta_tags: 'style guide, multi-product guide, solution guide'
+namespace: documentation_style_guide_multi_product_guides
+permalink: /documentacao/guia-de-estilo/conteudo/guias-multiproduto/
+menu_namespace: styleGuideMenu
+---
+
+## Propósito
+
+Um guia multiproduto leva o leitor a um objetivo que nenhum produto sozinho alcança. Ele aplica a forma base de [how-to](/pt-br/documentacao/guia-de-estilo/conteudo/guias-how-to/).
+
+Outros conjuntos de documentação dividem esse tipo em guias de solução, guias de design e guias de implementação. Esta documentação usa um nome e um conjunto de regras, porque os três descrevem a mesma página.
+
+## Quando usar
+
+Escreva um guia multiproduto quando:
+
+- O objetivo precisa de dois ou mais produtos, e nenhuma seção de produto é dona dele.
+- O leitor pensa em resultados, como proteger um checkout, e não em nomes de produto.
+- Um guia de produto único fica mandando o leitor para outro produto no meio da tarefa.
+
+Não escreva um guia multiproduto quando:
+
+- Um produto alcança o objetivo. Escreva um [guia how-to](/pt-br/documentacao/guia-de-estilo/conteudo/guias-how-to/) na seção daquele produto.
+- O leitor quer entender o design em vez de construí-lo. Escreva uma [página de arquitetura](/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura/).
+- O objetivo é um cenário comercial com enquadramento de negócio. Isso é um caso de uso, e usa a mesma forma base com um cenário e uma tabela de requisitos.
+
+## Registro
+
+Procedural: 20 palavras por frase, uma instrução por passo, imperativo e ativo. Tom: diretivo, claro, decidido. [Estrutura de frases](/pt-br/documentacao/guia-de-estilo/escrita/estrutura-de-frases/) tem as regras.
+
+## Estrutura
+
+**Componentes obrigatórios**
+
+- **Abertura pelo problema**: uma ou duas frases declaram o problema, antes de qualquer nome de produto. Os produtos entram depois do problema, pelo papel: "Você configura o cache com **Applications** e a filtragem de requisições com **Firewall**."
+- **Pré-requisitos**: uma seção `## Pré-requisitos`, em lista; cada item é um link ou um comando de uma linha. Um único pré-requisito é uma frase, não uma lista.
+- **Etapas**: um `##` por etapa do fluxo, nunca por produto, cada um com um heading imperativo que nomeia a etapa. Cada etapa nomeia seu produto na entrada, contém um procedimento comum e se sustenta sozinha.
+- **Frase de resultado**: todo procedimento termina declarando o que o leitor agora tem ou vê.
+- **Próximos passos**: uma seção final `## Próximos passos` com links em lista, cada um no formato `[Título](/caminho/) - motivo`.
+
+**Componentes opcionais**
+
+- **Uma tabela de produtos**: o que cada produto contribui, quando há mais de três envolvidos.
+- **Um diagrama**: quando a ordem das peças é difícil de segurar em texto. Aponte para a [página de arquitetura](/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura/) quando existir uma.
+
+## Template
+
+Copie o template e substitua cada `<placeholder>`.
+
+```md
+[Uma ou duas frases: o problema primeiro, depois os
+produtos, pelo papel.]
+
+## Pré-requisitos
+
+- <Um link ou um comando de uma linha por item>
+
+---
+
+## <Heading imperativo que nomeia a primeira etapa do fluxo>
+
+<Uma frase que nomeia o produto em que a etapa roda.>
+
+Para <alcançar o resultado da etapa>:
+
+1. <Uma instrução imperativa.>
+2. <Uma instrução imperativa.>
+
+<O resultado: o que o leitor agora tem ou vê.>
+
+---
+
+## <Heading imperativo que nomeia a próxima etapa>
+
+---
+
+## Próximos passos
+
+- [<Título>](/caminho/) - <por que o leitor seguiria o link>
+```
+
+Separe as seções principais da página com uma régua `---`, e nunca coloque uma logo depois do frontmatter.
+
+## Regras
+
+- **Nomeie o objetivo, não os produtos.** O título declara o objetivo em linguagem simples, sem nomes de produto: `Sirva um site com conteúdo em cache e um checkout protegido`. O leitor busca pelo resultado.
+- **Declare o problema primeiro.** Uma ou duas frases, depois os produtos pelo papel: "Você configura o cache com **Applications** e a filtragem de requisições com **Firewall**."
+- **Ordene pelo fluxo, nunca pelo catálogo de produtos.** Uma página organizada produto a produto é um pacote de guias how-to com um só título.
+- **Nomeie o produto em cada etapa.** Um nome de interface sem qualificação fica ambíguo quando a página cruza produtos.
+- **Continue sendo um how-to.** Os produtos são a rota, não o assunto. Um parágrafo de contexto de produto pertence a uma página de conceito; aponte para ela.
+- **Siga as regras de passos.** Os passos seguem [Procedimentos](/pt-br/documentacao/guia-de-estilo/escrita/procedimentos/), e todo procedimento termina com sua frase de resultado.
+- **Mostre o output depois de cada comando.** O leitor vê como o sucesso se parece antes que o próximo passo dependa dele. A regra está em [Procedimentos](/pt-br/documentacao/guia-de-estilo/escrita/procedimentos/).
+- **Comprometa-se com um caminho recomendado.** Alternativas vão em um aside, nunca como bifurcações nos passos.
+- **Verifique o caminho inteiro.** Esses guias falham nas emendas, então cheque o resultado e não o último passo.
+- **Aponte para os vizinhos.** Os guias how-to e a página de referência de cada produto, no corpo ou em `## Próximos passos`.
+
+## Exemplos
+
+O trecho a seguir, mantido em inglês, mostra a abertura pelo problema, os pré-requisitos e a primeira etapa do fluxo:
+
+```mdx
+Each route of a storefront needs a different rule. The catalogue can answer from cache, the cart must not, and the checkout needs a rate limit. You configure caching with **Applications** and request filtering with **Firewall**.
+
+## Prerequisites
+
+- An application that serves the store
+- A firewall
+
+## Turn on Application Accelerator
+
+The **Bypass Cache** behavior requires the **Application Accelerator** module of **Applications**.
+
+To turn on the module:
+
+1. Access [Azion Console](https://console.azion.com/) > **Applications** > **your application**.
+2. In the **Main Settings** tab, go to the **Modules** section.
+3. Turn on the **Application Accelerator** switch.
+4. Select **Save**.
+
+The Application Accelerator module is enabled for the application.
+```
+
+## Relacionados
+
+- [Guias how-to](/pt-br/documentacao/guia-de-estilo/conteudo/guias-how-to/): a forma base que este tipo aplica.
+- [Páginas de arquitetura](/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura/): a página que descreve o design que este guia constrói.
+- [Arquitetura de informação](/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura-de-informacao/): onde fica um guia que não pertence a nenhuma seção de produto.
+- [Escolher um tipo de conteúdo](/pt-br/documentacao/guia-de-estilo/conteudo/escolher-um-tipo-de-conteudo/): o catálogo completo de tipos de página.

--- a/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/hubs-de-navegacao.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/hubs-de-navegacao.mdx
@@ -8,6 +8,9 @@ namespace: documentation_style_guide_navigation_hubs
 permalink: /documentacao/guia-de-estilo/conteudo/hubs-de-navegacao/
 menu_namespace: styleGuideMenu
 ---
+import FrameBox from '@aziontech/webkit/frame-box'
+import ItemList from '@aziontech/webkit/item-list'
+import DocItem from '@aziontech/webkit/doc-item'
 
 ## Propósito
 
@@ -120,8 +123,13 @@ This section holds the guides to manage Object Storage buckets and objects, and 
 
 ## Relacionados
 
-- [Páginas de visão geral](/pt-br/documentacao/guia-de-estilo/conteudo/visao-geral/) - A raiz do produto, que orienta e aponta, mas também descreve.
-- [Arquitetura de informação](/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura-de-informacao/) - Onde os hubs ficam e quais seções precisam de um.
-- [Frontmatter](/pt-br/documentacao/guia-de-estilo/convencoes/frontmatter/) - O campo `type: homepage` que um hub em grade de cards define.
-- [Escolher um tipo de conteúdo](/pt-br/documentacao/guia-de-estilo/conteudo/escolher-um-tipo-de-conteudo/) - O catálogo completo de tipos de página.
-- [Guias how-to](/pt-br/documentacao/guia-de-estilo/conteudo/guias-how-to/) e [Tutoriais](/pt-br/documentacao/guia-de-estilo/conteudo/tutoriais/) - Os dois tipos que um hub em tabela lista.
+<FrameBox>
+<ItemList>
+  <DocItem title="Páginas de visão geral" href="/pt-br/documentacao/guia-de-estilo/conteudo/visao-geral/">A raiz do produto, que orienta e aponta, mas também descreve.</DocItem>
+  <DocItem title="Arquitetura de informação" href="/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura-de-informacao/">Onde os hubs ficam e quais seções precisam de um.</DocItem>
+  <DocItem title="Frontmatter" href="/pt-br/documentacao/guia-de-estilo/convencoes/frontmatter/">O campo `type: homepage` que um hub em grade de cards define.</DocItem>
+  <DocItem title="Escolher um tipo de conteúdo" href="/pt-br/documentacao/guia-de-estilo/conteudo/escolher-um-tipo-de-conteudo/">O catálogo completo de tipos de página.</DocItem>
+  <DocItem title="Guias how-to" href="/pt-br/documentacao/guia-de-estilo/conteudo/guias-how-to/">Os dois tipos que um hub em tabela lista.</DocItem>
+  <DocItem title="Tutoriais" href="/pt-br/documentacao/guia-de-estilo/conteudo/tutoriais/">Os dois tipos que um hub em tabela lista.</DocItem>
+</ItemList>
+</FrameBox>

--- a/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/hubs-de-navegacao.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/hubs-de-navegacao.mdx
@@ -1,0 +1,127 @@
+---
+title: Hubs de navegação
+description: >-
+  Escreva um hub de navegação em uma de suas duas formas: links agrupados para
+  destinos variados, ou uma tabela gerada para um conjunto que o leitor compara.
+meta_tags: 'style guide, navigation, hub, landing page'
+namespace: documentation_style_guide_navigation_hubs
+permalink: /documentacao/guia-de-estilo/conteudo/hubs-de-navegacao/
+menu_namespace: styleGuideMenu
+---
+
+## Propósito
+
+Um hub de navegação leva o leitor para dentro da documentação. Ele carrega links e uma frase de orientação, e nada mais.
+
+Ele **não** aplica nenhuma forma base do Diátaxis. Um hub não ensina, não instrui, não descreve e não explica: ele direciona. Por isso ele não tem orçamento de frase para um texto que não deveria estar ali.
+
+## Quando usar
+
+- Escreva um hub quando uma seção tem mais páginas do que o menu lateral consegue mostrar de forma legível.
+- Escreva um para uma seção que reúne páginas de vários produtos, como um índice de soluções ou de arquiteturas.
+- Escreva um para o slot Guias e tutoriais de uma seção de produto, que é uma única linha na sidebar apontando para um hub, e não um dropdown. [Arquitetura de informação](/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura-de-informacao/) carrega essa regra.
+
+Não escreva um hub quando:
+
+- A seção é um produto. Um produto abre com uma [visão geral](/pt-br/documentacao/guia-de-estilo/conteudo/visao-geral/), que orienta e aponta.
+- A página explicaria longamente do que a seção trata. Isso é uma [página de conceito](/pt-br/documentacao/guia-de-estilo/conteudo/conceito/).
+- O menu lateral já torna as páginas encontráveis. Um hub que duplica o menu é mais uma coisa para manter e mais uma coisa para desatualizar.
+
+## Registro
+
+Descritivo: 25 palavras por frase, voz ativa, passiva apenas quando o agente é desconhecido. Tom: breve, claro, orientador. [Estrutura de frases](/pt-br/documentacao/guia-de-estilo/escrita/estrutura-de-frases/) tem as regras.
+
+## Estrutura
+
+As duas formas abrem e fecham do mesmo jeito. Só o corpo muda.
+
+- **Abertura**: uma frase de orientação dizendo o que a seção contém.
+- **Fechamento**: nenhum. O último link ou a última linha da tabela encerra a página.
+
+### Forma 1: links agrupados
+
+O padrão. Use quando os destinos são diferentes entre si e o leitor precisa de uma frase para distinguir um do outro.
+
+- **Corpo**: grupos de links sob headings `##` em frase nominal.
+- **Forma do link**: `[Título](/caminho/) - uma frase sobre o que o leitor encontra lá.`
+
+### Forma 2: uma tabela
+
+Use quando o hub lista um conjunto homogêneo e o leitor escolhe por esforço e atualidade, e não por descrição. O slot Guias e tutoriais tem essa forma, porque cada linha é um how-to ou um tutorial do mesmo produto e uma frase por linha repetiria o título da página.
+
+- **Corpo**: um `<GuidesTable>`, sem headings `##` e sem grupos.
+- **Colunas**: nome, última atualização, dificuldade.
+- **A tabela é gerada, nunca digitada.** A data vem do último commit do arquivo e a dificuldade do campo `difficulty` no frontmatter de cada página, então o hub não fica fora de passo com as páginas que lista.
+- **Toda página listada define `difficulty`**: `Beginner`, `Intermediate` ou `Advanced`. Uma página sem o campo mostra um traço, o que se lê como esquecimento.
+
+## Template
+
+Copie o template da forma que você precisa e substitua cada `<placeholder>`.
+
+Links agrupados:
+
+```md
+<Uma frase: o que a seção contém.>
+
+## <Nome do grupo>
+
+- [<Título da página>](<url>) - <o que o leitor encontra lá, em uma frase>.
+- [<Título da página>](<url>) - <o que o leitor encontra lá, em uma frase>.
+
+## <Nome do próximo grupo>
+
+- [<Título da página>](<url>) - <o que o leitor encontra lá, em uma frase>.
+```
+
+Uma tabela:
+
+```mdx
+import GuidesTable from '~/components/GuidesTable.astro'
+
+<Uma frase: o que a seção contém.>
+
+<GuidesTable
+  lang="pt-br"
+  prefixes={['<prefixo dos guias>', '<prefixo dos tutoriais>']}
+  exclude={['<esta página de hub>']}
+/>
+```
+
+## Regras
+
+- **Nenhum fechamento e nenhum outro texto.** Uma frase de orientação; a explicação vai em uma [página de conceito](/pt-br/documentacao/guia-de-estilo/conteudo/conceito/).
+- **Faça cada link justificar o seu lugar.** Um hub é julgado pelo que ele deixa de fora; um hub que lista tudo não hierarquiza nada.
+- **Escreva descrições que diferenciam.** Diga o que esta página dá que as vizinhas não dão.
+- **Agrupe quando a lista passa de sete**, pelo que o leitor está tentando fazer. Uma tabela não agrupa: ela ordena, da mais recente para a mais antiga.
+- **Escolha a forma pelo que o leitor compara.** Destinos variados precisam de uma frase cada, então pedem links agrupados. Um único tipo de página, comparado por esforço e atualidade, pede a tabela.
+- **Nunca escreva uma linha de tabela à mão.** Uma data digitada fica errada na primeira vez que alguém esquece, e é por isso que este é o único lugar em que o guia permite uma data fora de um changelog.
+- **Registre os caminhos cobertos na sidebar.** A linha de menu que abre um hub em tabela carrega `covers`, listando os prefixos de caminho cujas páginas o hub possui. Sem isso, essas páginas falham na verificação de propriedade da sidebar.
+- **Mantenha o hub em dia com a seção.** Atualize o hub na mesma mudança que adiciona uma página.
+- **Defina `type: homepage` somente em um hub em grade de cards.** Todas as outras páginas omitem o campo. Para mais informações, consulte [Frontmatter](/pt-br/documentacao/guia-de-estilo/convencoes/frontmatter/).
+
+## Exemplos
+
+- [Arquiteturas](/pt-br/documentacao/architectures/) - Uma linha de orientação, e depois os designs agrupados pelo problema que resolvem.
+- [Guias e tutoriais do Cache](/pt-br/documentacao/build/cache/guides/) - A forma em tabela: uma frase, e depois cada guia e tutorial com sua data e dificuldade.
+
+Um hub de Object Storage, cortado até a frase de orientação e o primeiro grupo. O exemplo está em inglês; a versão em português segue a mesma forma:
+
+```mdx
+This section holds the guides to manage Object Storage buckets and objects, and the product reference.
+
+## Buckets
+
+- [Create an Object Storage bucket](/en/documentation/products/store/storage/create-bucket/) - Create a bucket to store your objects.
+- [Update an Object Storage bucket](/en/documentation/products/store/storage/update-buckets/) - Update a bucket after you create it.
+- [Delete an Object Storage bucket](/en/documentation/products/store/storage/delete-buckets/) - Delete a bucket that you no longer need.
+- [List Object Storage buckets](/en/documentation/products/store/storage/list-buckets/) - List all of your buckets.
+- [Use a bucket as origin](/en/documentation/products/store/storage/use-bucket-as-origin/) - Use a bucket as the origin for your content.
+```
+
+## Relacionados
+
+- [Páginas de visão geral](/pt-br/documentacao/guia-de-estilo/conteudo/visao-geral/) - A raiz do produto, que orienta e aponta, mas também descreve.
+- [Arquitetura de informação](/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura-de-informacao/) - Onde os hubs ficam e quais seções precisam de um.
+- [Frontmatter](/pt-br/documentacao/guia-de-estilo/convencoes/frontmatter/) - O campo `type: homepage` que um hub em grade de cards define.
+- [Escolher um tipo de conteúdo](/pt-br/documentacao/guia-de-estilo/conteudo/escolher-um-tipo-de-conteudo/) - O catálogo completo de tipos de página.
+- [Guias how-to](/pt-br/documentacao/guia-de-estilo/conteudo/guias-how-to/) e [Tutoriais](/pt-br/documentacao/guia-de-estilo/conteudo/tutoriais/) - Os dois tipos que um hub em tabela lista.

--- a/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/quickstart.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/quickstart.mdx
@@ -8,6 +8,9 @@ namespace: documentation_style_guide_quickstart
 permalink: /documentacao/guia-de-estilo/conteudo/quickstart/
 menu_namespace: styleGuideMenu
 ---
+import FrameBox from '@aziontech/webkit/frame-box'
+import ItemList from '@aziontech/webkit/item-list'
+import DocItem from '@aziontech/webkit/doc-item'
 
 ## Propósito
 
@@ -38,7 +41,7 @@ Uma página de quickstart segue o esqueleto do tutorial. [Tutoriais](/pt-br/docu
 - **Cadeia de objetos**: depois da abertura, nomeie cada objeto que o leitor cria e a que cada um precisa ser vinculado, em ordem. Uma lista curta, antes dos pré-requisitos.
 - **Pré-requisitos**: uma seção `## Pré-requisitos` com itens em marcadores. Cada item é um link, um comando de uma linha ou uma frase nominal que nomeia o requisito. Um único pré-requisito é uma frase, não uma lista.
 - **Etapas**: títulos de etapa numerados, `## 1. <Frase verbal no imperativo>` até `## N.`, terminando em uma etapa que ativa ou verifica. Cada etapa contém um procedimento e termina com sua frase de resultado.
-- **Próximos passos**: um fechamento `## Próximos passos` com links em marcadores na forma `[Título](/caminho/) - uma frase sobre por que o leitor seguiria o link.`
+- **Próximos passos**: um fechamento `## Próximos passos`, um `DocCardGroup` com um card por destino: o título, o link e uma frase sobre por que o leitor seguiria o link.
 
 **Componentes opcionais**
 
@@ -49,7 +52,10 @@ Uma página de quickstart segue o esqueleto do tutorial. [Tutoriais](/pt-br/docu
 
 Copie o template e substitua cada `<placeholder>`:
 
-```md
+```mdx
+import DocCardGroup from '@aziontech/webkit/doc-card-group'
+import DocCard from '@aziontech/webkit/doc-card'
+
 Este guia conduz você por <resultado, enquadrado como um primeiro:
 seu primeiro bucket, seu primeiro deploy>.
 
@@ -82,8 +88,10 @@ Para <alcançar o resultado>, você cria e conecta estes objetos:
 
 ## Próximos passos
 
-- [Título](/caminho/) - uma frase sobre por que o leitor seguiria o link.
-- [Título](/caminho/) - uma frase sobre por que o leitor seguiria o link.
+<DocCardGroup cols={2}>
+  <DocCard title="Título" href="/caminho/" label="uma frase sobre por que o leitor seguiria o link." />
+  <DocCard title="Título" href="/caminho/" label="uma frase sobre por que o leitor seguiria o link." />
+</DocCardGroup>
 ```
 
 ## Regras
@@ -96,7 +104,7 @@ Para <alcançar o resultado>, você cria e conecta estes objetos:
 - **Escreva cada etapa como um procedimento.** Os passos seguem [Procedimentos](/pt-br/documentacao/guia-de-estilo/escrita/procedimentos/), e cada etapa termina com sua frase de resultado.
 - **Mantenha os pré-requisitos no mínimo real.** Cada item é um motivo para abandonar a página.
 - **Termine em uma etapa que ativa ou verifica.** O leitor sai com a prova do resultado que funciona.
-- **Aponte tutoriais e os principais how-tos em `## Próximos passos`.** Dê a cada link seu motivo.
+- **Aponte tutoriais e os principais how-tos em `## Próximos passos`.** Dê a cada card seu motivo.
 - **Teste todo comando antes de publicar.** Uma instrução por passo, e um resultado visível em cada um.
 - **Mostre o output depois de cada comando.** O leitor vê como o sucesso se parece antes que o próximo passo dependa dele. A regra está em [Procedimentos](/pt-br/documentacao/guia-de-estilo/escrita/procedimentos/).
 - **Coloque a página logo depois do Overview do produto.**
@@ -130,7 +138,11 @@ A cadeia explica ao leitor por que quatro objetos existem antes de uma requisiç
 
 ## Relacionados
 
-- [Tutoriais](/pt-br/documentacao/guia-de-estilo/conteudo/tutoriais/): a forma base que este padrão aplica.
-- [Guias how-to](/pt-br/documentacao/guia-de-estilo/conteudo/guias-how-to/): para onde vão as opções e as alternativas.
-- [Arquitetura de informação](/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura-de-informacao/): onde a página fica na seção de produto.
-- [Escolher um tipo de conteúdo](/pt-br/documentacao/guia-de-estilo/conteudo/escolher-um-tipo-de-conteudo/): o catálogo completo de tipos de página.
+<FrameBox>
+<ItemList>
+  <DocItem title="Tutoriais" href="/pt-br/documentacao/guia-de-estilo/conteudo/tutoriais/">A forma base que este padrão aplica.</DocItem>
+  <DocItem title="Guias how-to" href="/pt-br/documentacao/guia-de-estilo/conteudo/guias-how-to/">Para onde vão as opções e as alternativas.</DocItem>
+  <DocItem title="Arquitetura de informação" href="/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura-de-informacao/">Onde a página fica na seção de produto.</DocItem>
+  <DocItem title="Escolher um tipo de conteúdo" href="/pt-br/documentacao/guia-de-estilo/conteudo/escolher-um-tipo-de-conteudo/">O catálogo completo de tipos de página.</DocItem>
+</ItemList>
+</FrameBox>

--- a/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/quickstart.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/quickstart.mdx
@@ -1,0 +1,136 @@
+---
+title: Páginas de quickstart
+description: >-
+  Escreva uma página de quickstart: um tutorial cujo objetivo é a primeira
+  ativação de um produto, com um único caminho e pré-requisitos mínimos.
+meta_tags: 'style guide, quickstart, get started'
+namespace: documentation_style_guide_quickstart
+permalink: /documentacao/guia-de-estilo/conteudo/quickstart/
+menu_namespace: styleGuideMenu
+---
+
+## Propósito
+
+Uma página de quickstart é um tutorial cujo objetivo é a primeira ativação de um produto: de não usar o produto até o menor resultado que funciona. Ela segue a forma base do [tutorial](/pt-br/documentacao/guia-de-estilo/conteudo/tutoriais/).
+
+Quickstart é o slot por produto. A seção de onboarding de plataforma em `/documentation/get-started/` tem nome parecido e é outra coisa: ela não pertence a nenhum produto.
+
+## Quando usar
+
+- Escreva uma página de quickstart quando um produto precisa de um caminho documentado até o primeiro resultado que funciona.
+- Escreva pelo menos uma página de quickstart por produto, como ponto de entrada logo depois do Overview do produto.
+- Escreva uma variante por interface quando a interface tem público próprio de primeiro uso e passos próprios.
+- Não escreva uma página de quickstart para uma tarefa que o leitor já tem em mente. Essa tarefa precisa de um [guia how-to](/pt-br/documentacao/guia-de-estilo/conteudo/guias-how-to/).
+- Não apresente opções nem compare interfaces dentro de uma página. Cada página documenta uma interface, do início ao fim.
+- Não escreva uma página de quickstart separada para um módulo ou um recurso. O padrão cobre um produto inteiro.
+
+## Registro
+
+Procedural: 20 palavras por frase, uma instrução por passo, imperativo e ativo. Tom: diretivo, claro, ágil, seguro. [Estrutura de frases](/pt-br/documentacao/guia-de-estilo/escrita/estrutura-de-frases/) tem as regras.
+
+## Estrutura
+
+Uma página de quickstart segue o esqueleto do tutorial. [Tutoriais](/pt-br/documentacao/guia-de-estilo/conteudo/tutoriais/) argumenta cada parte, e esta lista nomeia o que o padrão exige. Uma página única leva o título `<Product> quickstart`. Uma variante por interface leva `<Product> quickstart using <interface>`: `using Azion Console`, `using the Azion CLI`, `using the API` ou `using an AI agent`.
+
+**Componentes obrigatórios**
+
+- **Abertura**: `Este guia conduz você por <resultado>.` seguido de uma lista curta com marcadores do que o leitor terá feito. Enquadre o resultado como um primeiro: "seu primeiro bucket", "seu primeiro deploy".
+- **Cadeia de objetos**: depois da abertura, nomeie cada objeto que o leitor cria e a que cada um precisa ser vinculado, em ordem. Uma lista curta, antes dos pré-requisitos.
+- **Pré-requisitos**: uma seção `## Pré-requisitos` com itens em marcadores. Cada item é um link, um comando de uma linha ou uma frase nominal que nomeia o requisito. Um único pré-requisito é uma frase, não uma lista.
+- **Etapas**: títulos de etapa numerados, `## 1. <Frase verbal no imperativo>` até `## N.`, terminando em uma etapa que ativa ou verifica. Cada etapa contém um procedimento e termina com sua frase de resultado.
+- **Próximos passos**: um fechamento `## Próximos passos` com links em marcadores na forma `[Título](/caminho/) - uma frase sobre por que o leitor seguiria o link.`
+
+**Componentes opcionais**
+
+- **Capturas de tela**: para um passo cujo resultado visível é uma tela, não a saída de um comando.
+- **Asides**: raros. Um tutorial cheio de blocos de nota tenta ser material de referência.
+
+## Template
+
+Copie o template e substitua cada `<placeholder>`:
+
+```md
+Este guia conduz você por <resultado, enquadrado como um primeiro:
+seu primeiro bucket, seu primeiro deploy>.
+
+- <O que o leitor terá feito, como uma lista curta>
+- <...>
+
+Para <alcançar o resultado>, você cria e conecta estes objetos:
+
+1. <O primeiro objeto, e o que o cria.>
+2. <O objeto seguinte, e a que ele precisa ser vinculado.>
+3. <O último vínculo, e o que ele torna alcançável.>
+
+## Pré-requisitos
+
+- <Um link ou um comando de uma linha quando existe um, senão uma frase nominal>
+
+## 1. <Frase verbal no imperativo>
+
+<Um procedimento, numerado quando tem duas ou mais ações.>
+
+<A frase de resultado: o que o leitor agora tem ou vê.>
+
+## 2. <Frase verbal no imperativo>
+
+<...>
+
+## N. <Frase verbal no imperativo que ativa ou verifica>
+
+<...>
+
+## Próximos passos
+
+- [Título](/caminho/) - uma frase sobre por que o leitor seguiria o link.
+- [Título](/caminho/) - uma frase sobre por que o leitor seguiria o link.
+```
+
+## Regras
+
+- **Declare a cadeia de objetos antes do primeiro passo.** Nomeie cada objeto que o leitor cria e a que ele precisa ser vinculado, em ordem. Um quickstart que lista cliques sem o modelo de composição deixa o leitor incapaz de repetir o resultado com outros objetos.
+- **Documente um único caminho linear por página.** Dentro de uma página, escolha uma interface e permaneça nela. Sem `<Tabs>` e sem comparação de interfaces ou opções.
+- **Divida por interface quando a interface muda o caminho.** Uma página é o piso. Adicione uma variante quando uma interface tem público próprio de primeiro uso e passos próprios: Azion Console, Azion CLI, API ou um agente de IA conectado pelo [servidor MCP da Azion](/pt-br/documentacao/agent-setup/). As variantes ficam sob um único grupo Quickstart na barra lateral, com o Console primeiro. O grupo é um pai de menu, não uma página.
+- **Nomeie os caminhos irmãos em uma linha**, logo abaixo da abertura: `Prefere a CLI? Consulte [<Product> quickstart using the Azion CLI](/caminho/).` O leitor que cai no caminho errado sai dele em um passo.
+- **Apague a variante que você não consegue manter verdadeira.** Cada variante multiplica os comandos que rodam antes de um release. Uma página de primeiro uso desatualizada falha com o leitor no primeiro contato.
+- **Escreva cada etapa como um procedimento.** Os passos seguem [Procedimentos](/pt-br/documentacao/guia-de-estilo/escrita/procedimentos/), e cada etapa termina com sua frase de resultado.
+- **Mantenha os pré-requisitos no mínimo real.** Cada item é um motivo para abandonar a página.
+- **Termine em uma etapa que ativa ou verifica.** O leitor sai com a prova do resultado que funciona.
+- **Aponte tutoriais e os principais how-tos em `## Próximos passos`.** Dê a cada link seu motivo.
+- **Teste todo comando antes de publicar.** Uma instrução por passo, e um resultado visível em cada um.
+- **Mostre o output depois de cada comando.** O leitor vê como o sucesso se parece antes que o próximo passo dependa dele. A regra está em [Procedimentos](/pt-br/documentacao/guia-de-estilo/escrita/procedimentos/).
+- **Coloque a página logo depois do Overview do produto.**
+
+## Exemplos
+
+Este exemplo, em inglês, mostra a abertura, a cadeia de objetos e os pré-requisitos de uma página de quickstart de **Functions**:
+
+```mdx
+This guide instructs you through running your first function on the Azion Web Platform.
+
+- Create a function and write its code.
+- Connect the function to an application and a workload.
+- Verify that the function answers a request.
+
+To run a function, you create and connect these objects:
+
+1. A **function**, which holds the code.
+2. A **function instance**, which binds the function to an application.
+3. A **rule** in the Rules Engine, which decides the requests that trigger the instance.
+4. A **workload**, which the application is linked to and which receives the traffic.
+
+---
+
+## Prerequisites
+
+- An [Azion account](https://console.azion.com/).
+```
+
+A cadeia explica ao leitor por que quatro objetos existem antes de uma requisição chegar ao código dele. Sem ela, os passos parecem cliques sem explicação.
+
+## Relacionados
+
+- [Tutoriais](/pt-br/documentacao/guia-de-estilo/conteudo/tutoriais/): a forma base que este padrão aplica.
+- [Guias how-to](/pt-br/documentacao/guia-de-estilo/conteudo/guias-how-to/): para onde vão as opções e as alternativas.
+- [Arquitetura de informação](/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura-de-informacao/): onde a página fica na seção de produto.
+- [Escolher um tipo de conteúdo](/pt-br/documentacao/guia-de-estilo/conteudo/escolher-um-tipo-de-conteudo/): o catálogo completo de tipos de página.

--- a/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/referencia.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/referencia.mdx
@@ -8,6 +8,9 @@ namespace: documentation_style_guide_reference
 permalink: /documentacao/guia-de-estilo/conteudo/referencia/
 menu_namespace: styleGuideMenu
 ---
+import FrameBox from '@aziontech/webkit/frame-box'
+import ItemList from '@aziontech/webkit/item-list'
+import DocItem from '@aziontech/webkit/doc-item'
 
 ## Propósito
 
@@ -37,7 +40,7 @@ Descritivo: 25 palavras por frase, voz ativa, passiva apenas quando o agente é 
 - **Abertura**: uma a três frases definicionais sobre o artefato, e depois direto para os dados. Sem enquadramento de procedimento.
 - **Seções**: `##`s como expressões nominais que nomeiam o objeto, o grupo de campos ou o nível real. As tabelas carregam a informação — campos, valores, padrões, limites — com fraseado consistente em cada coluna e unidade em cada número. A prosa entre as tabelas é uma ou duas frases de orientação.
 - **Limites**: uma seção `## Limites` quando o produto os tem, **dimensionada por plano**. Use `| Escopo | Plano | Limite |` quando um escopo se repete entre planos, ou uma coluna por plano quando o conjunto é curto o bastante para ler na horizontal. Cada linha carrega sua unidade e diz se o limite é rígido ou ajustável.
-- **Fechamento**: `## Recursos relacionados`, com links no formato `[Título](/caminho/) - motivo`, cobrindo a página de conceito e os principais how-tos.
+- **Fechamento**: `## Recursos relacionados`, uma lista de `DocItem` cobrindo a página de conceito e os principais how-tos, cada linha com seu motivo.
 
 **Componentes opcionais**
 
@@ -51,7 +54,11 @@ Quando o conjunto de limites cresce o bastante para ser consultado sozinho, ele 
 
 Copie o template e substitua cada `<placeholder>`:
 
-```md
+```mdx
+import FrameBox from '@aziontech/webkit/frame-box'
+import ItemList from '@aziontech/webkit/item-list'
+import DocItem from '@aziontech/webkit/doc-item'
+
 **<Produto ou recurso>** é <uma a três frases definicionais sobre o artefato>.
 
 ## <Objeto, grupo de campos ou nível, como expressão nominal>
@@ -82,8 +89,12 @@ O suporte pode aumentar os limites marcados como ajustáveis. Entre em contato c
 
 ## Recursos relacionados
 
-- [<A página de conceito>](<url>) - <por que o leitor seguiria o link>
-- [<Um how-to principal>](<url>) - <por que o leitor seguiria o link>
+<FrameBox>
+<ItemList>
+  <DocItem title="<A página de conceito>" href="<url>"><por que o leitor seguiria o link></DocItem>
+  <DocItem title="<Um how-to principal>" href="<url>"><por que o leitor seguiria o link></DocItem>
+</ItemList>
+</FrameBox>
 ```
 
 ## Regras
@@ -106,6 +117,10 @@ O suporte pode aumentar os limites marcados como ajustáveis. Entre em contato c
 Este exemplo, em inglês, mostra a abertura definicional, uma seção de objeto com sua tabela e o fechamento de uma referência de **Object Storage**:
 
 ```mdx
+import FrameBox from '@aziontech/webkit/frame-box'
+import ItemList from '@aziontech/webkit/item-list'
+import DocItem from '@aziontech/webkit/doc-item'
+
 **Object Storage** is a Store product that stores objects in buckets. A bucket is the container; an object is the stored item plus its metadata. Azion stores all buckets in the _us-east_ cloud region and bills storage per GB/hour, with no minimum retention.
 
 ## Buckets
@@ -123,8 +138,12 @@ You cannot rename a bucket. You can delete a bucket only when it is empty, 24 ho
 
 ## Related resources
 
-- [Create an Object Storage bucket](/en/documentation/products/store/storage/create-bucket/) - create a bucket and set its `workloads_access` permission.
-- [Use a bucket as origin](/en/documentation/products/store/storage/use-bucket-as-origin/) - serve content from a bucket through Connectors.
+<FrameBox>
+<ItemList>
+  <DocItem title="Create an Object Storage bucket" href="/en/documentation/products/store/storage/create-bucket/">create a bucket and set its `workloads_access` permission.</DocItem>
+  <DocItem title="Use a bucket as origin" href="/en/documentation/products/store/storage/use-bucket-as-origin/">serve content from a bucket through Connectors.</DocItem>
+</ItemList>
+</FrameBox>
 ```
 
 Este exemplo mostra uma tabela de limites em que a separação por plano não foi confirmada. A tabela carrega as colunas que foram confirmadas e nada mais:
@@ -146,8 +165,12 @@ A coluna ausente é o ponto. A separação por plano desses números não foi co
 
 ## Relacionados
 
-- [Escolher um tipo de conteúdo](/pt-br/documentacao/guia-de-estilo/conteudo/escolher-um-tipo-de-conteudo/): o catálogo completo de tipos de página.
-- [Tutoriais](/pt-br/documentacao/guia-de-estilo/conteudo/tutoriais/): o tipo de conteúdo que ensina por meio de um primeiro projeto.
-- [Guias how-to](/pt-br/documentacao/guia-de-estilo/conteudo/guias-how-to/): o tipo de conteúdo que carrega os passos.
-- [Conceito](/pt-br/documentacao/guia-de-estilo/conteudo/conceito/): o tipo de página que carrega o raciocínio.
-- [Voz da documentação](/pt-br/documentacao/guia-de-estilo/escrita/voz/): o único registro que todas as páginas usam.
+<FrameBox>
+<ItemList>
+  <DocItem title="Escolher um tipo de conteúdo" href="/pt-br/documentacao/guia-de-estilo/conteudo/escolher-um-tipo-de-conteudo/">O catálogo completo de tipos de página.</DocItem>
+  <DocItem title="Tutoriais" href="/pt-br/documentacao/guia-de-estilo/conteudo/tutoriais/">O tipo de conteúdo que ensina por meio de um primeiro projeto.</DocItem>
+  <DocItem title="Guias how-to" href="/pt-br/documentacao/guia-de-estilo/conteudo/guias-how-to/">O tipo de conteúdo que carrega os passos.</DocItem>
+  <DocItem title="Conceito" href="/pt-br/documentacao/guia-de-estilo/conteudo/conceito/">O tipo de página que carrega o raciocínio.</DocItem>
+  <DocItem title="Voz da documentação" href="/pt-br/documentacao/guia-de-estilo/escrita/voz/">O único registro que todas as páginas usam.</DocItem>
+</ItemList>
+</FrameBox>

--- a/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/referencia.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/referencia.mdx
@@ -1,0 +1,153 @@
+---
+title: Referência
+description: >-
+  Escreva uma página de referência: o que ela descreve, a ordem padrão das
+  seções, tabelas com unidades e valores padrão e o limite de frase.
+meta_tags: 'style guide, reference pages'
+namespace: documentation_style_guide_reference
+permalink: /documentacao/guia-de-estilo/conteudo/referencia/
+menu_namespace: styleGuideMenu
+---
+
+## Propósito
+
+Uma página de referência é material de consulta. O leitor a consulta para encontrar um valor, um campo ou um limite, e depois sai.
+
+## Quando usar
+
+Escreva uma página de referência quando:
+
+- O leitor precisa consultar um campo, uma configuração, um limite ou uma flag.
+- A informação é enumerável e cabe em uma tabela.
+
+Não escreva uma página de referência quando:
+
+- O leitor precisa de passos para uma tarefa. Escreva um [guia how-to](/pt-br/documentacao/guia-de-estilo/conteudo/guias-how-to/).
+- O leitor precisa do raciocínio por trás de um design. Escreva uma [página de conceito](/pt-br/documentacao/guia-de-estilo/conteudo/conceito/).
+
+## Registro
+
+Descritivo: 25 palavras por frase, voz ativa, passiva apenas quando o agente é desconhecido. Tom: claro, neutro, exaustivo. [Estrutura de frases](/pt-br/documentacao/guia-de-estilo/escrita/estrutura-de-frases/) tem as regras.
+
+## Estrutura
+
+**Componentes obrigatórios**
+
+- **Título**: uma expressão nominal que nomeia a coisa: `Object Storage`, `Configurações de cache`, `azion create bucket`.
+- **Abertura**: uma a três frases definicionais sobre o artefato, e depois direto para os dados. Sem enquadramento de procedimento.
+- **Seções**: `##`s como expressões nominais que nomeiam o objeto, o grupo de campos ou o nível real. As tabelas carregam a informação — campos, valores, padrões, limites — com fraseado consistente em cada coluna e unidade em cada número. A prosa entre as tabelas é uma ou duas frases de orientação.
+- **Limites**: uma seção `## Limites` quando o produto os tem, **dimensionada por plano**. Use `| Escopo | Plano | Limite |` quando um escopo se repete entre planos, ou uma coluna por plano quando o conjunto é curto o bastante para ler na horizontal. Cada linha carrega sua unidade e diz se o limite é rígido ou ajustável.
+- **Fechamento**: `## Recursos relacionados`, com links no formato `[Título](/caminho/) - motivo`, cobrindo a página de conceito e os principais how-tos.
+
+**Componentes opcionais**
+
+- **Asides**: uma dica acima da tabela de limites quando o suporte pode aumentar os limites, e um aviso de atenção para uma mudança de versão ou de migração. Não use outros asides.
+
+As seções mantêm essa ordem.
+
+Quando o conjunto de limites cresce o bastante para ser consultado sozinho, ele vai para o slot Limites da seção de produto. Estas regras não mudam: só o lugar muda. [Arquitetura de informação](/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura-de-informacao/) tem a lista de slots.
+
+## Template
+
+Copie o template e substitua cada `<placeholder>`:
+
+```md
+**<Produto ou recurso>** é <uma a três frases definicionais sobre o artefato>.
+
+## <Objeto, grupo de campos ou nível, como expressão nominal>
+
+<Uma ou duas frases de orientação.>
+
+| Campo | Descrição |
+| --- | --- |
+| <Nome do campo> | <O que ele contém, com o valor padrão> |
+
+## <Objeto, grupo de campos ou nível, como expressão nominal>
+
+<...>
+
+---
+
+## Limites
+
+:::tip[dica]
+O suporte pode aumentar os limites marcados como ajustáveis. Entre em contato com o <link do suporte>.
+:::
+
+| Escopo | Plano | Limite | Ajustável |
+| --- | --- | --- | --- |
+| <Escopo> | <Nome do plano> | <Valor com a unidade> | Sim / Não |
+
+---
+
+## Recursos relacionados
+
+- [<A página de conceito>](<url>) - <por que o leitor seguiria o link>
+- [<Um how-to principal>](<url>) - <por que o leitor seguiria o link>
+```
+
+## Regras
+
+- **Nunca um passo a passo numerado.** No momento em que um aparece, a página é um [guia how-to](/pt-br/documentacao/guia-de-estilo/conteudo/guias-how-to/) arquivado no lugar errado. Aponte para o how-to.
+- **Seja completo antes de ser interessante.** Uma referência sem três de doze campos está quebrada; uma com descrições sem graça dos doze cumpre o papel.
+- **Coloque informação enumerável em tabelas.** Campos, limites, flags, padrões, códigos de status.
+- **Mantenha o fraseado consistente na coluna.** O leitor escaneia; fraseado variado obriga a ler.
+- **Declare as unidades e os valores padrão.** Um limite sem unidade não é um fato.
+- **Dimensione todo limite por plano.** Um limite que muda entre planos não é um fato só. Um número publicado sem o plano a que pertence está errado para todo leitor que está em outro plano.
+- **Separe limite de valor padrão.** Um valor padrão é um campo e fica na tabela de campos. Um limite é um teto e fica em `## Limites`.
+- **Diga se cada limite é rígido ou ajustável.** A próxima ação do leitor depende disso: um limite ajustável é um chamado no suporte, um limite rígido é uma restrição de design.
+- **Nunca invente um limite nem um nome de plano.** Tire os dois da página de pricing, do contrato de planos ou do time de produto. Um valor que você não consegue confirmar não é publicado: estreite a tabela até as dimensões que você consegue confirmar.
+- **Nunca repita um preço.** Valores, cotas vendidas por unidade e métricas de cobrança vivem só na página de pricing. Aponte para ela; não copie.
+- **Sem marketing.** Diga o que faz e onde para.
+- **Uma página de comando da CLI tem sua própria forma.** Um resumo de uma linha, depois `## Uso` com o comando, depois `## Flags opcionais` com uma entrada por flag.
+
+## Exemplos
+
+Este exemplo, em inglês, mostra a abertura definicional, uma seção de objeto com sua tabela e o fechamento de uma referência de **Object Storage**:
+
+```mdx
+**Object Storage** is a Store product that stores objects in buckets. A bucket is the container; an object is the stored item plus its metadata. Azion stores all buckets in the _us-east_ cloud region and bills storage per GB/hour, with no minimum retention.
+
+## Buckets
+
+Bucket names follow these rules:
+
+| Rule | Value |
+| --- | --- |
+| Length | 6 to 63 characters |
+| Characters | Alphanumeric characters and hyphen |
+| Reserved prefix | Must not start with `azion` |
+| Uniqueness | Exclusive across all Azion accounts |
+
+You cannot rename a bucket. You can delete a bucket only when it is empty, 24 hours after the removal of the final object.
+
+## Related resources
+
+- [Create an Object Storage bucket](/en/documentation/products/store/storage/create-bucket/) - create a bucket and set its `workloads_access` permission.
+- [Use a bucket as origin](/en/documentation/products/store/storage/use-bucket-as-origin/) - serve content from a bucket through Connectors.
+```
+
+Este exemplo mostra uma tabela de limites em que a separação por plano não foi confirmada. A tabela carrega as colunas que foram confirmadas e nada mais:
+
+```mdx
+## Limits
+
+:::tip
+Support can raise the limits marked raisable. Contact the [technical support team](/en/documentation/services/support/).
+:::
+
+| Scope | Limit | Raisable |
+| --- | --- | --- |
+| Buckets | 100 per account | Yes |
+| S3 credential access keys | 100,000 per account | Yes |
+```
+
+A coluna ausente é o ponto. A separação por plano desses números não foi confirmada, então a tabela não tem coluna de plano, em vez de uma coluna inventada.
+
+## Relacionados
+
+- [Escolher um tipo de conteúdo](/pt-br/documentacao/guia-de-estilo/conteudo/escolher-um-tipo-de-conteudo/): o catálogo completo de tipos de página.
+- [Tutoriais](/pt-br/documentacao/guia-de-estilo/conteudo/tutoriais/): o tipo de conteúdo que ensina por meio de um primeiro projeto.
+- [Guias how-to](/pt-br/documentacao/guia-de-estilo/conteudo/guias-how-to/): o tipo de conteúdo que carrega os passos.
+- [Conceito](/pt-br/documentacao/guia-de-estilo/conteudo/conceito/): o tipo de página que carrega o raciocínio.
+- [Voz da documentação](/pt-br/documentacao/guia-de-estilo/escrita/voz/): o único registro que todas as páginas usam.

--- a/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/troubleshooting.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/troubleshooting.mdx
@@ -8,6 +8,9 @@ namespace: documentation_style_guide_troubleshooting
 permalink: /documentacao/guia-de-estilo/conteudo/troubleshooting/
 menu_namespace: styleGuideMenu
 ---
+import FrameBox from '@aziontech/webkit/frame-box'
+import ItemList from '@aziontech/webkit/item-list'
+import DocItem from '@aziontech/webkit/doc-item'
 
 ## Propósito
 
@@ -38,7 +41,7 @@ O título tem a forma `Troubleshoot <recurso ou classe de sintomas>` em inglês 
 - **A causa**: o que produz o sintoma.
 - **A correção**: um procedimento numerado, ou marcadores na forma `**<Nome da solução>**: o que ela faz e seu link`.
 - **O resultado**: o que o leitor deve ver agora, fechando cada seção.
-- **Recursos relacionados**: um fechamento `## Recursos relacionados` com os guias how-to e as páginas de referência em que as correções se apoiam.
+- **Recursos relacionados**: um fechamento `## Recursos relacionados`, uma lista de `DocItem` com os guias how-to e as páginas de referência em que as correções se apoiam.
 
 **Componentes opcionais**
 
@@ -49,7 +52,11 @@ O título tem a forma `Troubleshoot <recurso ou classe de sintomas>` em inglês 
 
 Copie o template e substitua cada `<placeholder>`:
 
-```md
+```mdx
+import FrameBox from '@aziontech/webkit/frame-box'
+import ItemList from '@aziontech/webkit/item-list'
+import DocItem from '@aziontech/webkit/doc-item'
+
 [Uma frase de escopo: o produto e a classe de sintomas
 que a página cobre.]
 
@@ -84,7 +91,11 @@ Para <corrigir o sintoma>:
 
 ## Recursos relacionados
 
-- [<Título>](/caminho/) - <o guia how-to ou a página de referência em que as correções se apoiam>
+<FrameBox>
+<ItemList>
+  <DocItem title="<Título>" href="/caminho/"><o guia how-to ou a página de referência em que as correções se apoiam></DocItem>
+</ItemList>
+</FrameBox>
 ```
 
 Separe as seções de sintoma com uma linha `---` e nunca coloque uma imediatamente depois do bloco de frontmatter.
@@ -99,7 +110,7 @@ Separe as seções de sintoma com uma linha `---` e nunca coloque uma imediatame
 - **Ordene as causas por frequência.** Quando um sintoma tem mais de uma causa, o leitor tenta as correções de cima para baixo.
 - **Escreva as correções como passos numerados e imperativos** conforme [Procedimentos](/pt-br/documentacao/guia-de-estilo/escrita/procedimentos/), ou como marcadores na forma `**<Nome da solução>**: o que ela faz e seu link`.
 - **Aponte procedimentos longos em vez de repeti-los.** A correção contém o que é específico do sintoma; o caminho genérico é um link.
-- **Feche com `## Recursos relacionados`**: os guias how-to e as páginas de referência em que as correções se apoiam. Um aside de suporte pode vir antes.
+- **Feche com `## Recursos relacionados`**: uma lista de `DocItem` com os guias how-to e as páginas de referência em que as correções se apoiam. Um aside de suporte pode vir antes.
 - **Posicione pelo escopo.** Problemas da plataforma em Suporte, problemas de produto nos guias daquele produto.
 
 ## Exemplos
@@ -139,6 +150,10 @@ The new allowed rule appears in the **Allowed Rules** tab of the **WAF Rules** p
 
 ## Relacionados
 
-- [Guias how-to](/pt-br/documentacao/guia-de-estilo/conteudo/guias-how-to/): a forma base que este padrão aplica.
-- [Arquitetura de informação](/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura-de-informacao/): onde vivem o troubleshooting da plataforma e o de produto.
-- [Escolher um tipo de conteúdo](/pt-br/documentacao/guia-de-estilo/conteudo/escolher-um-tipo-de-conteudo/): o catálogo completo de tipos de página.
+<FrameBox>
+<ItemList>
+  <DocItem title="Guias how-to" href="/pt-br/documentacao/guia-de-estilo/conteudo/guias-how-to/">A forma base que este padrão aplica.</DocItem>
+  <DocItem title="Arquitetura de informação" href="/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura-de-informacao/">Onde vivem o troubleshooting da plataforma e o de produto.</DocItem>
+  <DocItem title="Escolher um tipo de conteúdo" href="/pt-br/documentacao/guia-de-estilo/conteudo/escolher-um-tipo-de-conteudo/">O catálogo completo de tipos de página.</DocItem>
+</ItemList>
+</FrameBox>

--- a/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/troubleshooting.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/troubleshooting.mdx
@@ -1,0 +1,144 @@
+---
+title: Páginas de troubleshooting
+description: >-
+  Escreva uma página de troubleshooting: nomeie o sintoma que o leitor vê,
+  ordene as causas por frequência e coloque a correção antes do ticket.
+meta_tags: 'style guide, troubleshooting'
+namespace: documentation_style_guide_troubleshooting
+permalink: /documentacao/guia-de-estilo/conteudo/troubleshooting/
+menu_namespace: styleGuideMenu
+---
+
+## Propósito
+
+Uma página de troubleshooting corrige um sintoma que o leitor está vendo agora. Ela aplica a forma base de [guia how-to](/pt-br/documentacao/guia-de-estilo/conteudo/guias-how-to/): a tarefa é uma correção.
+
+## Quando usar
+
+- Escreva uma página de troubleshooting quando uma falha conhecida tem uma correção que o leitor aplica sozinho.
+- Escreva uma página para um grupo de sintomas relacionados, com uma seção por sintoma.
+- Não escreva uma página de troubleshooting para uma tarefa que o leitor planeja. Uma tarefa planejada precisa de um [guia how-to](/pt-br/documentacao/guia-de-estilo/conteudo/guias-how-to/).
+- Não escreva uma página quando o produto funciona como projetado. As razões de um design pertencem a uma página de [conceito](/pt-br/documentacao/guia-de-estilo/conteudo/conceito/).
+- Não escreva uma página quando a única correção é um ticket de suporte. Uma página cujo único passo é "abra um ticket" é um link, não uma página.
+
+## Registro
+
+Procedural: 20 palavras por frase, uma instrução por passo, imperativo e ativo. Tom: calmo, claro, diretivo, resolutivo. [Estrutura de frases](/pt-br/documentacao/guia-de-estilo/escrita/estrutura-de-frases/) tem as regras.
+
+## Estrutura
+
+O título tem a forma `Troubleshoot <recurso ou classe de sintomas>` em inglês e `Solução de problemas de <recurso ou classe de sintomas>` em português.
+
+**Componentes obrigatórios**
+
+- **Abertura**: uma frase de escopo que nomeia o produto e a classe de sintomas que a página cobre.
+- **Seções de sintoma**: uma seção `##` por sintoma, cada uma autossuficiente e legível em qualquer ordem.
+- **Headings de sintoma**: uma frase nominal que declara o comportamento observável, com as mensagens de erro citadas literalmente em monospace: `` ## `403 Forbidden` em requisições legítimas ``.
+- **O sintoma**: o que o leitor vê, em uma ou duas frases, primeiro em cada seção.
+- **A causa**: o que produz o sintoma.
+- **A correção**: um procedimento numerado, ou marcadores na forma `**<Nome da solução>**: o que ela faz e seu link`.
+- **O resultado**: o que o leitor deve ver agora, fechando cada seção.
+- **Recursos relacionados**: um fechamento `## Recursos relacionados` com os guias how-to e as páginas de referência em que as correções se apoiam.
+
+**Componentes opcionais**
+
+- **Saída de erro**: a mensagem ou a tela que confirma que o leitor tem esse sintoma.
+- **Contato com o suporte**: um aside que aponta o caminho do suporte, depois de todas as correções.
+
+## Template
+
+Copie o template e substitua cada `<placeholder>`:
+
+```md
+[Uma frase de escopo: o produto e a classe de sintomas
+que a página cobre.]
+
+---
+
+## <Comportamento observável, com a mensagem de erro em monospace>
+
+<O sintoma: o que o leitor vê, em uma ou duas frases.>
+
+<A causa.>
+
+Para <corrigir o sintoma>:
+
+1. <Uma instrução imperativa.>
+2. <Uma instrução imperativa.>
+
+<O resultado que o leitor deve ver agora.>
+
+---
+
+## <Próximo sintoma, legível sozinho>
+
+<O sintoma.>
+
+<A causa.>
+
+- **<Nome da solução>**: <o que ela faz e seu link>.
+
+<O resultado.>
+
+---
+
+## Recursos relacionados
+
+- [<Título>](/caminho/) - <o guia how-to ou a página de referência em que as correções se apoiam>
+```
+
+Separe as seções de sintoma com uma linha `---` e nunca coloque uma imediatamente depois do bloco de frontmatter.
+
+## Regras
+
+- **Nomeie a página pela classe de sintomas.** O título tem a forma `Troubleshoot <recurso ou classe de sintomas>`.
+- **Abra com uma frase de escopo** que nomeia o produto e a classe de sintomas que a página cobre.
+- **Nomeie o sintoma, não a causa.** O leitor busca com o que ele vê; cite as mensagens de erro literalmente em monospace.
+- **Faça cada seção de sintoma ficar de pé sozinha.** O leitor chega a qualquer seção primeiro; nomeie o assunto em cada uma.
+- **Mantenha a ordem dentro de cada seção**: o sintoma, a causa, a correção, o resultado.
+- **Ordene as causas por frequência.** Quando um sintoma tem mais de uma causa, o leitor tenta as correções de cima para baixo.
+- **Escreva as correções como passos numerados e imperativos** conforme [Procedimentos](/pt-br/documentacao/guia-de-estilo/escrita/procedimentos/), ou como marcadores na forma `**<Nome da solução>**: o que ela faz e seu link`.
+- **Aponte procedimentos longos em vez de repeti-los.** A correção contém o que é específico do sintoma; o caminho genérico é um link.
+- **Feche com `## Recursos relacionados`**: os guias how-to e as páginas de referência em que as correções se apoiam. Um aside de suporte pode vir antes.
+- **Posicione pelo escopo.** Problemas da plataforma em Suporte, problemas de produto nos guias daquele produto.
+
+## Exemplos
+
+Este exemplo, em inglês, mostra a abertura e a primeira seção de sintoma de uma página de troubleshooting sobre falsos positivos do WAF:
+
+```mdx
+**Web Application Firewall (WAF)** can block legitimate requests when an internal rule matches them. This page covers these false positives and the allowed rules that fix them.
+
+---
+
+## `403 Forbidden` on legitimate requests
+
+After you turn on the WAF in blocking mode, legitimate requests receive a `403 Forbidden` response.
+
+The cause is a WAF internal rule that matches the request. Common examples include:
+
+| Rule ID | Matches |
+| --- | --- |
+| `1000` | SQL keywords |
+| `1013` | Apostrophe (`'`) |
+| `1302` | HTML open tag (`<`) |
+
+To find the rule and allow the legitimate requests with WAF Tuning:
+
+1. Access [Azion Console](https://console.azion.com/) > **WAF Rules** > **your rule set**.
+2. Go to the **Tuning** tab.
+3. Set a **Time Range**, for example _Last 12 hours_. WAF Tuning queries cover up to 3 days.
+4. In the **Workloads** dropdown, select the domains to analyze. Results only appear with at least one domain selected.
+5. Select **Apply**. The **Possible Attacks** list shows **Rule ID**, **Description**, **Hits**, **Paths**, **IPs**, and **Countries**.
+6. (Optional) To see more details for a record, select **More Details**.
+7. Use the **Field** checkbox to select the legitimate records.
+8. Select **Allow Rules**.
+
+The new allowed rule appears in the **Allowed Rules** tab of the **WAF Rules** page. The WAF no longer blocks the requests that match the allowed rule.
+```
+
+## Relacionados
+
+- [Guias how-to](/pt-br/documentacao/guia-de-estilo/conteudo/guias-how-to/): a forma base que este padrão aplica.
+- [Arquitetura de informação](/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura-de-informacao/): onde vivem o troubleshooting da plataforma e o de produto.
+- [Escolher um tipo de conteúdo](/pt-br/documentacao/guia-de-estilo/conteudo/escolher-um-tipo-de-conteudo/): o catálogo completo de tipos de página.

--- a/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/tutoriais.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/tutoriais.mdx
@@ -1,0 +1,147 @@
+---
+title: Tutoriais
+description: >-
+  Escreva um tutorial: o autor escolhe o objetivo, garante o resultado e
+  mantém todas as decisões longe do leitor.
+meta_tags: 'style guide, tutorials'
+namespace: documentation_style_guide_tutorials
+permalink: /documentacao/guia-de-estilo/conteudo/tutoriais/
+menu_namespace: styleGuideMenu
+---
+
+## Propósito
+
+Um tutorial ensina o produto ao levar o leitor a construir algo que funciona. O autor escolhe o objetivo, garante o resultado e mantém todas as decisões longe do leitor.
+
+## Quando usar
+
+**Reconheça um tutorial por:**
+
+- Um leitor que já escolheu o produto e ainda não construiu nada com ele.
+- Um artefato que funciona quando a última etapa termina.
+- Um caminho único que o autor escolheu e garante, do primeiro comando até um resultado verificado.
+- Aprendizado que chega como efeito de construir, nunca como aula.
+
+**Continua sendo um tutorial quando:**
+
+- Usa mais de um produto, porque o artefato precisa deles. O autor escolheu o objetivo, e é isso que decide o tipo.
+- Constrói sobre um serviço de terceiro que faz parte do artefato. Nomeie o passo do fornecedor e aponte para fora; nunca documente a interface dele.
+- Roda inteiramente no Azion Console, porque esse é o caminho honesto até o resultado.
+- Deixa de fora uma capacidade que o artefato não precisa. Completude é assunto de [referência](/pt-br/documentacao/guia-de-estilo/conteudo/referencia/).
+
+**Escreva outra coisa quando:**
+
+- O leitor chegou com a tarefa já em mente. Isso é um [guia how-to](/pt-br/documentacao/guia-de-estilo/conteudo/guias-how-to/).
+- A página ativa um produto pela primeira vez. Isso é um [quickstart](/pt-br/documentacao/guia-de-estilo/conteudo/quickstart/).
+- A página implementa um cenário de negócio do início ao fim. Isso é um [caso de uso](/pt-br/documentacao/guia-de-estilo/conteudo/casos-de-uso/).
+- O assunto é campos, valores e padrões. Isso é [referência](/pt-br/documentacao/guia-de-estilo/conteudo/referencia/).
+- Nada fica pronto no fim. Passos que não terminam em nada não ensinam nada, então encontre o artefato ou descarte a página.
+
+Quando dois tipos ainda parecem possíveis, [Escolher um tipo de conteúdo](/pt-br/documentacao/guia-de-estilo/conteudo/escolher-um-tipo-de-conteudo/) tem o roteiro.
+
+## Registro
+
+Procedural: 20 palavras por frase, uma instrução por passo, imperativo e ativo. Tom: diretivo, claro, didático, seguro. [Estrutura de frases](/pt-br/documentacao/guia-de-estilo/escrita/estrutura-de-frases/) tem as regras.
+
+## Estrutura
+
+O título é uma frase verbal no imperativo que nomeia o artefato: `Construa uma API de comentários`, `Faça o deploy de um site estático com Functions`.
+
+**Componentes obrigatórios**
+
+- **Abertura**: `Neste tutorial, você vai <verbo> <o artefato e seu objetivo>.` Depois, uma frase que enumera os subobjetivos: "Você vai criar ..., configurar ... e fazer o deploy de ...".
+- **Pré-requisitos**: uma seção `## Pré-requisitos`, sempre primeiro, cada item um link ou um comando de uma linha quando existe um, senão uma frase nominal.
+- **Etapas**: títulos de etapa numerados, `## 1. <Frase verbal no imperativo>`, na ordem de construção. `(Opcional)` pode vir depois do número: `## 8. (Opcional) Adicione um domínio personalizado`. A etapa final faz o deploy ou verifica.
+- **Próximos passos**: um fechamento `## Próximos passos` com links em marcadores na forma `[Título](/caminho/) - uma frase sobre por que o leitor seguiria o link.`
+
+**Componentes opcionais**
+
+- **Uma frase de conceito** com link para uma página de [conceito](/pt-br/documentacao/guia-de-estilo/conteudo/conceito/), quando um conceito é genuinamente necessário.
+- **Uma imagem** como resultado visível de um passo, quando as palavras sozinhas não mostram.
+
+## Template
+
+Copie o template e substitua cada `<placeholder>`:
+
+```md
+Neste tutorial, você vai <verbo> <o artefato e seu objetivo>.
+Você vai criar <...>, configurar <...> e fazer o deploy de <...>.
+
+## Pré-requisitos
+
+- <Um link ou um comando de uma linha quando existe um, senão uma frase nominal>
+
+## 1. <Frase verbal no imperativo>
+
+<Um procedimento. Cada passo mostra um resultado visível.>
+
+<A frase de resultado: o que o leitor agora tem ou vê.>
+
+## 2. <Frase verbal no imperativo>
+
+<...>
+
+## 3. (Opcional) <Frase verbal no imperativo>
+
+<Uma etapa opcional. `(Opcional)` vem depois do número.>
+
+## 4. <Frase verbal no imperativo que faz o deploy ou verifica>
+
+<...>
+
+## Próximos passos
+
+- [Título](/caminho/) - uma frase sobre por que o leitor seguiria o link.
+- [Título](/caminho/) - uma frase sobre por que o leitor seguiria o link.
+```
+
+## Regras
+
+- **Cumpra o contrato.** Você escolhe cada opção: sem ramificação, sem "dependendo das suas necessidades". Cada passo mostra um resultado visível, e você rodou todo comando.
+- **Sem `<Tabs>`.** Tabs são uma ramificação, e tutoriais não ramificam. Uma tarefa que genuinamente precisa de três interfaces é um [guia how-to](/pt-br/documentacao/guia-de-estilo/conteudo/guias-how-to/).
+- **Não explique.** Uma frase e um link quando o conceito é genuinamente necessário. Mantenha os asides raros.
+- **Toda captura de tela precisa se justificar.** Uma imagem para um resultado que as palavras não mostram, nunca um print de cada tela pela qual o leitor passa.
+- **Aponte para fora nos produtos de terceiros.** Nomeie o passo do fornecedor; não documente a interface dele.
+- **Dê a cada bloco de código uma introdução com dois-pontos.** "Instale a CLI:" e depois o comando. Use `<Code>` para tudo que o leitor copia.
+- **Mostre o output depois de cada comando.** O leitor vê como o sucesso se parece antes que o próximo passo dependa dele. A regra está em [Procedimentos](/pt-br/documentacao/guia-de-estilo/escrita/procedimentos/).
+- **Mantenha tutoriais escassos.** Um por área de produto. Tutoriais são caros de manter funcionando.
+- **Aponte os how-tos e conceitos que o tutorial tocou em `## Próximos passos`.** Dê a cada link seu motivo.
+
+## Exemplos
+
+Este exemplo, em inglês, mostra a abertura, os pré-requisitos e a primeira etapa de um tutorial que constrói uma API de lista de usuários:
+
+```mdx
+In this tutorial, you will build a user list API with **Functions** and **SQL Database**. You will create a database, seed a `users` table, create a function, and route requests to it.
+
+## Prerequisites
+
+- An Azion account with a configured personal token
+- An application with a domain in the format `<id>.map.azionedge.net`
+
+---
+
+## 1. Create the database
+
+To create the database, send a `POST` request to the databases endpoint:
+
+<Code lang="bash" code={`curl --location 'https://api.azion.com/v4/edge_sql/databases' \\
+--header 'Authorization: Token [TOKEN VALUE]' \\
+--header 'Content-Type: application/json' \\
+--data '{"name": "mydatabase"}'`} />
+
+The response returns `"state": "pending"` and `"status": "creating"`. Database creation is asynchronous.
+
+To check the creation status, send `GET` requests to the same endpoint until `status` is `created`:
+
+<Code lang="bash" code={`curl --location 'https://api.azion.com/v4/edge_sql/databases' \\
+--header 'Authorization: Token [TOKEN VALUE]'`} />
+
+The database is ready when `status` is `created`.
+```
+
+## Relacionados
+
+- [Páginas de quickstart](/pt-br/documentacao/guia-de-estilo/conteudo/quickstart/): o tutorial cujo objetivo é a primeira ativação.
+- [Guias how-to](/pt-br/documentacao/guia-de-estilo/conteudo/guias-how-to/): a página para o leitor que chegou com uma tarefa.
+- [Escolher um tipo de conteúdo](/pt-br/documentacao/guia-de-estilo/conteudo/escolher-um-tipo-de-conteudo/): o roteiro.

--- a/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/tutoriais.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/tutoriais.mdx
@@ -8,6 +8,9 @@ namespace: documentation_style_guide_tutorials
 permalink: /documentacao/guia-de-estilo/conteudo/tutoriais/
 menu_namespace: styleGuideMenu
 ---
+import FrameBox from '@aziontech/webkit/frame-box'
+import ItemList from '@aziontech/webkit/item-list'
+import DocItem from '@aziontech/webkit/doc-item'
 
 ## Propósito
 
@@ -52,7 +55,7 @@ O título é uma frase verbal no imperativo que nomeia o artefato: `Construa uma
 - **Abertura**: `Neste tutorial, você vai <verbo> <o artefato e seu objetivo>.` Depois, uma frase que enumera os subobjetivos: "Você vai criar ..., configurar ... e fazer o deploy de ...".
 - **Pré-requisitos**: uma seção `## Pré-requisitos`, sempre primeiro, cada item um link ou um comando de uma linha quando existe um, senão uma frase nominal.
 - **Etapas**: títulos de etapa numerados, `## 1. <Frase verbal no imperativo>`, na ordem de construção. `(Opcional)` pode vir depois do número: `## 8. (Opcional) Adicione um domínio personalizado`. A etapa final faz o deploy ou verifica.
-- **Próximos passos**: um fechamento `## Próximos passos` com links em marcadores na forma `[Título](/caminho/) - uma frase sobre por que o leitor seguiria o link.`
+- **Próximos passos**: um fechamento `## Próximos passos`, um `DocCardGroup` com um card por destino: o título, o link e uma frase sobre por que o leitor seguiria o link.
 
 **Componentes opcionais**
 
@@ -63,7 +66,10 @@ O título é uma frase verbal no imperativo que nomeia o artefato: `Construa uma
 
 Copie o template e substitua cada `<placeholder>`:
 
-```md
+```mdx
+import DocCardGroup from '@aziontech/webkit/doc-card-group'
+import DocCard from '@aziontech/webkit/doc-card'
+
 Neste tutorial, você vai <verbo> <o artefato e seu objetivo>.
 Você vai criar <...>, configurar <...> e fazer o deploy de <...>.
 
@@ -91,8 +97,10 @@ Você vai criar <...>, configurar <...> e fazer o deploy de <...>.
 
 ## Próximos passos
 
-- [Título](/caminho/) - uma frase sobre por que o leitor seguiria o link.
-- [Título](/caminho/) - uma frase sobre por que o leitor seguiria o link.
+<DocCardGroup cols={2}>
+  <DocCard title="Título" href="/caminho/" label="uma frase sobre por que o leitor seguiria o link." />
+  <DocCard title="Título" href="/caminho/" label="uma frase sobre por que o leitor seguiria o link." />
+</DocCardGroup>
 ```
 
 ## Regras
@@ -105,7 +113,7 @@ Você vai criar <...>, configurar <...> e fazer o deploy de <...>.
 - **Dê a cada bloco de código uma introdução com dois-pontos.** "Instale a CLI:" e depois o comando. Use `<Code>` para tudo que o leitor copia.
 - **Mostre o output depois de cada comando.** O leitor vê como o sucesso se parece antes que o próximo passo dependa dele. A regra está em [Procedimentos](/pt-br/documentacao/guia-de-estilo/escrita/procedimentos/).
 - **Mantenha tutoriais escassos.** Um por área de produto. Tutoriais são caros de manter funcionando.
-- **Aponte os how-tos e conceitos que o tutorial tocou em `## Próximos passos`.** Dê a cada link seu motivo.
+- **Aponte os how-tos e conceitos que o tutorial tocou em `## Próximos passos`.** Dê a cada card seu motivo.
 
 ## Exemplos
 
@@ -142,6 +150,10 @@ The database is ready when `status` is `created`.
 
 ## Relacionados
 
-- [Páginas de quickstart](/pt-br/documentacao/guia-de-estilo/conteudo/quickstart/): o tutorial cujo objetivo é a primeira ativação.
-- [Guias how-to](/pt-br/documentacao/guia-de-estilo/conteudo/guias-how-to/): a página para o leitor que chegou com uma tarefa.
-- [Escolher um tipo de conteúdo](/pt-br/documentacao/guia-de-estilo/conteudo/escolher-um-tipo-de-conteudo/): o roteiro.
+<FrameBox>
+<ItemList>
+  <DocItem title="Páginas de quickstart" href="/pt-br/documentacao/guia-de-estilo/conteudo/quickstart/">O tutorial cujo objetivo é a primeira ativação.</DocItem>
+  <DocItem title="Guias how-to" href="/pt-br/documentacao/guia-de-estilo/conteudo/guias-how-to/">A página para o leitor que chegou com uma tarefa.</DocItem>
+  <DocItem title="Escolher um tipo de conteúdo" href="/pt-br/documentacao/guia-de-estilo/conteudo/escolher-um-tipo-de-conteudo/">O roteiro.</DocItem>
+</ItemList>
+</FrameBox>

--- a/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/visao-geral.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/visao-geral.mdx
@@ -35,7 +35,7 @@ Descritivo: 25 palavras por frase, voz ativa, passiva apenas quando o agente é 
 **Componentes obrigatórios**
 
 - **Bloco de definição**, em duas camadas. Primeiro o conceito: uma ou duas frases dizendo o que é a classe da coisa, para um leitor que nunca usou uma, com qualquer termo do mercado definido no próprio texto. Depois o produto: `**<Produto>** <verbo> <o conceito> <onde e como na Azion>.` Depois uma frase nomeando as tarefas concretas para as quais as pessoas o usam, no vocabulário do leitor: `Use <Produto> para fazer A, executar B ou servir C.` Uma lista de benefícios em bullets é a forma mais fraca dessa frase: parece um folheto e custa uma tela.
-- **CTAs**: um `LinkButton` primário com o label **Quickstart** e um secundário com o label `Referência de <Produto>`.
+- **CTAs**: um `DocButton` primário com o label **Quickstart** e um secundário com o label `Referência de <Produto>`.
 - **A amostra**: quando o produto tem um artefato de código, um objeto de configuração ou uma requisição, um exemplo completo e mínimo dele, inteiro, na primeira tela. Dois a quatro bullets nomeiam as partes, e uma frase diz qual conhecimento prévio se aproveita. Um produto sem esse artefato pula a seção em vez de inventar uma.
 - **O mecanismo**: quando uma requisição, um evento ou um job atravessa mais de dois objetos antes de o produto executar, essa cadeia como um diagrama `mermaid`, seguido de um percurso numerado com no máximo seis itens. Abra com o que o leitor presumiria errado.
 - **As fronteiras**: um único bloco compacto de bullets com introduções em negrito — linguagens, APIs, frameworks, integrações e os principais limites. Um bloco, não uma seção por feature.
@@ -49,14 +49,14 @@ As seções mantêm essa ordem.
 Copie o template e substitua cada `<placeholder>`:
 
 ```mdx
-import LinkButton from 'azion-webkit/linkbutton'
+import DocButton from '~/components/webkit/DocButton.vue'
 
 <O que é a classe da coisa, para um leitor que nunca usou uma. Uma ou duas frases; defina qualquer termo do mercado no próprio texto.>
 
 **<Produto>** <verbo> <o conceito> <onde e como na Azion>. Use <Produto> para <tarefa A>, <tarefa B> ou <tarefa C>.
 
-<LinkButton label="Quickstart" link="<URL do quickstart>" />
-<LinkButton severity="secondary" label="Referência de <Produto>" link="<URL da referência>" />
+<DocButton href="<URL do quickstart>" label="Quickstart" size="medium" />
+<DocButton href="<URL da referência>" label="Referência de <Produto>" kind="secondary" size="medium" />
 
 ## <O artefato, como expressão nominal>
 

--- a/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/visao-geral.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/visao-geral.mdx
@@ -8,6 +8,9 @@ namespace: documentation_style_guide_overview_pages
 permalink: /documentacao/guia-de-estilo/conteudo/visao-geral/
 menu_namespace: styleGuideMenu
 ---
+import FrameBox from '@aziontech/webkit/frame-box'
+import ItemList from '@aziontech/webkit/item-list'
+import DocItem from '@aziontech/webkit/doc-item'
 
 ## Propósito
 
@@ -40,7 +43,7 @@ Descritivo: 25 palavras por frase, voz ativa, passiva apenas quando o agente é 
 - **O mecanismo**: quando uma requisição, um evento ou um job atravessa mais de dois objetos antes de o produto executar, essa cadeia como um diagrama `mermaid`, seguido de um percurso numerado com no máximo seis itens. Abra com o que o leitor presumiria errado.
 - **As fronteiras**: um único bloco compacto de bullets com introduções em negrito — linguagens, APIs, frameworks, integrações e os principais limites. Um bloco, não uma seção por feature.
 - **Seções de capacidade**: só para uma capacidade que muda o que o leitor construiria, no máximo três. Uma capacidade que cabe em uma frase e um link pertence ao bloco de fronteiras ou ao roteador.
-- **Fechamento**: `## Próximos passos`, uma tabela de duas colunas indexada pelo que o leitor quer fazer: `| Se você quer | Vá para |`.
+- **Fechamento**: `## Próximos passos`, um `DocCardGroup` indexado pelo que o leitor quer fazer: cada card nomeia o destino, e seu texto é a intenção (`Executar o primeiro agora.`).
 
 As seções mantêm essa ordem.
 
@@ -50,6 +53,8 @@ Copie o template e substitua cada `<placeholder>`:
 
 ```mdx
 import DocButton from '~/components/webkit/DocButton.vue'
+import DocCardGroup from '@aziontech/webkit/doc-card-group'
+import DocCard from '@aziontech/webkit/doc-card'
 
 <O que é a classe da coisa, para um leitor que nunca usou uma. Uma ou duas frases; defina qualquer termo do mercado no próprio texto.>
 
@@ -87,10 +92,10 @@ import DocButton from '~/components/webkit/DocButton.vue'
 
 ## Próximos passos
 
-| Se você quer | Vá para |
-| --- | --- |
-| <Executar o primeiro agora> | [Quickstart](<url>) |
-| <Consultar um campo, um limite ou um padrão> | [Referência](<url>) |
+<DocCardGroup cols={2}>
+  <DocCard title="Quickstart" href="<url>" label="<Executar o primeiro agora>." />
+  <DocCard title="Referência" href="<url>" label="<Consultar um campo, um limite ou um padrão>." />
+</DocCardGroup>
 ```
 
 ## Regras
@@ -137,19 +142,26 @@ If you know the Web `Request` and `Response` objects, you know the code model.
 A mesma página fecha com o roteador, indexado pelo que o leitor quer fazer e não pelo título das páginas:
 
 ```mdx
+import DocCardGroup from '@aziontech/webkit/doc-card-group'
+import DocCard from '@aziontech/webkit/doc-card'
+
 ## Next steps
 
-| If you want to | Go to |
-| --- | --- |
-| Run your first function now | [Quickstart](/en/documentation/build/functions/quickstart/) |
-| Understand what invokes a function | [How Functions works](/en/documentation/build/functions/how-it-works/) |
-| Look up a handler, a parameter, or a limit | [Handlers](/en/documentation/build/functions/reference/handlers/) |
-| Look up a term | [Glossary](/en/documentation/build/functions/glossary/) |
+<DocCardGroup cols={2}>
+  <DocCard title="Quickstart" href="/en/documentation/build/functions/quickstart/" label="Run your first function now." />
+  <DocCard title="How Functions works" href="/en/documentation/build/functions/how-it-works/" label="Understand what invokes a function." />
+  <DocCard title="Handlers" href="/en/documentation/build/functions/reference/handlers/" label="Look up a handler, a parameter, or a limit." />
+  <DocCard title="Glossary" href="/en/documentation/build/functions/glossary/" label="Look up a term." />
+</DocCardGroup>
 ```
 
 ## Relacionados
 
-- [Referência](/pt-br/documentacao/guia-de-estilo/conteudo/referencia/): a forma base que a visão geral aplica.
-- [Páginas de quickstart](/pt-br/documentacao/guia-de-estilo/conteudo/quickstart/): a página para onde a visão geral envia o leitor.
-- [Arquitetura de informação](/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura-de-informacao/): onde a visão geral fica na seção do produto.
-- [Escolher um tipo de conteúdo](/pt-br/documentacao/guia-de-estilo/conteudo/escolher-um-tipo-de-conteudo/): o catálogo completo de tipos de página.
+<FrameBox>
+<ItemList>
+  <DocItem title="Referência" href="/pt-br/documentacao/guia-de-estilo/conteudo/referencia/">A forma base que a visão geral aplica.</DocItem>
+  <DocItem title="Páginas de quickstart" href="/pt-br/documentacao/guia-de-estilo/conteudo/quickstart/">A página para onde a visão geral envia o leitor.</DocItem>
+  <DocItem title="Arquitetura de informação" href="/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura-de-informacao/">Onde a visão geral fica na seção do produto.</DocItem>
+  <DocItem title="Escolher um tipo de conteúdo" href="/pt-br/documentacao/guia-de-estilo/conteudo/escolher-um-tipo-de-conteudo/">O catálogo completo de tipos de página.</DocItem>
+</ItemList>
+</FrameBox>

--- a/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/visao-geral.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/conteudo/visao-geral.mdx
@@ -1,0 +1,155 @@
+---
+title: Páginas de visão geral
+description: >-
+  Escreva a visão geral de um produto: a raiz da seção, que diz o que o
+  produto é, o que ele faz e quando usá-lo.
+meta_tags: 'style guide, overview'
+namespace: documentation_style_guide_overview_pages
+permalink: /documentacao/guia-de-estilo/conteudo/visao-geral/
+menu_namespace: styleGuideMenu
+---
+
+## Propósito
+
+Uma página de visão geral é a raiz da seção de um produto. Ela diz o que o produto é, o que ele faz e quando o leitor o usaria. Ela explica a classe da coisa antes de nomear a versão da Azion, para que um leitor que nunca usou uma consiga acompanhar a página. Ela aplica a forma base de [referência](/pt-br/documentacao/guia-de-estilo/conteudo/referencia/).
+
+Todo produto tem uma. É a página onde o leitor chega pela busca, pelo menu lateral e por outro produto que aponta para este.
+
+## Quando usar
+
+- Escreva uma visão geral para cada produto, como a primeira página da seção.
+- Escreva-a antes de qualquer outra página da seção. A visão geral define do que a seção trata.
+
+Não escreva uma visão geral quando:
+
+- O assunto é um módulo ou uma funcionalidade. Isso vai em uma [página de referência](/pt-br/documentacao/guia-de-estilo/conteudo/referencia/) dentro da seção.
+- A página levaria o leitor por uma tarefa. Isso é um [guia how-to](/pt-br/documentacao/guia-de-estilo/conteudo/guias-how-to/), com link a partir daqui.
+- A página só listaria links. Isso é um [hub de navegação](/pt-br/documentacao/guia-de-estilo/conteudo/hubs-de-navegacao/).
+
+## Registro
+
+Descritivo: 25 palavras por frase, voz ativa, passiva apenas quando o agente é desconhecido. Tom: acolhedor, factual, direto. [Estrutura de frases](/pt-br/documentacao/guia-de-estilo/escrita/estrutura-de-frases/) tem as regras.
+
+## Estrutura
+
+**Componentes obrigatórios**
+
+- **Bloco de definição**, em duas camadas. Primeiro o conceito: uma ou duas frases dizendo o que é a classe da coisa, para um leitor que nunca usou uma, com qualquer termo do mercado definido no próprio texto. Depois o produto: `**<Produto>** <verbo> <o conceito> <onde e como na Azion>.` Depois uma frase nomeando as tarefas concretas para as quais as pessoas o usam, no vocabulário do leitor: `Use <Produto> para fazer A, executar B ou servir C.` Uma lista de benefícios em bullets é a forma mais fraca dessa frase: parece um folheto e custa uma tela.
+- **CTAs**: um `LinkButton` primário com o label **Quickstart** e um secundário com o label `Referência de <Produto>`.
+- **A amostra**: quando o produto tem um artefato de código, um objeto de configuração ou uma requisição, um exemplo completo e mínimo dele, inteiro, na primeira tela. Dois a quatro bullets nomeiam as partes, e uma frase diz qual conhecimento prévio se aproveita. Um produto sem esse artefato pula a seção em vez de inventar uma.
+- **O mecanismo**: quando uma requisição, um evento ou um job atravessa mais de dois objetos antes de o produto executar, essa cadeia como um diagrama `mermaid`, seguido de um percurso numerado com no máximo seis itens. Abra com o que o leitor presumiria errado.
+- **As fronteiras**: um único bloco compacto de bullets com introduções em negrito — linguagens, APIs, frameworks, integrações e os principais limites. Um bloco, não uma seção por feature.
+- **Seções de capacidade**: só para uma capacidade que muda o que o leitor construiria, no máximo três. Uma capacidade que cabe em uma frase e um link pertence ao bloco de fronteiras ou ao roteador.
+- **Fechamento**: `## Próximos passos`, uma tabela de duas colunas indexada pelo que o leitor quer fazer: `| Se você quer | Vá para |`.
+
+As seções mantêm essa ordem.
+
+## Template
+
+Copie o template e substitua cada `<placeholder>`:
+
+```mdx
+import LinkButton from 'azion-webkit/linkbutton'
+
+<O que é a classe da coisa, para um leitor que nunca usou uma. Uma ou duas frases; defina qualquer termo do mercado no próprio texto.>
+
+**<Produto>** <verbo> <o conceito> <onde e como na Azion>. Use <Produto> para <tarefa A>, <tarefa B> ou <tarefa C>.
+
+<LinkButton label="Quickstart" link="<URL do quickstart>" />
+<LinkButton severity="secondary" label="Referência de <Produto>" link="<URL da referência>" />
+
+## <O artefato, como expressão nominal>
+
+<Um exemplo completo e mínimo do artefato.>
+
+- **<Parte>**: <o que é>.
+- **<Parte>**: <o que é>.
+
+<Uma frase sobre qual conhecimento prévio se aproveita.>
+
+---
+
+## <A cadeia, como expressão nominal>
+
+<O que o leitor presumiria errado.>
+
+<Um fence mermaid desenhando a cadeia da requisição à resposta.>
+
+1. <O que acontece primeiro.>
+2. <...>
+
+## <As fronteiras, como expressão nominal>
+
+- **<Dimensão>**: <o que suporta, e onde para>.
+- **<Dimensão>**: <...>.
+
+---
+
+## Próximos passos
+
+| Se você quer | Vá para |
+| --- | --- |
+| <Executar o primeiro agora> | [Quickstart](<url>) |
+| <Consultar um campo, um limite ou um padrão> | [Referência](<url>) |
+```
+
+## Regras
+
+- **Nunca instrua.** Sem passos numerados, sem procedimentos, sem sequências de cliques. A amostra não é um walkthrough: ela aparece uma vez, completa, sem nada para o leitor fazer. Uma visão geral que instrui é uma página de [quickstart](/pt-br/documentacao/guia-de-estilo/conteudo/quickstart/) arquivada no lugar errado.
+- **Sem adjetivos de qualidade.** Diga o que o produto faz e onde para.
+- **O título é o nome do produto, um substantivo.** Não "documentação", não um gerúndio.
+- **Explique a coisa antes do produto.** A primeira frase diz o que é a classe da coisa; a frase do produto vem depois. Cubra o nome do produto: o que sobra precisa valer para a versão de qualquer fornecedor.
+- **Nomeie o produto até a segunda frase, e nunca abra com o contexto do problema.** Uma frase de conceito explica um mecanismo. Uma frase sobre a importância do problema não explica nada.
+- **Organize pelas perguntas do leitor, não pela sua lista de features.** As seções respondem, na ordem: o que é isto e o que a versão da Azion faz, o que eu escrevo, como isso é chamado, o que faz e onde para, para onde vou agora. Um sumário que reproduz a lista de módulos do produto é um catálogo: responde "o que vendemos" em vez de "o que estou decidindo".
+- **As perguntas moldam as seções; elas nunca viram títulos.** Um título é uma expressão nominal curta, nunca uma pergunta: `Estrutura da function`, não `Como é uma function`.
+- **Desenhe o diagrama a partir da sequência documentada.** Um diagrama de uma sequência que a documentação já descreve em prosa é uma mudança de notação, não um fato novo. Cada nó e cada seta corresponde a um passo que o produto executa, e o percurso numerado carrega o significado se a figura não renderizar.
+- **Envie o leitor para o [Quickstart](/pt-br/documentacao/guia-de-estilo/conteudo/quickstart/)**, nos CTAs e de novo no roteador.
+- **Nunca encurte a amostra nem tire o diagrama para deixar a página mais curta.** Eles são as duas coisas que o leitor veio buscar. Uma página que cresceu demais cresceu em seções de capacidade; comprima essas no bloco de fronteiras.
+
+## Exemplos
+
+Este trecho, em inglês, da visão geral de **Functions** mostra o bloco de definição em duas camadas e depois a amostra. O primeiro parágrafo explica o que é uma function para um leitor que nunca usou uma; o segundo nomeia o produto e o que ele faz na Azion; a amostra mostra o artefato em vez de descrevê-lo:
+
+```mdx
+A function is code that runs when a request arrives, on infrastructure Azion operates. You write a handler that receives the request and returns a response. The platform starts the handler on demand and stops it when the response is sent, so there is no server to provision or scale. That model is called [serverless](https://www.azion.com/en/learning/serverless/what-is-serverless/).
+
+**Functions** runs that code in JavaScript on Azion's distributed network, inside the request path of an application or a firewall. Use Functions to build APIs, manipulate request and response headers, apply logic from request metadata, or block traffic before it reaches your application.
+
+## Function structure
+
+A function exports one default object whose keys are handlers. The `fetch` handler answers an HTTP request:
+
+<Code lang="javascript" code={`
+export default {
+  fetch: async (request, env, ctx) => {
+    return new Response('Hello World');
+  }
+};
+`} />
+
+- **`export default`** exposes the object Azion Runtime reads. Each key names a handler for one event.
+- **`fetch(request, env, ctx)`** runs on an HTTP request.
+- **The returned `Response`** answers the request.
+
+If you know the Web `Request` and `Response` objects, you know the code model.
+```
+
+A mesma página fecha com o roteador, indexado pelo que o leitor quer fazer e não pelo título das páginas:
+
+```mdx
+## Next steps
+
+| If you want to | Go to |
+| --- | --- |
+| Run your first function now | [Quickstart](/en/documentation/build/functions/quickstart/) |
+| Understand what invokes a function | [How Functions works](/en/documentation/build/functions/how-it-works/) |
+| Look up a handler, a parameter, or a limit | [Handlers](/en/documentation/build/functions/reference/handlers/) |
+| Look up a term | [Glossary](/en/documentation/build/functions/glossary/) |
+```
+
+## Relacionados
+
+- [Referência](/pt-br/documentacao/guia-de-estilo/conteudo/referencia/): a forma base que a visão geral aplica.
+- [Páginas de quickstart](/pt-br/documentacao/guia-de-estilo/conteudo/quickstart/): a página para onde a visão geral envia o leitor.
+- [Arquitetura de informação](/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura-de-informacao/): onde a visão geral fica na seção do produto.
+- [Escolher um tipo de conteúdo](/pt-br/documentacao/guia-de-estilo/conteudo/escolher-um-tipo-de-conteudo/): o catálogo completo de tipos de página.

--- a/src/content/docs/pt-br/pages/guia-de-estilo/convencoes/frontmatter.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/convencoes/frontmatter.mdx
@@ -1,0 +1,74 @@
+---
+title: Frontmatter
+description: >-
+  Defina os cinco campos de frontmatter de cada página — title, description,
+  meta_tags, namespace e permalink — sob as regras de cada um.
+meta_tags: 'style guide, frontmatter, namespace, permalink'
+namespace: documentation_style_guide_frontmatter
+permalink: /documentacao/guia-de-estilo/convencoes/frontmatter/
+menu_namespace: styleGuideMenu
+---
+
+## Comece pelo template
+
+Toda página da documentação abre com um bloco de frontmatter. Quem escreve define cinco campos. O exemplo mostra a página em inglês do par, que é a fonte da verdade:
+
+```yaml
+---
+title: Create an Object Storage bucket
+description: >-
+  Create a read-only Object Storage bucket and grant read-write
+  permissions from the Azion API, the CLI, or Azion Console.
+meta_tags: 'Object Storage, bucket, permissions, edge storage, create bucket'
+namespace: docs_store_storage_create_bucket
+permalink: /documentation/products/store/storage/create-bucket/
+---
+```
+
+O `title` vira o H1 da página. Por isso, o corpo começa em um heading `##`, nunca em `#`. Escreva o título com maiúscula só na primeira palavra e nos nomes próprios, como define [Terminologia da documentação](/pt-br/documentacao/guia-de-estilo/escrita/terminologia/).
+
+Um validador roda dentro de cada build. Ele interrompe o build quando um `namespace` ou um `permalink` está ausente, malformado ou aparece duas vezes no mesmo idioma. O validador não lê os outros campos; a qualidade deles depende de quem escreve.
+
+## Defina o namespace
+
+O `namespace` identifica a página no site. Ele também é a chave que une os idiomas: a página em inglês e a tradução em português carregam o mesmo valor, caractere por caractere. [Páginas bilíngues](/pt-br/documentacao/guia-de-estilo/convencoes/paginas-bilingues/) descreve o vínculo completo.
+
+Duas regras se aplicam:
+
+- Mantenha o valor único dentro do idioma. Um valor duplicado interrompe o build.
+- Mantenha o valor idêntico entre os dois idiomas. Um valor diferente quebra o seletor de idioma, e o build passa mesmo assim.
+
+A segunda regra não tem rede de proteção. O seletor perde a conexão entre as duas páginas em silêncio; confira o valor manualmente.
+
+Escreva o valor em palavras minúsculas unidas por underscore. Construa o valor a partir do produto e da funcionalidade: `docs_store_storage_create_bucket`.
+
+## Defina o permalink
+
+O `permalink` é a URL da página sem o segmento de idioma. Só o permalink define a URL; o caminho do arquivo não define.
+
+- Não adicione prefixo de idioma. A árvore de diretórios fornece o prefixo: um arquivo na árvore em português publica em `/pt-br/` mais o permalink. Um permalink que começa com `/pt-br/` publica a página em `/pt-br/pt-br/...`.
+- Use só letras ASCII minúsculas, dígitos, hífens e barras, e termine com uma barra: `/documentacao/produtos/store/storage/criar-bucket/`.
+- Mantenha o permalink único dentro do idioma. A página em inglês e a página em português têm permalinks diferentes, então o par nunca colide.
+- Remova os acentos dos permalinks em português: `configuracao`, não `configuração`.
+- Nomeie a URL pelo assunto da página, nunca pela posição atual no menu lateral. Mover um arquivo não muda a URL, então um permalink escolhido pelo assunto sobrevive a toda reorganização.
+- Mudar um permalink muda a URL, e a URL antiga passa a precisar de um redirect na mesma mudança.
+
+## Escreva a description e as meta_tags
+
+A `description` vira a meta description da página. O valor de `meta_tags` vira as keywords, em uma lista separada por vírgulas entre aspas.
+
+Nenhuma verificação valida esses dois campos, então um campo vazio publica em silêncio. Escreva os dois em toda página.
+
+Escreva a description como uma ou duas frases que se sustentam sozinhas, com 50 a 160 caracteres. Comece com um verbo no imperativo e diga o que o leitor realiza na página. Não repita o título palavra por palavra. As regras de [Estrutura de frases](/pt-br/documentacao/guia-de-estilo/escrita/estrutura-de-frases/) valem para a description.
+
+Quatro aberturas são proibidas: `Esta página descreve...`, `Este documento explica...`, `Saiba mais sobre...` e `Aprenda a...`. Comece direto com o verbo. Uma abertura genérica gasta a description sem acrescentar informação.
+
+## Posicione a página em um menu lateral
+
+O campo opcional `menu_namespace` nomeia o menu lateral que lista a página. Sem o campo, a página usa o menu padrão. Defina o campo quando a página pertence a uma seção com menu lateral próprio, e dê o mesmo valor aos dois idiomas.
+
+O campo também resolve a posse: cada página pertence a exatamente uma seção. Uma seção pode listar uma página que outra seção possui, e essa linha é um cross-link, não uma reivindicação. Mantenha a posse na seção onde os vizinhos da página vivem.
+
+## Omita o campo type
+
+O frontmatter aceita um campo opcional `type`, que troca a página para um layout especial, como uma home com grade de cards. Páginas de documentação omitem o campo. Uma página sem o campo usa o layout padrão, que é o correto para conteúdo de documentação.

--- a/src/content/docs/pt-br/pages/guia-de-estilo/convencoes/paginas-bilingues.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/convencoes/paginas-bilingues.mdx
@@ -1,0 +1,99 @@
+---
+title: Páginas bilíngues
+description: >-
+  Una as versões em inglês e português de uma página pelo namespace, com
+  permalinks localizados, links com prefixo de idioma e as regras de tradução.
+meta_tags: 'style guide, bilingual, translation, portuguese'
+namespace: documentation_style_guide_bilingual
+permalink: /documentacao/guia-de-estilo/convencoes/paginas-bilingues/
+menu_namespace: styleGuideMenu
+---
+
+## Escreva cada página duas vezes
+
+A documentação publica toda página em inglês e em português do Brasil. O inglês é a fonte da verdade. Escreva a página em português sobre a página em inglês pronta, não em paralelo com ela. A estrutura da página em português segue a página em inglês, e uma mudança na página em inglês cria trabalho correspondente na página em português.
+
+Para escrever ou atualizar uma página em português, abra primeiro a página em inglês. Se a página em inglês não existe, escreva-a primeiro: uma página em português escrita primeiro não tem fonte, e a página em inglês que vier depois vira uma tradução de uma tradução.
+
+## Vincule as versões pelo namespace
+
+O site vincula as duas versões de uma página pelo campo `namespace`, não pelo caminho do arquivo. O seletor de idioma depende desse vínculo. Os dois arquivos carregam o mesmo valor, caractere por caractere:
+
+```
+en:     title:     Create an Object Storage bucket
+        permalink: /documentation/products/store/storage/create-bucket/
+        namespace: docs_store_storage_create_bucket
+
+pt-br:  title:     Criar um bucket do Object Storage
+        permalink: /documentacao/produtos/store/storage/criar-bucket/
+        namespace: docs_store_storage_create_bucket
+```
+
+Cada campo do frontmatter segue uma de três regras na página em português:
+
+| Campo | Página em português |
+| --- | --- |
+| `title` | traduzido |
+| `description` | traduzida |
+| `permalink` | traduzido |
+| `namespace` | idêntico ao inglês |
+| `menu_namespace` | idêntico ao inglês |
+| `meta_tags` | por convenção, em inglês |
+
+Um namespace diferente entre as versões quebra o seletor de idioma, e o build passa mesmo assim. Nada avisa; confira o valor caractere por caractere antes de publicar. As regras de cada campo estão em [Frontmatter](/pt-br/documentacao/guia-de-estilo/convencoes/frontmatter/).
+
+## Localize diretórios e permalinks
+
+Localize os nomes de diretórios e de arquivos; não copie a árvore em inglês. `guides/` vira `guias/`, e `create-bucket.mdx` vira `criar-bucket.mdx`. Os permalinks seguem a mesma regra: `/documentation/products/...` vira `/documentacao/produtos/...`.
+
+Os permalinks ficam em ASCII nos dois idiomas. Remova os acentos em vez de codificá-los: `configuracao`, não `configuração`.
+
+## Use o prefixo de idioma correto nos links
+
+Links internos são absolutos, começam com um prefixo de idioma e terminam com barra. O mesmo link muda só o prefixo entre as duas versões:
+
+```
+Página em inglês:    [Applications](/en/documentation/build/applications/)
+Página em português: [Applications](/pt-br/documentacao/build/applications/)
+```
+
+Uma página em português aponta para uma página em inglês só quando a tradução não existe. Nunca envie o leitor para o inglês quando a página em português existe.
+
+## Escreva o inglês para sobreviver à tradução
+
+A página em inglês define a tarefa de quem traduz. Uma frase curta traduz um para um. Uma frase de 45 palavras com três orações subordinadas força quem traduz a reestruturá-la, e a reestruturação é onde o sentido se perde.
+
+As regras estruturais de [Estrutura de frases](/pt-br/documentacao/guia-de-estilo/escrita/estrutura-de-frases/) valem para o português sem mudança. Limite de tamanho de frase, uma instrução por passo, tempos verbais simples, voz ativa e agrupamentos curtos de substantivos: tudo se transfere. As regras de vocabulário não se transferem; o vocabulário do português está em [Terminologia da documentação](/pt-br/documentacao/guia-de-estilo/escrita/terminologia/).
+
+## Aplique as regras de tradução
+
+Cinco regras cobrem a maior parte do trabalho em uma página em português:
+
+- Não traduza termos técnicos genéricos: `data center`, `serverless`, `template`, `compliance`, `on-premise`. As strings `edge` e `edge computing` permanecem sem tradução onde já aparecem, mas textos novos não as introduzem.
+- Não traduza nomes de produto: **Applications**, **Functions**, **Firewall**, **Azion Platform**, **Azion Marketplace**.
+- Aplique as substituições: `aplicação`, não `aplicativo`; `edge`, não `borda`; `performance`, não `desempenho`.
+- Escreva títulos com maiúscula só na primeira palavra e nos nomes próprios.
+- Localize os rótulos dos asides: `:::note[nota]`, `:::tip[dica]`, `:::caution[Atenção]`. Um rótulo em inglês em uma página em português é um defeito visível.
+
+A lista completa de termos que ficam em inglês está em [Terminologia da documentação](/pt-br/documentacao/guia-de-estilo/escrita/terminologia/).
+
+## Use as formas fixas em português
+
+Três elementos recorrentes se traduzem sempre da mesma forma. Não improvise uma forma nova para eles.
+
+Três nomes de seção têm forma fixa em português:
+
+- `## Prerequisites` vira `## Pré-requisitos`.
+- `## Next steps` vira `## Próximos passos`.
+- `## Related resources` vira `## Recursos relacionados`.
+
+As frases padrão de link têm forma fixa, e o verbo é `consulte`:
+
+- `Para mais informações, consulte [Título](/pt-br/.../).`
+- `Para <fazer algo>, consulte [Título](/pt-br/.../).`
+
+Os rótulos da interface do Console ficam como a interface mostra. Não traduza nomes de botões e campos que o Console exibe em inglês: **Save**, **Workloads Access**, **+ Bucket**.
+
+## Revise toda tradução
+
+Nunca publique uma tradução automática sem revisão. Uma tradução errada é mais difícil de achar e corrigir do que uma tradução ausente, porque a página parece completa. Use tradução automática só como primeiro rascunho, e revise o rascunho antes de publicar.

--- a/src/content/docs/pt-br/pages/guia-de-estilo/escrita/acessibilidade.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/escrita/acessibilidade.mdx
@@ -1,0 +1,73 @@
+---
+title: Acessibilidade
+description: >-
+  Mantenha cada página utilizável com um leitor de tela: títulos e links
+  descritivos, sem linguagem direcional, alt text e instruções explícitas.
+meta_tags: 'style guide, accessibility, alt text'
+namespace: documentation_style_guide_accessibility
+permalink: /documentacao/guia-de-estilo/escrita/acessibilidade/
+menu_namespace: styleGuideMenu
+---
+
+Alguns leitores usam um leitor de tela, alguns navegam pelo teclado e alguns não distinguem cores. As regras desta página mantêm a documentação utilizável para todos eles. Elas seguem as Web Content Accessibility Guidelines (WCAG) 2.2.
+
+## Escreva um título de página descritivo e único
+
+O título identifica a página nos resultados de busca, na aba do navegador e no anúncio de página do leitor de tela. Um título genérico não identifica nada, e duas páginas com o mesmo título ficam indistinguíveis. Coloque a informação mais específica primeiro e nunca repita um título.
+
+- Incorreto: `Solução de problemas`
+- Correto: `Solucione erros de resolução de DNS`
+
+## Use um único H1 e não pule níveis de heading
+
+Um usuário de leitor de tela navega de heading em heading, e o esquema de headings funciona como o sumário da página. O campo `title` do frontmatter vira o único H1 da página. Comece o corpo em `##` e avance um nível por vez. Um salto de `##` para `####` implica um nível que não existe, e o esquema perde a estrutura.
+
+As regras completas de headings estão em [Títulos](/pt-br/documentacao/guia-de-estilo/formatacao/titulos/).
+
+## Escreva textos de link que nomeiam o destino
+
+Um leitor de tela pode apresentar os links de uma página como uma lista, fora das frases. Nessa lista, "clique aqui" e "leia mais" não nomeiam nada, e cada link genérico soa igual aos outros. Use o título da página de destino como texto do link.
+
+- Incorreto: `Para os limites de comprimento, [clique aqui](/pt-br/documentacao/guia-de-estilo/escrita/estrutura-de-frases/).`
+- Correto: `Os limites de comprimento estão em [Estrutura de frases](/pt-br/documentacao/guia-de-estilo/escrita/estrutura-de-frases/).`
+
+As regras de formatação de links estão em [Formatação de texto](/pt-br/documentacao/guia-de-estilo/formatacao/texto/).
+
+## Não use linguagem direcional
+
+"A caixa à direita" e "a seção abaixo" descrevem uma posição. A posição muda com o tamanho da tela e não significa nada para um leitor de tela, que lê a página em uma única ordem. Nomeie o elemento ou a seção.
+
+- Incorreto: `Clique no botão abaixo.`
+- Correto: `Selecione **Save**.`
+- Incorreto: `Veja a seção acima.`
+- Correto: `Consulte a seção Pré-requisitos.`
+
+## Escreva texto alternativo que descreve o que a imagem transmite
+
+O texto alternativo (alt text) substitui a imagem para o usuário de leitor de tela. Descreva o que a imagem transmite e por que ela está na página, em menos de 150 caracteres. Para um diagrama complexo, coloque a descrição completa no texto ao redor da imagem e mantenha o texto alternativo curto.
+
+Não comece com "imagem de" ou "foto de": o leitor de tela já anuncia o elemento como imagem. Use texto alternativo vazio (`![]`) apenas para uma imagem puramente decorativa. Não acumule keywords, porque o texto alternativo serve ao leitor, não ao ranking de busca.
+
+- Incorreto: `![Screenshot](/assets/docs/images/uploads/request-flow.png)`
+- Incorreto: `![edge, cache, CDN, fluxo de requisição, cache](/assets/docs/images/uploads/request-flow.png)`
+- Correto: `![Diagrama de uma requisição que vai do cliente, pelo edge, até a origem](/assets/docs/images/uploads/request-flow.png)`
+
+## Não use apenas cor em diagramas
+
+A cor não chega a todo leitor: muitos leitores não a distinguem, e um leitor de tela não a anuncia. Em um diagrama, use rótulos ou formas além da cor, e escreva a legenda com nomes, não com cores.
+
+- Incorreto: `As caixas verdes são as respostas em cache.`
+- Correto: `As caixas com o rótulo "cache hit" são as respostas em cache.`
+
+## Expanda as siglas no primeiro uso
+
+Escreva cada sigla por extenso no primeiro uso em cada página, porque o leitor chega a qualquer página diretamente. A regra completa está em [Escolha de palavras](/pt-br/documentacao/guia-de-estilo/escrita/escolha-de-palavras/).
+
+## Escreva instruções explícitas
+
+Uma instrução nomeia o controle e a ação, porque "salve as alterações" deixa o leitor procurar o controle na tela. Quando um campo tem um formato ou um limite, inclua a exigência no próprio passo.
+
+- Incorreto: `Salve as alterações.`
+- Correto: `Selecione **Save**.`
+- Incorreto: `Insira um valor.`
+- Correto: `Insira o TTL em segundos.`

--- a/src/content/docs/pt-br/pages/guia-de-estilo/escrita/escolha-de-palavras.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/escrita/escolha-de-palavras.mdx
@@ -1,0 +1,141 @@
+---
+title: Escolha de palavras
+description: >-
+  Corte o vocabulário de enchimento, evite adjetivos vazios, mantenha as
+  palavras que descrevem comportamento e rastreie cada número e nome até uma fonte.
+meta_tags: 'style guide, word choice, vocabulary'
+namespace: documentation_style_guide_word_choice
+permalink: /documentacao/guia-de-estilo/escrita/escolha-de-palavras/
+menu_namespace: styleGuideMenu
+---
+
+## Corte o vocabulário de enchimento
+
+Algumas palavras aparecem em rascunhos como decoração e não carregam significado técnico. Apague o enchimento e mantenha a frase: "é importante notar que" e "note que" não adicionam nada. Prefira a forma curta: "para" em vez de "a fim de", "porque" em vez de "devido ao fato de que" e "pode" em vez de "tem a capacidade de".
+
+Prefira o verbo simples: "use" em vez de "utilize", e "cubra" em vez de "explore em profundidade". Troque uma quantidade vaga pela real: nomeie o intervalo em vez de "uma ampla gama de" e conte as opções em vez de "várias".
+
+- Antes: `A fim de aproveitar as várias opções de cache, note que a configuração é simples.`
+- Depois: `Para armazenar conteúdo em cache, defina o TTL e a cache key.`
+
+Mantenha uma palavra dessa família quando ela carrega significado técnico. Corte quando ela decora.
+
+## Evite adjetivos vazios
+
+Um adjetivo vazio afirma qualidade sem descrever comportamento. Retire o adjetivo e diga o que o produto faz, o que ele suporta ou o que ele cobre. [Voz da documentação](/pt-br/documentacao/guia-de-estilo/escrita/voz/) é a dona da regra de registro. Esta página cobre o vocabulário.
+
+O teste é se a palavra afirma *qualidade* ou descreve *comportamento*. "Robust security" pede que o leitor confie em um adjetivo. "A robust retry with exponential backoff" nomeia o mecanismo, e o adjetivo agora descreve algo testável. Mantenha uma palavra que passa nesse teste. Substitua a que não passa.
+
+A mesma falha se esconde em molduras de frase. Escreva "Use para" em vez de "Perfeito para" ou "Essencial para", e "Use quando" em vez de "Melhor para". Diga a ação diretamente em vez de "capacita você a", e retire "moderno", "seamless" e "de ponta" como modificadores.
+
+- Antes: `Applications oferece um cache poderoso e flexível, perfeito para o e-commerce moderno.`
+- Depois: `Applications armazena conteúdo em cache na rede distribuída da Azion.`
+
+*Inflação de importância* é a mesma falha apontada para um conceito: uma frase sobre a importância de algo no lugar do que ele faz. "O cache desempenha um papel crucial na performance da web moderna" não dá ao leitor nada para fazer. Diga o que a coisa faz e quais são os limites.
+
+## Corte os padrões de enchimento
+
+Cinco padrões adicionam palavras sem adicionar informação.
+
+*Particípio de enchimento* é uma oração final com gerúndio: "…reduzindo a latência e melhorando a performance, garantindo uma experiência melhor." Corte a oração e mantenha a afirmação mensurável. A regra desse padrão no nível da frase está em [Estrutura de frases](/pt-br/documentacao/guia-de-estilo/escrita/estrutura-de-frases/).
+
+*Paralelismo negativo* é a forma "Não é só X, é Y." Diga Y.
+
+*Falsos intervalos* conectam itens que não estão em uma escala: "da configuração ao deploy ao monitoramento". Liste o conjunto real.
+
+*"Você pode" sem conteúdo* promete sem entregar: "Você pode configurar várias opções." Nomeie as opções ou aponte para a página que as nomeia.
+
+*Conclusões genéricas* repetem a página sem adicionar nada. Termine no último fato concreto ou em um link que valha a pena seguir.
+
+## Varie a forma de frases consecutivas
+
+Duas frases seguidas que começam com as mesmas palavras, ou que compartilham a mesma forma gramatical, soam como um template mesmo quando todos os fatos estão certos:
+
+- Antes: `Um edge node que tem uma cópia válida responde do cache. Um edge node que não tem uma cópia válida busca o objeto na origem.`
+- Depois: `Quando um node tem uma cópia válida, ele responde do cache. Caso contrário, o node busca o objeto na origem.`
+
+Três técnicas quebram o padrão: comece pela condição, e não pelo sujeito; contraste com um conectivo como `Caso contrário` em vez de nomear o sujeito duas vezes; e deixe uma frase carregar duas orações quando elas são um só pensamento. Um parágrafo cujas frases têm todas o mesmo comprimento médio soa do mesmo jeito, então varie o comprimento e prefira frases curtas.
+
+## Nomeie as coisas nos títulos
+
+Um título nomeia uma coisa ou uma tarefa. Uma pergunta retórica não faz nenhuma das duas.
+
+- Antes: `O que é cache?`
+- Depois: `Cache`
+- Antes: `Por que usar o Tiered Cache?`
+- Depois: `Quando usar o Tiered Cache`
+
+## Evite estas palavras em qualquer página
+
+Não chame uma tarefa de "simples", "fácil" ou "óbvia", e não suavize um passo com "basta", "é só" ou "simplesmente". Se a tarefa fosse fácil, o leitor não estaria aqui, e essas palavras dizem a um leitor travado que ele deveria se envergonhar.
+
+Não escreva "por favor". A documentação instrui. Ela não pede.
+
+Não ancore uma página no tempo com "atualmente", "no momento da escrita", "em breve", "agora disponível", "recentemente" ou "novo" como modificador. Todas envelhecem mal, e ninguém volta para corrigir. Nenhum mês ou ano aparece fora de um changelog: diga o que é verdade e deixe o changelog carregar a linha do tempo. Uma data gerada por um passo de build, como a coluna de última atualização em um hub de Guias e tutoriais, é exceção, porque nada escrito à mão envelhece ali.
+
+Escreva "por exemplo" e "isto é", nunca "e.g." nem "i.e.".
+
+## Use os verbos da interface
+
+Cada ação de interface recebe um verbo, o mesmo em todas as páginas. A tabela registra a regra do texto em inglês, a fonte canônica:
+
+| Use | Not |
+| --- | --- |
+| select | click, hit, tap |
+| go to | navigate to |
+| turn on, turn off | enable, disable (for switches and toggles) |
+| enter | type in, input |
+| refer to | see, check out |
+
+Em inglês, "enable" e "disable" continuam legítimos para descrever estado em prosa: "When the module is enabled, requests pass through it."
+
+Os procedimentos publicados em português usam "acesse", "selecione", "digite" e "defina"; nunca "clique".
+
+Não use linguagem direcional. Nomeie o elemento, conforme [Acessibilidade](/pt-br/documentacao/guia-de-estilo/escrita/acessibilidade/).
+
+A gramática de passos que usa esses verbos está em [Procedimentos](/pt-br/documentacao/guia-de-estilo/escrita/procedimentos/).
+
+## Use linguagem inclusiva
+
+A documentação trata o leitor por "você", e o leitor genérico nunca precisa de um pronome de gênero. No texto em inglês, um terceiro genérico — quem ataca, quem desenvolve — recebe "they", nunca "he" ou "she".
+
+Expressões com marca de gênero e expressões capacitistas seguem a mesma regra. Escreva `validate`, não `sanity check`.
+
+Um cargo ou uma profissão usa um substantivo neutro. Escreva `operador de câmera`, não uma forma marcada por gênero.
+
+Substitua um termo técnico carregado quando a indústria aceita uma alternativa. Os termos ficam em inglês porque o texto em inglês é a fonte canônica:
+
+| Evite | Use |
+| --- | --- |
+| whitelist | allowlist |
+| blacklist | blocklist |
+| master/slave | primary/replica |
+
+Não use referências culturais nem expressões idiomáticas. Elas fazem sentido em um único lugar e não sobrevivem à tradução. Cada página aqui é publicada em dois idiomas, conforme [Páginas bilíngues](/pt-br/documentacao/guia-de-estilo/convencoes/paginas-bilingues/).
+
+## Retire o artigo antes de um nome de produto
+
+Um nome de produto é um nome próprio, então não leva artigo.
+
+- Incorreto: `Acesse o Azion Console.`
+- Correto: `Acesse Azion Console.`
+
+O artigo volta quando um substantivo comum acompanha o nome, porque aí ele pertence a esse substantivo: `O módulo Application Accelerator acelera conteúdo dinâmico.`
+
+## Use a grafia do inglês americano
+
+Nos trechos em inglês, escreva `organize`, `behavior` e `license`. Grafias britânicas entram em páginas copiadas da documentação de fornecedores, então confira as que diferem.
+
+## Expanda as siglas no primeiro uso
+
+O primeiro uso em cada página escreve o termo por extenso e coloca a sigla entre parênteses: `time to live (TTL)`. Depois disso, apenas a sigla. O leitor chega a qualquer página diretamente, por um resultado de busca, e uma definição em outra página não existe para ele.
+
+Nomes de produto não são siglas. Escreva o nome conforme as regras em [Terminologia da documentação](/pt-br/documentacao/guia-de-estilo/escrita/terminologia/) e não o expanda.
+
+## Confirme cada dado
+
+Um dado inventado é a pior falha da documentação. Um limite, um valor padrão, um nome de campo, uma flag ou uma mensagem de erro inventados parecem iguais aos corretos. O leitor descobre a diferença só quando tenta usar e falha.
+
+Cada número, nome de campo e comando vem de algum lugar que você consegue apontar: o próprio produto, a API dele ou o time que cuida dele. Quando não consegue confirmar um valor, deixe-o de fora. Uma página que diz menos é recuperável. Uma página com um valor errado e confiante não é, porque ninguém sabe que precisa conferir.
+
+Os nomes de produto seguem regras próprias, em [Terminologia da documentação](/pt-br/documentacao/guia-de-estilo/escrita/terminologia/).

--- a/src/content/docs/pt-br/pages/guia-de-estilo/escrita/estrutura-de-frases.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/escrita/estrutura-de-frases.mdx
@@ -1,0 +1,113 @@
+---
+title: Estrutura de frases
+description: >-
+  Aplique o ASD-STE100 a cada frase: limites por tipo de conteúdo, tempos
+  simples, voz ativa e as regras que evitam ambiguidade.
+meta_tags: 'style guide, sentences, simplified technical english, ASD-STE100'
+namespace: documentation_style_guide_sentence_structure
+permalink: /documentacao/guia-de-estilo/escrita/estrutura-de-frases/
+menu_namespace: styleGuideMenu
+---
+
+## Escreva para um leitor que não pode perguntar
+
+A indústria aeroespacial e de defesa publica o ASD-STE100, uma linguagem controlada para escrita técnica. A Issue 9, de 15 de janeiro de 2025, contém 53 regras de escrita em 9 seções. O padrão também traz um dicionário com cerca de 900 palavras aprovadas. Cada palavra desse dicionário tem um significado e uma classe gramatical.
+
+A documentação da Azion segue essas regras porque seus leitores correspondem ao leitor-alvo do padrão. Muitos leitores trabalham em um segundo idioma. Nenhum autor está presente para responder perguntas. Sistemas de busca indexam estas páginas em seções e retornam uma seção, não a página inteira. Uma frase em inglês que segue essas regras também chega ao português com menos desvio.
+
+## Ajuste o limite de frase ao tipo de conteúdo
+
+O ASD-STE100 define regras mais rígidas para procedimentos do que para descrições. A Azion aplica essa divisão às quatro formas base.
+
+| Tipo de conteúdo | Modo | Limite por frase |
+| --- | --- | --- |
+| Tutorial | Procedural | 20 palavras |
+| How-to | Procedural | 20 palavras |
+| Referência | Descritivo | 25 palavras |
+| Explicação | Descritivo | 25 palavras |
+
+Um procedimento tem o limite mais rígido porque o leitor executa cada passo sob pressão. Um passo que o leitor lê errado vira uma ação que falha. Os limites contam apenas frases de texto corrido. Células de tabela, código e saída de comando ficam fora da contagem.
+
+## Use apenas tempos verbais simples
+
+Escreva com o imperativo, o presente simples, o passado simples e o futuro simples. Não construa tempos compostos com verbos auxiliares. Prefira o presente simples para comportamento do produto, porque a plataforma se comporta da mesma forma em cada requisição.
+
+- Antes: `O deploy está sendo processado.`
+- Depois: `O deploy está em andamento.`
+- Antes: `Firewall vai bloquear a requisição.`
+- Depois: `Firewall bloqueia a requisição.`
+
+## Use termos em -ing apenas como substantivos
+
+Em inglês, um termo em -ing precisa ser um substantivo ou parte de um, como em `caching` ou `request logging`. Não use um termo em -ing como verbo nem como oração final. Em português, o mesmo defeito aparece como oração final no gerúndio, que esconde quem age e quando a ação acontece.
+
+- Antes: `A função valida o token, retornando um erro quando a assinatura falha.`
+- Depois: `A função valida o token. Quando a assinatura falha, a função retorna um erro.`
+
+A mesma lógica vale para títulos de tarefa, que começam com um verbo no imperativo, não com gerúndio. As regras completas estão em [Títulos](/pt-br/documentacao/guia-de-estilo/formatacao/titulos/).
+
+## Limite os agrupamentos de substantivos a três palavras
+
+Em inglês, uma pilha de quatro ou mais substantivos não tem gramática entre as palavras. O leitor não sabe qual palavra modifica qual. Desfaça o agrupamento com preposições. Um nome de produto conta como uma unidade, então **Real-Time Metrics** ocupa uma das três posições.
+
+- Antes: `the request phase behavior execution order`
+- Depois: `the execution order of the behaviors in the request phase`
+
+O português desfaz esses agrupamentos com preposições. Mantenha as preposições na tradução.
+
+## Mantenha o sujeito, o verbo e os artigos
+
+Não corte palavras para encurtar uma frase. Uma frase sem sujeito, verbo ou artigos é mais curta e diz menos. Quando uma frase fica longa, divida a frase em duas.
+
+- Antes: `Objetos não armazenados em cache são buscados na origem.`
+- Depois: `Quando um objeto não está no cache, a Azion o busca na origem.`
+
+## Mantenha cada parágrafo em um tópico
+
+Escreva um tópico por parágrafo, em no máximo seis frases. Sistemas de busca cortam as páginas em blocos, e um parágrafo com dois tópicos divide mal em qualquer ponto de corte. Cada fragmento carrega metade do significado.
+
+- Antes: um parágrafo que define a cache key e depois descreve o purge.
+- Depois: um parágrafo para a cache key e um segundo parágrafo para o purge.
+
+## Use uma lista vertical para uma sequência
+
+Formate três ou mais passos, condições ou alternativas como uma lista numerada ou com marcadores. Uma sequência em uma única frase obriga o leitor a interpretar a ordem e as ações ao mesmo tempo.
+
+Antes:
+
+`Salve o arquivo, depois execute o build e depois faça o deploy da aplicação.`
+
+Depois:
+
+1. Salve o arquivo.
+2. Execute o build.
+3. Faça o deploy da aplicação.
+
+## Use a mesma palavra para a mesma ação
+
+Escolha um verbo para cada ação e repita esse verbo na página inteira. Uma rotação de sinônimos diz ao leitor que cada verbo nomeia uma ação diferente.
+
+- Antes: `Verifique se o build passou. Depois confira se o deploy passou.`
+- Depois: `Verifique se o build passou. Depois verifique se o deploy passou.`
+
+Quando uma frase descreve um controle do Console, use o rótulo que o Console mostra. Não melhore o vocabulário da interface.
+
+O ASD-STE100 acompanha suas regras com um dicionário aprovado. As regras 1.5 e 1.12 permitem que um projeto aprove seus próprios nomes técnicos e verbos técnicos. A Azion usa essa permissão: o vocabulário aprovado está em [Escolha de palavras](/pt-br/documentacao/guia-de-estilo/escrita/escolha-de-palavras/) e em [Terminologia da documentação](/pt-br/documentacao/guia-de-estilo/escrita/terminologia/).
+
+## Confira seu rascunho
+
+Confirme cada ponto antes de publicar a página:
+
+- Cada tempo verbal é simples, e o comportamento do produto usa o presente simples.
+- Cada termo em -ing funciona como substantivo e nenhuma frase termina em gerúndio.
+- Cada agrupamento de substantivos tem no máximo três palavras, com um nome de produto contado como uma.
+- Cada frase mantém o sujeito, o verbo e os artigos.
+- Cada parágrafo cobre um tópico em no máximo seis frases.
+- Cada sequência de três ou mais itens é uma lista vertical.
+- Cada ação mantém o mesmo verbo na página inteira.
+
+## Fontes
+
+- [Site oficial do ASD-STE100](https://www.asd-ste100.org/): o padrão, com download gratuito.
+- [About STE](https://www.asd-ste100.org/about_STE.html): as 53 regras, as 9 seções e a data da Issue 9.
+- [Guia de estilo de documentação do Google: headings](https://developers.google.com/style/headings): o caso contra o gerúndio como primeira palavra de um título.

--- a/src/content/docs/pt-br/pages/guia-de-estilo/escrita/procedimentos.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/escrita/procedimentos.mdx
@@ -1,0 +1,100 @@
+---
+title: Procedimentos
+description: >-
+  Escreva passos numerados com uma ação cada, o primeiro passo canônico do
+  Console, localização antes da ação e uma frase de resultado por procedimento.
+meta_tags: 'style guide, procedures, steps, numbered lists'
+namespace: documentation_style_guide_procedures
+permalink: /documentacao/guia-de-estilo/escrita/procedimentos/
+menu_namespace: styleGuideMenu
+---
+
+## O primeiro passo
+
+Todo procedimento numerado da documentação segue estas regras, em qualquer tipo de página. A primeira regra consolida acesso e navegação em um único passo. Não faça de "Log in" um passo próprio quando o passo seguinte é ir a algum lugar.
+
+Procedimentos no Console começam com a string canônica:
+
+```
+1. Acesse [Azion Console](https://console.azion.com/) > **<Produto>**.
+```
+
+Preencha o produto: `> **Object Storage**`, `> **Firewall**`. Uma navegação mais profunda estende a cadeia: `> **Applications** > **sua aplicação**`.
+
+Um procedimento de um único comando não é uma lista numerada. Escreva uma frase de introdução terminada em dois-pontos e depois o comando:
+
+```mdx
+Para criar o bucket com a Azion CLI:
+
+<Code lang="bash" code={`azion create bucket --name <your-bucket-name>`} />
+```
+
+A numeração começa quando o procedimento tem duas ou mais ações. A introdução de um procedimento de API nomeia o método e o endpoint: "Envie uma requisição `POST` para o endpoint de buckets:" e depois o bloco `curl`.
+
+## Uma ação por passo
+
+Um passo com duas ações é um passo em que a segunda ação é pulada.
+
+- Incorreto: `Selecione **Save**, depois faça o purge do cache e confirme a mudança do TTL.`
+- Correto: três passos numerados, um para cada ação.
+
+Movimentos pequenos que formam um único gesto podem dividir um passo, e portanto uma única frase: `Digite um nome e selecione **Read Only**.` Este é o único lugar em que uma frase carrega dois imperativos, e ele prevalece sobre as regras de frase em [Estrutura de frases](/pt-br/documentacao/guia-de-estilo/escrita/estrutura-de-frases/).
+
+## Ordem dentro de um passo
+
+O leitor se orienta, depois age. A localização vem antes da ação:
+
+- Incorreto: `Selecione **Add Rule** na aba Rules Engine.`
+- Correto: `Na aba **Rules Engine**, selecione **Add Rule**.`
+
+A finalidade vem antes da ação. Quando um passo existe por uma razão que o leitor não pode ver, comece por ela: `Para excluir a regra, selecione **Delete**.`
+
+A condição vem antes da ação: `Se a lista estiver vazia, selecione **Add**.`
+
+## Gramática do passo
+
+- Escreva no imperativo, na voz ativa e no presente: `Selecione **Save**.` Nunca "Você deve selecionar" ou "O botão Save deve ser selecionado".
+- Comece um passo opcional com a palavra literal `(Opcional)`: `3. (Opcional) Digite uma descrição para a regra.`
+- Marque subpassos com letras minúsculas (`a.`, `b.`) e o nível seguinte com números romanos minúsculos. Se um passo precisa desse terceiro nível, o procedimento pede divisão.
+- Use negrito no rótulo da interface e itálico no valor: `Defina **Workloads Access** como _Read Only_.`
+- Use apenas os verbos da interface. Em inglês: select, go to, turn on, turn off, enter; nunca click, hit, enable, disable. Em português, os procedimentos usam acesse, selecione, digite e defina; nunca clique. A tabela está em [Escolha de palavras](/pt-br/documentacao/guia-de-estilo/escrita/escolha-de-palavras/).
+- Use as palavras da própria interface. Se o botão diz **Save**, o passo diz selecione **Save**, não "confirme" ou "aplique". Não melhore o vocabulário da interface na prosa que a descreve.
+- Não use linguagem direcional. Nomeie o elemento, não onde ele fica na tela, conforme [Acessibilidade](/pt-br/documentacao/guia-de-estilo/escrita/acessibilidade/).
+- Mantenha cada frase em 20 palavras e cada passo com uma instrução. O orçamento procedural está em [Estrutura de frases](/pt-br/documentacao/guia-de-estilo/escrita/estrutura-de-frases/).
+
+## A frase de introdução
+
+Imediatamente antes da lista numerada, uma frase declara o objetivo e termina em dois-pontos:
+
+```
+Para fazer o deploy do conjunto de regras da sua aplicação:
+```
+
+Use dois-pontos quando a frase precede os passos imediatamente. Use ponto final quando algo fica entre eles, como um aside. Nunca escreva uma frase parcial que os passos completam.
+
+## Depois do procedimento
+
+Termine todo procedimento com uma frase de resultado. Diga o que o leitor agora tem ou vê, para que ele saiba que teve sucesso sem perguntar.
+
+- `O bucket aparece na lista de buckets.`
+- `A resposta retorna "state": "executed" com o nome do bucket.`
+
+Quando a interface não mostra saída, declare o estado resultante: `O bucket tem o novo nível de acesso.` Nunca escreva saída da interface, códigos de resposta, headers ou mensagens que você não viu o produto produzir. Essa distinção separa uma frase de resultado de um fato inventado.
+
+Avise sobre o tempo de propagação. Se um resultado demora a propagar, diga isso e diga o que fazer: "Novas regras podem levar alguns minutos para propagar. Diante de uma resposta inesperada, aguarde e tente novamente antes de diagnosticar."
+
+Tarefas seguintes vão para a seção `## Próximos passos` da página, nunca para uma seção de "pós-requisitos".
+
+## Mostre o output esperado
+
+Todo comando que o leitor executa é seguido do output que ele deve ver. Mostre o output completo quando ele é curto, e o trecho relevante quando ele é longo. O output confirma que o passo funcionou antes que o próximo passo dependa dele.
+
+Input e output usam blocos diferentes: um bloco `<Code>` para o comando que o leitor copia, um fence para o output que ele lê. A mecânica está em [Código](/pt-br/documentacao/guia-de-estilo/formatacao/codigo/).
+
+Quando um comando não produz output, declare o estado resultante. Quando não é possível declarar nenhum dos dois, corte o comando ou reestruture o passo em torno de um resultado que o leitor consegue conferir: um comando que o leitor não consegue verificar é pior do que um comando a menos. Nunca escreva um output que você não viu o comando produzir.
+
+## Múltiplas interfaces
+
+Quando uma tarefa tem um caminho no Console, na CLI e na API, os caminhos vão em um bloco `<Tabs>`: um procedimento por painel, com o Console primeiro. Cada painel abre com a própria frase de introdução nomeando a interface: `Para criar o bucket com a Azion CLI:`. Os passos ou o comando vêm em seguida, e a introdução nunca é repetida como um passo. Nunca misture duas interfaces em uma mesma lista numerada. A mecânica do bloco `<Tabs>` está em [Componentes](/pt-br/documentacao/guia-de-estilo/componentes/).
+
+Inclua um painel só quando tiver executado o procedimento dele do início ao fim. Deixe de fora uma interface que você ainda não consegue verificar, em vez de preencher os passos dela a partir dos outros painéis.

--- a/src/content/docs/pt-br/pages/guia-de-estilo/escrita/terminologia.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/escrita/terminologia.mdx
@@ -1,0 +1,53 @@
+---
+title: Terminologia da documentação
+description: >-
+  Aplique as regras de nomes: os nomes de produto da documentação e os termos
+  que ficam em inglês.
+meta_tags: 'style guide, terminology, product names'
+namespace: documentation_style_guide_terminology
+permalink: /documentacao/guia-de-estilo/escrita/terminologia/
+menu_namespace: styleGuideMenu
+---
+
+## Use os nomes de produto da documentação
+
+Todo produto tem um nome de documentação, e toda página usa esse nome. Busque o nome atual na página de visão geral do produto, a raiz da seção. Este guia não repete os nomes, porque uma cópia fica errada no dia em que um nome muda.
+
+Quando um nome de marketing difere do nome da documentação, escreva o nome de marketing uma vez, entre parênteses, na primeira menção. Depois disso, o nome da documentação aparece sozinho.
+
+A Azion renomeou seus produtos e recursos de plataforma ao longo do tempo. Os nomes antigos ainda aparecem em páginas antigas, URLs e nomes de diretórios, e por isso parecem atuais. Trate esses nomes como história, não como sinônimos.
+
+## Nomeie um módulo como produto
+
+**Applications**, **Firewall** e **Connectors** são recursos de plataforma: capacidades da própria plataforma. Os módulos de um recurso são produtos. Nomeie o produto primeiro, com o recurso como contexto.
+
+- Correto: `Web Application Firewall (WAF) é um módulo do Firewall que inspeciona requisições HTTP e HTTPS.`
+- Incorreto: `Firewall é um produto que inclui o WAF.`
+
+## Use verbo no singular com um nome de forma plural
+
+Um nome de produto nomeia um produto, qualquer que seja a forma. Applications, Functions e Connectors levam verbo no singular: `Applications armazena conteúdo em cache`, `Functions executa seu código` — nunca `Applications armazenam`. O inglês concorda da mesma forma: `Applications caches content`, nunca `Applications cache`.
+
+## Escreva em minúscula a coisa que o cliente constrói
+
+O nome do produto leva maiúscula. A coisa que o cliente cria com ele é um substantivo comum, e fica em minúscula.
+
+- Correto: `Use **Applications** para construir suas próprias aplicações.`
+- Correto: `**Functions** executa suas funções na rede distribuída da Azion.`
+- Incorreto: `Faça o deploy da sua primeira Application.`
+
+A distinção mantém o nome do produto com significado. Uma página que escreve os dois em maiúscula deixa o leitor sem saber o que é o produto e o que é o objeto.
+
+## Mantenha nomes históricos em documentos históricos
+
+Changelogs, release notes e contratos datados registram o que era verdade no dia da publicação. Esses documentos mantêm os nomes de produto da época da publicação. Um Termos de Serviço de 2020 mantém os nomes que eram corretos em 2020.
+
+Não renomeie produtos em um documento histórico. Um nome atualizado reescreve o registro e separa o texto da sua data.
+
+## Deixe estes termos em inglês
+
+Estes termos são vocabulário técnico genérico, não nomes de produto. Eles ficam em inglês nos dois idiomas:
+
+`data center` · `serverless` · `on-premise` · `template` · `compliance` · `e-commerce` · `e-mail` · `keywords` · `meta description`
+
+Uma tradução cria um segundo nome para um conceito que o leitor já conhece em inglês. A documentação usa um termo para cada conceito, em todas as páginas.

--- a/src/content/docs/pt-br/pages/guia-de-estilo/escrita/voz.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/escrita/voz.mdx
@@ -1,0 +1,67 @@
+---
+title: Voz da documentação
+description: >-
+  Escreva em segunda pessoa, presente simples e voz ativa: passos no
+  imperativo, comportamento no lugar de qualidade e frases que mantêm a
+  gramática.
+meta_tags: 'style guide, voice, writing'
+namespace: documentation_style_guide_voice
+permalink: /documentacao/guia-de-estilo/escrita/voz/
+menu_namespace: styleGuideMenu
+---
+
+## Trate o leitor por "você"
+
+A documentação fala com a pessoa que executa o trabalho. A segunda pessoa mantém o leitor dentro da frase, como sujeito do verbo. "O usuário" transforma o leitor em um terceiro e empurra o verbo para o futuro.
+
+- Antes: `O usuário criará um bucket.`
+- Depois: `Você cria um bucket.`
+
+## Use o presente simples
+
+Descreva o comportamento do produto no presente simples. O presente afirma o que a plataforma faz todas as vezes, e é sobre essa afirmação que o leitor age.
+
+- Antes: `Applications armazenará conteúdo em cache na rede distribuída da Azion.`
+- Depois: `Applications armazena conteúdo em cache na rede distribuída da Azion.`
+
+[Estrutura de frases](/pt-br/documentacao/guia-de-estilo/escrita/estrutura-de-frases/) é a dona das regras completas de tempos verbais, incluindo a proibição de tempos compostos com verbos auxiliares.
+
+## Use a voz ativa
+
+A voz ativa nomeia o ator. A passiva esconde o ator, e o ator costuma ser a resposta que o leitor veio buscar.
+
+- Antes: `Uma política de cache é aplicada à requisição.`
+- Depois: `Rules Engine aplica uma política de cache à requisição.`
+
+A versão passiva deixa em aberto quem aplica a política: a plataforma, o navegador ou o leitor. Em texto descritivo, a passiva é aceitável apenas quando o ator é desconhecido ou é a própria plataforma. Nunca use a passiva em um passo.
+
+## Escreva os passos no imperativo
+
+Um passo é uma instrução, então ele começa pelo verbo: `Selecione **Save**.`, nunca "Você deve selecionar" nem "O botão deve ser selecionado". [Procedimentos](/pt-br/documentacao/guia-de-estilo/escrita/procedimentos/) é a página dona da gramática de passos.
+
+## Descreva comportamento, não qualidade
+
+A documentação descreve comportamento e limites. Ela não vende, porque o leitor já escolheu o produto. Um adjetivo que afirma qualidade não dá ao leitor nada para fazer; um comportamento e um limite dão.
+
+- Antes: `Applications oferece capacidades de cache poderosas e flexíveis.`
+- Depois: `Applications armazena conteúdo em cache na rede distribuída da Azion. O TTL padrão é de 60 segundos.`
+
+A reescrita troca dois adjetivos por fatos que o leitor pode testar. As regras de vocabulário estão em [Escolha de palavras](/pt-br/documentacao/guia-de-estilo/escrita/escolha-de-palavras/).
+
+## Divida frases longas, não corte palavras
+
+Frases curtas carregam melhor o conteúdo técnico. Curto não é o mesmo que truncado: nunca corte o sujeito, o verbo ou o artigo para encurtar uma frase. Quando uma frase fica longa, divida a frase em duas. [Estrutura de frases](/pt-br/documentacao/guia-de-estilo/escrita/estrutura-de-frases/) é a dona desta regra e dos limites de comprimento.
+
+## Não use contrações
+
+Em inglês, escreva "do not", "cannot" e "it is". Contrações soam casuais e traduzem de forma desigual. O exemplo permanece em inglês porque a regra se aplica ao texto em inglês.
+
+- Antes: `You don't need to configure the origin again.`
+- Depois: `You do not need to configure the origin again.`
+
+## Não escreva "nós"
+
+Nunca escreva "nós". O ator é "a Azion" ou "você". "Nós" não nomeia nem a plataforma nem o leitor. Em português, a regra também vale para o verbo na primeira pessoa do plural, como em "recomendamos".
+
+- Antes: `Nós recomendamos um TTL de 60 segundos.`
+- Depois: `A Azion recomenda um TTL de 60 segundos.`

--- a/src/content/docs/pt-br/pages/guia-de-estilo/formatacao/codigo.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/formatacao/codigo.mdx
@@ -1,0 +1,60 @@
+---
+title: Código
+description: >-
+  Execute cada comando antes de publicar, use placeholders que não se
+  confundem com valores reais e deixe credenciais fora dos blocos de código.
+meta_tags: 'style guide, code blocks, placeholders'
+namespace: documentation_style_guide_code
+permalink: /documentacao/guia-de-estilo/formatacao/codigo/
+menu_namespace: styleGuideMenu
+---
+
+## Execute cada comando antes de publicar
+
+Um bloco de código não testado é um palpite com aparência de autoridade. A prosa sinaliza incerteza com palavras; um bloco de código não sinaliza nada, e o leitor o executa com confiança total. Na página, um comando inventado é idêntico a um comando testado. A diferença aparece quando o comando falha, na máquina do leitor.
+
+Execute cada comando e cada snippet antes de publicar a página. Quando não puder executar um, não o publique. Uma página que afirma menos, e acerta em tudo o que afirma, vale mais do que uma página que adivinha.
+
+## Componha, não invente
+
+Um bloco de código mistura dois tipos de conteúdo: os fatos que ele carrega e a sintaxe que os expressa. A sintaxe de ferramenta necessária para expressar um fato com fonte é composição, não invenção. Flags de `curl`, um cabeçalho `Content-Type` para um dado corpo JSON e as aspas do shell entram nessa categoria. Um novo valor de produto, campo, endpoint ou valor padrão é invenção.
+
+Para a regra de que cada dado rastreia até uma fonte, consulte [Escolha de palavras](/pt-br/documentacao/guia-de-estilo/escrita/escolha-de-palavras/).
+
+## Torne os placeholders óbvios e consistentes
+
+Um placeholder tem um trabalho: o leitor precisa ver de imediato que deve substituir aquele valor. Dois formatos cumprem esse trabalho: colchetes com maiúsculas, `[TOKEN VALUE]`, e os sinais `<` e `>` com palavras minúsculas, `<your-bucket-name>`. Use um único formato para todos os placeholders de uma página; três convenções na mesma página não ensinam nenhuma.
+
+Cada tipo de valor tem uma forma reservada:
+
+| Tipo de valor | Forma |
+| --- | --- |
+| Segredo ou token | `[TOKEN VALUE]` |
+| Nome ou valor fornecido pelo leitor | `<your-bucket-name>`, `<your-azion-domain>` |
+| Domínio de exemplo | `example.com`, `example.org` |
+| Faixa de IP de exemplo | `192.0.2.0/24`, `198.51.100.0/24`, `203.0.113.0/24` |
+
+As faixas de IP são reservadas para documentação e não roteiam para nenhum destino.
+
+- Incorreto: `--token abc123`
+- Correto: `--token [TOKEN VALUE]`
+
+`abc123` parece um valor que pode funcionar, e um leitor com pressa o cola sem alterar. `[TOKEN VALUE]` não passa por um valor real. O pior placeholder é um valor falso realista, porque esconde que existe algo para substituir.
+
+## Introduza cada bloco de código
+
+Uma frase antes do bloco declara o que o código faz. Um bloco de código sem contexto é um trecho que o leitor precisa decifrar antes de decidir se executa.
+
+## Deixe o prompt fora do que o leitor copia
+
+Nenhum `$` ou `>` antes de um comando. O leitor cola a linha com o prompt junto, e o comando falha. Um prompt só cabe em saída mostrada em um fence, onde reproduz uma sessão real.
+
+## Escreva comentários como prosa
+
+Um comentário dentro de um snippet segue o idioma da página e as regras de frase, e diz por quê, não o quê. Um comentário que repete a linha abaixo dele não acrescenta nada.
+
+## Mantenha credenciais fora dos blocos de código
+
+Nenhuma credencial real aparece na documentação: nem uma ativa, nem uma expirada, nem uma revogada. Na página, uma credencial expirada é indistinguível de uma ativa, e por isso a proibição cobre todas por igual. Um valor inventado com formato realista é proibido pela mesma razão: nenhum leitor, e nenhum scanner, o distingue de um vazamento. Escreva o placeholder: `[TOKEN VALUE]`.
+
+Esta seção não mostra um exemplo incorreto. Uma credencial falsa realista em um guia de estilo ainda é uma credencial falsa realista em documentação pública.

--- a/src/content/docs/pt-br/pages/guia-de-estilo/formatacao/imagens.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/formatacao/imagens.mdx
@@ -1,0 +1,38 @@
+---
+title: Imagens
+description: >-
+  Adicione um screenshot só quando ele merece o lugar, mantenha dados
+  sensíveis fora dele e dê a cada imagem seu alt text.
+meta_tags: 'style guide, images, screenshots, alt text'
+namespace: documentation_style_guide_images
+permalink: /documentacao/guia-de-estilo/formatacao/imagens/
+menu_namespace: styleGuideMenu
+---
+
+## Use um screenshot somente quando as palavras falharam
+
+Todo screenshot é um custo de manutenção. A interface muda sem aviso, a página fica desatualizada em silêncio e um screenshot desatualizado engana com total confiança. Adicione um somente quando as palavras sozinhas não carregaram a instrução.
+
+O teste: se a frase nomeia o controle e a ação com clareza, o screenshot a repete. Apague o screenshot, mantenha a frase.
+
+## Mantenha informações sensíveis fora
+
+Um screenshot nunca mostra dados reais de conta: nomes, e-mails, tokens, domínios ou identificadores. Capture uma conta de teste, ou mascare os valores antes de publicar. Um valor vazado em uma imagem é tão público quanto um valor vazado em texto, e mais difícil de encontrar depois.
+
+## Recorte para a área relevante
+
+Capture a parte da interface que a instrução aponta, não a tela inteira. Elementos voláteis da interface — menus, avatares, banners de versão — datam a imagem e desviam a atenção do controle que importa.
+
+## Escreva alt text para cada imagem
+
+O alt text declara o que a imagem transmite, em uma frase. As regras estão em [Acessibilidade](/pt-br/documentacao/guia-de-estilo/escrita/acessibilidade/).
+
+## Formate o caminho do asset
+
+Caminhos de asset são absolutos a partir da raiz, sem prefixo de idioma, porque uma imagem serve as duas versões de idioma:
+
+- Correto: `/assets/docs/images/uploads/diagram.png`
+
+## Registros históricos são isentos
+
+Screenshots em changelogs e release notes registram como a interface era naquela data. Eles são registros de um momento: não os atualize quando a interface mudar.

--- a/src/content/docs/pt-br/pages/guia-de-estilo/formatacao/numeros.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/formatacao/numeros.mdx
@@ -1,0 +1,72 @@
+---
+title: Números e unidades
+description: >-
+  Escreva números do mesmo jeito em toda página: quando escrever por extenso,
+  separadores, unidades de medida, datas, horários e moeda.
+meta_tags: 'style guide, numbers, units, dates, measurements'
+namespace: documentation_style_guide_numbers
+permalink: /documentacao/guia-de-estilo/formatacao/numeros/
+menu_namespace: styleGuideMenu
+---
+
+## Escreva de zero a nove por extenso
+
+Escreva `zero` até `nove` por extenso, e `10` em diante com algarismos.
+
+- Correto: `Crie três regras.`
+- Correto: `A conta permite 100 buckets.`
+
+Três casos usam algarismo em qualquer valor: uma medida, uma versão e tudo o que o leitor digita ou lê na tela. `Defina o TTL em 5 segundos`, não `cinco segundos`.
+
+## Use vírgula para decimais e ponto para milhares
+
+| Regra | Exemplo |
+| --- | --- |
+| Vírgula como separador decimal | `9,5`, `3,14159` |
+| Ponto para milhares | `10.000`, `25.456.990` |
+| Zero antes da vírgula abaixo de um | `0,5`, nunca `,5` |
+
+O inglês inverte os dois separadores e escreve `10,000` e `9.5`. Um número copiado de um par para o outro sem conversão fica errado em um dos idiomas, e essa é a falha mais comum em uma tradução.
+
+## Escreva a unidade junto do número
+
+- Coloque um espaço entre o algarismo e a unidade: `20 MB`, `60 segundos`.
+- Use hífen quando a medida modifica um substantivo em inglês: `a 60-second TTL`.
+- Abrevie apenas ao lado de um número, e nunca coloque ponto depois da abreviação: `20 MB`, não `20 MB.` nem `vinte MB`.
+
+Todo valor em uma tabela carrega sua unidade. Uma célula com `100` deixa o leitor escolhendo entre megabytes, segundos e requisições. [Referência](/pt-br/documentacao/guia-de-estilo/conteudo/referencia/) trata um limite sem unidade como um fato incompleto.
+
+`MB` e `MiB` são números diferentes. Escreva a unidade que o produto declara e nunca converta entre as formas decimais (`kB`, `MB`, `GB`) e binárias (`KiB`, `MiB`, `GiB`). O mesmo vale para taxas: `Gbps` conta bits e `MB/s` conta bytes, oito vezes de diferença, então mantenha a forma que o produto usa.
+
+Um limite é exato e nunca é arredondado. Arredonde apenas um número ilustrativo, e marque: `cerca de 200 ms`.
+
+## Use traço médio em um número negativo
+
+Escreva `–40` com traço médio, não com hífen. A regra vale para a prosa: em código, comandos e qualquer valor que o leitor copia, mantenha o hífen ASCII — um `–40` colado não é interpretado. [Pontuação](/pt-br/documentacao/guia-de-estilo/formatacao/pontuacao/) cobre as demais regras de traços.
+
+## Escreva um ordinal sem sufixo além do número
+
+Escreva `primeiro` e `segundo` por extenso. Em algarismo, escreva `1º`, nunca `1ºmente`.
+
+## Formate uma data apenas onde uma data cabe
+
+Datas aparecem em changelogs e em nenhum outro lugar, o que [Escolha de palavras](/pt-br/documentacao/guia-de-estilo/escrita/escolha-de-palavras/) declara como regra. Uma data em qualquer outro lugar envelhece a página.
+
+Onde a data é permitida, escreva o mês por extenso: `10 de julho de 2026`. O inglês usa a ordem mês, dia, ano: `July 10, 2026`.
+
+- Incorreto: `10/07/2026`
+- Correto: `10 de julho de 2026`
+
+Uma data numérica é lida como mês primeiro nos Estados Unidos e como dia primeiro em quase todo o resto, então ela significa duas coisas ao mesmo tempo.
+
+## Escreva um horário no formato de 24 horas
+
+Em português, use o formato de 24 horas: `10:45` e `18:30`. Em inglês, escreva `AM` e `PM` em maiúsculas, com um espaço antes: `10:45 AM`.
+
+Não escreva `24/7`. Escreva `o tempo todo` ou nomeie a disponibilidade real.
+
+## Formate moeda apenas na página de pricing
+
+Um preço, uma cota vendida por unidade e uma métrica de cobrança vivem só na página de pricing. [Referência](/pt-br/documentacao/guia-de-estilo/conteudo/referencia/) proíbe repetir qualquer um deles em uma página de produto.
+
+Onde o valor é permitido, o símbolo vem antes do número, sem espaço: `$1.000`.

--- a/src/content/docs/pt-br/pages/guia-de-estilo/formatacao/pontuacao.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/formatacao/pontuacao.mdx
@@ -1,0 +1,94 @@
+---
+title: Pontuação
+description: >-
+  Pontue a documentação da Azion: vírgula em série, travessões e hifens,
+  pontuação de títulos e listas, espaçamento e os símbolos a evitar.
+meta_tags: 'style guide, punctuation, commas, dashes, hyphens'
+namespace: documentation_style_guide_punctuation
+permalink: /documentacao/guia-de-estilo/formatacao/pontuacao/
+menu_namespace: styleGuideMenu
+---
+
+## Use a vírgula em série no inglês
+
+Em uma lista de três ou mais itens em inglês, coloque uma vírgula antes da conjunção.
+
+- Incorreto: `Applications, Firewall and Edge DNS`
+- Correto: `Applications, Firewall, and Edge DNS`
+
+Essa vírgula final remove uma ambiguidade que o leitor teria de resolver sozinho. Em português a norma é o contrário: não use vírgula antes do `e` em uma enumeração simples.
+
+- Correto: `Applications, Firewall e Edge DNS`
+
+## Prefira um ponto ao travessão
+
+O travessão substitui um ponto, dois-pontos ou uma vírgula, e um desses três quase sempre é mais claro. Recorra a eles primeiro.
+
+- Antes: `O cache responde à requisição — a origem nunca a recebe.`
+- Depois: `O cache responde à requisição. A origem nunca a recebe.`
+
+Em português, o travessão que separa uma oração leva espaço de cada lado. Em inglês não leva espaço nenhum.
+
+Travessões usados para dar ênfase são o padrão a evitar, e [Escolha de palavras](/pt-br/documentacao/guia-de-estilo/escrita/escolha-de-palavras/) cobre essa família. Esta é uma regra de escrita, não um defeito de revisão: ninguém sinaliza um travessão isolado.
+
+## Use o traço médio em um intervalo
+
+O traço médio une as pontas de um intervalo de tempo ou de quantidade, sem espaço de nenhum lado.
+
+- Incorreto: `50 - 70%`
+- Correto: `50–70%`
+
+Escreva o intervalo com palavras quando uma preposição já o abriu: `de 50% a 70%`, nunca `de 50–70%`.
+
+## Hifenize um modificador composto em inglês
+
+Em inglês, duas palavras que modificam um substantivo juntas levam hífen, sem espaços.
+
+| Incorreto | Correto |
+| --- | --- |
+| `real time logging` | `real-time logging` |
+| `read only bucket` | `read-only bucket` |
+
+O hífen desaparece quando as palavras não modificam um substantivo: `the bucket is read only`.
+
+Em português, o hífen segue o Acordo Ortográfico e não acompanha o inglês. Mantenha os termos técnicos em inglês na forma original.
+
+## Não use reticências nem ponto de exclamação
+
+As reticências pedem que o leitor complete o raciocínio. A documentação completa o raciocínio.
+
+O ponto de exclamação adiciona volume, não informação. Ele também soa promocional, o que [Voz da documentação](/pt-br/documentacao/guia-de-estilo/escrita/voz/) descarta.
+
+A exceção é a saída citada. Quando Azion Console ou um comando imprime um desses sinais, cite exatamente.
+
+## Deixe títulos e URLs sem pontuação
+
+- Sem pontuação final em um título, um cabeçalho ou um rótulo de menu lateral.
+- Sem dois-pontos dentro de um título. `Configurações de cache: uma visão geral` vira `Configurações de cache`.
+- Sem ponto no fim de uma URL, porque o leitor copia o último caractere.
+
+## Pontue um item de lista pelo tamanho
+
+- Um item com quatro palavras ou mais termina com ponto.
+- Um item com três palavras ou menos não leva pontuação final.
+- Todos os itens de uma lista seguem a mesma escolha, então listas mistas são reescritas.
+
+Uma célula de tabela segue a mesma regra: uma célula que é uma frase termina com ponto, e uma célula que é um valor ou um fragmento não termina.
+
+## Use dois-pontos para introduzir, e evite o ponto e vírgula
+
+Dois-pontos introduzem uma lista, um procedimento ou um bloco de código. Use maiúscula depois de dois-pontos apenas quando uma lista se segue; no texto corrido, mantenha minúscula.
+
+- Correto: `Você precisa de três coisas: uma conta, um token e um domínio.`
+- Correto: `Para criar o bucket:`
+
+Evite o ponto e vírgula. Um ponto e vírgula que une duas orações são duas frases, e um que liga um passo ao seu resultado é a frase de resultado que [Procedimentos](/pt-br/documentacao/guia-de-estilo/escrita/procedimentos/) já exige.
+
+## Defina espaçamento e símbolos
+
+| Regra | Exemplo |
+| --- | --- |
+| Um espaço depois de ponto, interrogação ou dois-pontos | `Salve a regra. Faça o deploy da aplicação.` |
+| Sem espaço ao redor da barra | `100 km/h` |
+| O sinal de porcentagem gruda no número | `100%` |
+| Escreva `e`, nunca `&` | `Regras e comportamentos` |

--- a/src/content/docs/pt-br/pages/guia-de-estilo/formatacao/texto.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/formatacao/texto.mdx
@@ -66,7 +66,7 @@ Duas formas padrão cobrem quase toda frase de link, sempre com o verbo `consult
 
 Não escreva `Saiba mais sobre...`, `Para ler mais...`, `clique aqui`, `esta página` nem uma URL solta no texto. O texto do link nomeia o destino.
 
-Um link em seção de encerramento carrega o seu motivo: `[Título](/caminho/) - uma frase sobre o que o leitor encontra lá.`
+Um link em seção de encerramento carrega o seu motivo. Em um card de `## Próximos passos` ou em uma linha de `## Recursos relacionados`, o título é o destino e o texto é uma frase sobre o que o leitor encontra lá.
 
 O texto de link é único na página. Dois links com o mesmo texto precisam ir para o mesmo lugar, porque o leitor que vê as mesmas palavras espera o mesmo destino.
 

--- a/src/content/docs/pt-br/pages/guia-de-estilo/formatacao/texto.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/formatacao/texto.mdx
@@ -1,0 +1,132 @@
+---
+title: Formatação de texto
+description: >-
+  Formate o texto de uma página: quando usar negrito e itálico, como escrever
+  links internos e caminhos de assets, e quando numerar uma lista.
+meta_tags: 'style guide, formatting, links, lists, tables'
+namespace: documentation_style_guide_text_formatting
+permalink: /documentacao/guia-de-estilo/formatacao/texto/
+menu_namespace: styleGuideMenu
+---
+
+## Use negrito para labels da interface e nomes de produto
+
+O negrito marca um label que o leitor precisa encontrar na tela e marca um nome de produto. Todo o resto fica em texto simples, porque o negrito de ênfase compete com esses dois usos. Um parágrafo com três frases em negrito não tem nenhuma.
+
+- Incorreto: `Você **precisa** limpar o cache **antes** do deploy da **nova versão**.`
+- Correto: `Limpe o cache antes do deploy da nova versão.`
+
+O negrito cumpre o seu papel quando aponta para a interface: `Selecione **Save** para aplicar a alteração.` O leitor sabe qual palavra procurar na tela.
+
+## Use itálico para valores da interface e termos definidos
+
+O itálico marca um valor ou opção que o leitor escolhe na interface: `Defina a permissão como _Read Only_.` O label fica em negrito; o valor fica em itálico.
+
+O itálico também marca um termo no momento em que a página o define: `Uma *cache key* identifica um objeto no cache.` Depois da definição, o termo aparece em texto simples. Itálico em qualquer outro lugar dilui os dois sinais, e por isso a documentação o usa raramente.
+
+## Use monoespaçado para código e valores digitados
+
+O monoespaçado marca código e tudo o que o leitor digita: comandos, caminhos, nomes de campo, flags, headers, códigos de status e nomes de arquivo.
+
+Nomes de ferramenta ficam em monoespaçado, nunca em negrito: `azion`, `npm`, `curl`. O negrito nomeia um produto; o monoespaçado nomeia o comando que o leitor executa.
+
+Os três estilos dividem o trabalho: negrito para o label, itálico para o valor, monoespaçado para o texto digitado.
+
+## Nunca sublinhe, e nunca coloque um link em negrito
+
+O sublinhado pertence só aos links. Uma palavra sublinhada que não é link parece um link quebrado, e o leitor clica nela.
+
+Também não coloque em negrito o texto dentro de um link. O link já tem o próprio estilo, e o negrito por cima dele compete com o negrito que marca labels de interface.
+
+- Incorreto: `Consulte [**Configurações de cache**](/pt-br/documentacao/build/cache/reference/cache-settings/).`
+- Correto: `Consulte [Configurações de cache](/pt-br/documentacao/build/cache/reference/cache-settings/).`
+
+## Formate os links internos
+
+Um link interno é absoluto, começa com o prefixo de idioma e termina com barra.
+
+- Incorreto: `[Applications](../build/applications)`
+- Correto: `[Applications](/pt-br/documentacao/build/applications/)`
+
+Os caminhos de assets seguem outra regra. Uma mesma imagem serve as duas versões de idioma de uma página. Por isso, o caminho é absoluto a partir da raiz, sem prefixo de idioma.
+
+- Correto: `/assets/docs/images/uploads/diagram.png`
+
+## Escreva textos de link que nomeiam o destino
+
+O leitor decide se segue um link apenas pelo texto do link. "Clique aqui" nomeia a ação em vez do destino, e uma URL solta esconde o destino na sintaxe. Os dois obrigam o leitor a ler ao redor do link.
+
+- Incorreto: `Para saber mais sobre as regras de frase, [clique aqui](/pt-br/documentacao/guia-de-estilo/escrita/estrutura-de-frases/).`
+- Correto: `Os limites de frase estão definidos em [Estrutura de frases](/pt-br/documentacao/guia-de-estilo/escrita/estrutura-de-frases/).`
+
+Duas formas padrão cobrem quase toda frase de link, sempre com o verbo `consulte`:
+
+- `Para mais informações, consulte [Título](/pt-br/documentacao/.../).`
+- `Para <fazer algo>, consulte [Título](/pt-br/documentacao/.../).`
+
+Não escreva `Saiba mais sobre...`, `Para ler mais...`, `clique aqui`, `esta página` nem uma URL solta no texto. O texto do link nomeia o destino.
+
+Um link em seção de encerramento carrega o seu motivo: `[Título](/caminho/) - uma frase sobre o que o leitor encontra lá.`
+
+O texto de link é único na página. Dois links com o mesmo texto precisam ir para o mesmo lugar, porque o leitor que vê as mesmas palavras espera o mesmo destino.
+
+Links dentro de um parágrafo apontam para páginas da documentação. Links externos ficam reunidos no fim da página ou da seção, para o fluxo de leitura nunca sair da documentação no meio de uma tarefa.
+
+## Aponte a primeira menção de outro elemento documentado
+
+Quando a prosa nomeia um produto, um módulo ou uma feature que tem página própria, a primeira menção na página aponta para essa página: `Cache é um módulo do [Applications](/pt-br/documentacao/build/applications/).` As menções seguintes ficam em texto simples, ou em negrito onde a regra de nomes de produto pede.
+
+O link substitui o negrito nessa primeira menção, porque o texto dentro de um link nunca fica em negrito. Um leitor que encontra um nome desconhecido sempre tem a página dele a um clique.
+
+## Use asides para o que o texto não comporta
+
+Um aside carrega informação útil que não cabe no fluxo. As quatro variantes dividem o trabalho:
+
+| Variante | Carrega |
+| --- | --- |
+| `:::note[nota]` | Informação útil que não cabe no fluxo |
+| `:::tip[dica]` | Um atalho ou uma recomendação |
+| `:::caution[Atenção]` | Uma ação com consequências que o leitor precisa pesar |
+| `:::danger[perigo]` | Uma ação que quebra algo ou expõe dados |
+
+Três limites mantêm os asides legíveis. Use no máximo um aside de cada tipo por seção. Mantenha um aside em até três parágrafos curtos. Nunca coloque um título dentro de um aside.
+
+Um aside nunca carrega a resposta principal. O leitor que pula todos os asides ainda precisa completar a tarefa somente com o fluxo.
+
+## Numere uma lista apenas quando a ordem importa
+
+Uma lista numerada promete ordem: o leitor executa o passo 2 depois do passo 1. Quando a ordem não importa, a lista usa marcadores. Quando existe um único item, escreva uma frase, porque uma lista de um item é uma frase com um marcador na frente.
+
+As regras de frase para passos estão em [Estrutura de frases](/pt-br/documentacao/guia-de-estilo/escrita/estrutura-de-frases/).
+
+## Mantenha os itens da lista paralelos
+
+Os itens de uma lista compartilham uma gramática: todos começam com verbo, ou todos começam com substantivo. A gramática mista obriga o leitor a reinterpretar cada item, e a lista fica mais lenta de percorrer do que um parágrafo.
+
+Incorreto:
+
+```md
+- Crie um bucket
+- Permissões do bucket
+- Enviando os arquivos
+```
+
+Correto:
+
+```md
+- Crie um bucket
+- Defina as permissões do bucket
+- Envie os arquivos
+```
+
+## Use tabelas para conteúdo enumerável
+
+Campos, limites, flags, valores padrão e códigos de status pertencem a tabelas. O leitor de referência percorre uma tabela; ele não a lê. Duas regras protegem esse modo de leitura.
+
+Escreva uma coluna com estrutura consistente. Uma coluna com `Ativa o cache`, depois `esta opção liga os logs`, depois `compressão ligada` descreve um mesmo tipo de fato em três formas. Cada forma nova obriga uma leitura de verdade. Escreva `Ativa o cache`, `Ativa os logs`, `Ativa a compressão`.
+
+Declare a unidade e o valor padrão de cada valor. Um limite sem unidade não é um fato: uma célula com `100` deixa o leitor adivinhar entre megabytes, segundos e requisições. Escreva `100 MB` e declare o valor padrão quando existir um.
+
+Introduza cada tabela com uma frase que diz o que ela mostra. Uma tabela que chega sem contexto é um dado que o leitor precisa decifrar.
+
+Nunca coloque uma tabela no meio de um procedimento numerado. A tabela interrompe a sequência; posicione a tabela antes dos passos ou faça um link para ela.

--- a/src/content/docs/pt-br/pages/guia-de-estilo/formatacao/titulos.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/formatacao/titulos.mdx
@@ -1,0 +1,69 @@
+---
+title: Títulos
+description: >-
+  Escreva headings com maiúscula só na primeira palavra, verbo no imperativo
+  no lugar de gerúndio, níveis corretos e frases que funcionam como buscas.
+meta_tags: 'style guide, headings'
+namespace: documentation_style_guide_headings
+permalink: /documentacao/guia-de-estilo/formatacao/titulos/
+menu_namespace: styleGuideMenu
+---
+
+## Use maiúscula só na primeira palavra
+
+Em um heading, apenas a primeira palavra e os nomes próprios começam com maiúscula.
+
+- Incorreto: `Configure Políticas De Cache`
+- Correto: `Configure políticas de cache`
+
+A capitalização por palavra exige uma decisão a cada palavra, e essas decisões divergem entre as páginas. A maiúscula única remove as decisões, e os headings ficam consistentes nos dois idiomas.
+
+Um nome de produto mantém as maiúsculas em qualquer posição, porque é um nome próprio.
+
+## Comece com um verbo no imperativo
+
+Um heading que nomeia uma tarefa começa com o verbo no imperativo, nunca com gerúndio.
+
+- Incorreto: `Criando um bucket`
+- Correto: `Crie um bucket`
+
+Três razões sustentam a regra:
+
+- Gerúndios traduzem de forma inconsistente como primeira palavra de um heading. O guia de estilo para desenvolvedores do Google os proíbe por essa razão, e esta documentação publica cada página em dois idiomas.
+- O heading fica no mesmo registro dos passos abaixo dele, que [Estrutura de frases](/pt-br/documentacao/guia-de-estilo/escrita/estrutura-de-frases/) define como imperativo. O leitor percorre uma voz, não duas.
+
+Em inglês, duas formas em `-ing` continuam corretas. Uma palavra em `-ing` que nomeia uma coisa é um substantivo, e por isso `Getting started` e `Billing` permanecem. Uma palavra em `-ing` mais adiante no heading também é válida: `Introduction to request logging`.
+
+## Comece o corpo em `##`
+
+O campo `title` do frontmatter renderiza o único H1 da página. O corpo começa em `##`, e um `#` no corpo cria um segundo H1 e quebra a estrutura da página.
+
+## Não pule níveis
+
+Os níveis de heading avançam um de cada vez: `###` sob `##`, e `####` sob `###`. Um salto de `##` para `####` sugere um nível que não existe, e leitores e ferramentas perdem a estrutura.
+
+## Nomeie a coisa, não a seção
+
+Um heading rotula o conteúdo, não a posição na página. `Limites` diz o que a seção contém. `Passo 1` diz apenas onde a seção está, e não diz nada quando a seção aparece sozinha.
+
+| Incorreto | Correto |
+| --- | --- |
+| `Passo 1` | `Crie um bucket` |
+| `Alguns limites importantes para lembrar` | `Limites` |
+
+## Escreva headings que funcionam como buscas
+
+Um sistema de busca retorna uma seção da página, não a página inteira. O heading diz ao sistema e ao leitor o que a seção responde. `Configure o TTL de cache` corresponde ao que uma pessoa com essa tarefa digita. `Configuração` corresponde a quase tudo e, por isso, não recupera nada em particular.
+
+- Incorreto: `Configuração`
+- Correto: `Configure o TTL de cache`
+
+## Use uma sigla em um título só quando a página a expande
+
+Um título pode carregar uma sigla consagrada, desde que a primeira linha abaixo dele escreva o termo por extenso. `Configure conjuntos de regras do WAF` é um título válido quando o parágrafo abaixo escreve `Web Application Firewall (WAF)`.
+
+[Escolha de palavras](/pt-br/documentacao/guia-de-estilo/escrita/escolha-de-palavras/) tem a regra de expansão para o resto da página.
+
+## Mantenha emojis fora dos títulos
+
+Sem emojis em títulos, headings ou rótulos da barra lateral. Emojis quebram a indexação de busca, leem mal em leitores de tela e renderizam de forma inconsistente entre plataformas.

--- a/src/content/docs/pt-br/pages/guia-de-estilo/index.mdx
+++ b/src/content/docs/pt-br/pages/guia-de-estilo/index.mdx
@@ -1,0 +1,30 @@
+---
+title: Style Guide
+description: >-
+  Escreva documentação do jeito da Azion: voz, estrutura de frases,
+  terminologia, formatação, tipos de conteúdo e convenções de arquivos.
+meta_tags: 'style guide, writing, documentation, conventions'
+namespace: documentation_style_guide
+permalink: /documentacao/guia-de-estilo/
+menu_namespace: styleGuideMenu
+---
+
+Este guia descreve como a Azion escreve sua documentação. Use este guia quando você escrever uma página nova, traduzir uma página ou revisar o trabalho de outra pessoa. As regras existem para que todas as páginas tenham a mesma leitura, sejam bem traduzidas e continuem úteis quando uma máquina recupera uma seção sozinha.
+
+## O que este guia cobre
+
+- [Voz da documentação](/pt-br/documentacao/guia-de-estilo/escrita/voz/): o registro que todas as páginas usam.
+- [Estrutura de frases](/pt-br/documentacao/guia-de-estilo/escrita/estrutura-de-frases/): as regras de frase, adaptadas do ASD-STE100.
+- [Procedimentos](/pt-br/documentacao/guia-de-estilo/escrita/procedimentos/): a gramática de passo que todo procedimento numerado segue.
+- [Escolha de palavras](/pt-br/documentacao/guia-de-estilo/escrita/escolha-de-palavras/): o vocabulário a evitar e os padrões de enchimento a cortar.
+- [Terminologia da documentação](/pt-br/documentacao/guia-de-estilo/escrita/terminologia/): nomes de produtos e regras de tradução.
+- [Títulos](/pt-br/documentacao/guia-de-estilo/formatacao/titulos/), [formatação de texto](/pt-br/documentacao/guia-de-estilo/formatacao/texto/), [código](/pt-br/documentacao/guia-de-estilo/formatacao/codigo/), [pontuação](/pt-br/documentacao/guia-de-estilo/formatacao/pontuacao/) e [números e unidades](/pt-br/documentacao/guia-de-estilo/formatacao/numeros/): como o conteúdo é formatado.
+- [Estrutura de conteúdo](/pt-br/documentacao/guia-de-estilo/conteudo/escolher-um-tipo-de-conteudo/): os tipos de página e como escolher um, incluindo [quickstarts](/pt-br/documentacao/guia-de-estilo/conteudo/quickstart/) e [casos de uso](/pt-br/documentacao/guia-de-estilo/conteudo/casos-de-uso/).
+- [Arquitetura de informação](/pt-br/documentacao/guia-de-estilo/conteudo/arquitetura-de-informacao/): os treze slots que uma seção de produto pode preencher, na ordem em que o leitor os encontra.
+- [Convenções de arquivos](/pt-br/documentacao/guia-de-estilo/convencoes/frontmatter/): frontmatter e [páginas bilíngues](/pt-br/documentacao/guia-de-estilo/convencoes/paginas-bilingues/).
+- [Componentes](/pt-br/documentacao/guia-de-estilo/componentes/): o conjunto de componentes MDX ativos e as regras de cada um.
+- [Como escrevemos a documentação](/pt-br/documentacao/guia-de-estilo/como-documentamos/): como a documentação é produzida, em dois idiomas, para pessoas e agentes.
+
+## O guia segue as próprias regras
+
+Todas as páginas desta seção passam pelas regras que descrevem: os limites de frase, as regras de títulos e as metas de tamanho. Quando uma regra não funciona aqui, a regra muda antes de qualquer pessoa precisar segui-la.

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -201,7 +201,7 @@
 }
 
 @utility px-container {
-	max-width: 1344px;
+	max-width: var(--container-4xl);
 	margin-left: auto;
 	margin-right: auto;
 	padding-left: 1rem;


### PR DESCRIPTION
## What & why
Adds the style guides pages to the release branch. Makes a slightly change to the css (1 line), that makes the page to centralize content.

**Pages affected:** `/en/documentation/style-guide/**` and `/pt-br/documentacao/guia-de-estilo/**` (35 pages per language); `src/components/webkit/CodeBlock.vue`; `src/styles/main.css`

This PR adds the documentation style guide, in English and Portuguese, and makes it the single source for how a docs page is written and which components it may use. It also makes a 1-line css change for centralize content of the pages.

## Type of change

- [x] 🆕 New content (`feat`)
- [ ] 🩹 Fix (`fix`) — typo, broken link, wrong information
- [ ] ♻️ Content update (`docs`) — rewrite, expansion, upkeep
- [ ] 🌐 Translation sync (`i18n`)
- [ ] 🏗️ Platform / structure (`refactor` / `chore`) — reviewed by UXE, no content mixed in

## Author checklist

- [x] PR title follows `type(scope): summary` (see [GOVERNANCE.md §4](GOVERNANCE.md))
- [x] Frontmatter complete: `title`, `description`, `meta_tags`, `namespace`, `permalink`, `last_reviewed`
- [ ] No legacy "edge-" product names in the copy
- [ ] How-to/tutorial content includes at least one runnable, copy-paste-tested code block
- [ ] Screenshots (if any) have alt text and follow image standards
- [x] Internal links are relative and resolve locally
- [ ] **If any permalink changed or page moved: redirect added in this PR**
- [ ] **i18n:** `pt-br` updated in this PR **or** follow-up `i18n` issue created: <!-- link -->
- [x] I ran `pnpm build:local` (build + frontmatter check) without errors